### PR TITLE
Run PM2 as the nodejs user

### DIFF
--- a/nodejs/files/etc/update-motd.d/99-one-click
+++ b/nodejs/files/etc/update-motd.d/99-one-click
@@ -2,6 +2,9 @@
 #
 # Configured as part of the DigitalOcean 1-Click Image build process
 
+# Read in the passwords....
+. /root/.digitalocean_passwords
+
 myip=$(hostname -I | awk '{print$1}')
 cat <<EOF
 ********************************************************************************
@@ -10,8 +13,21 @@ Welcome to DigitalOcean's One-Click Node.js Droplet.
 To keep this Droplet secure, the UFW firewall is enabled.
 All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
 
-To get started, visit http://do.co/node1804
+Use these SFTP credentials to upload files with FileZilla/WinSCP/rsync:
+    Host: ${myip}
+    User: ${NODE_USER}
+    Pass: ${NODE_USER_PASSWORD}
+
+In a web browser, you can view:
+ * The Node.js One-Click Quickstart guide: http://do.co/node1804#start
+ * The new Node site: http://$myip
+
+On the server:
+  * The Node.js application is served from /var/www/html
+  * The Node.js passwords and keys are saved in /root/.digitalocean_passwords
+
+For help and more information, visit http://do.co/node1804
 
 ********************************************************************************
-To delete this message of the day: rm -rf $(readlink -f ${0})
+To delete this message of the day: rm -rf $(readlink -f "${0}")
 EOF

--- a/nodejs/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/nodejs/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,20 @@
+#!/bin/bash -x
+exec > >(tee /var/log/one_click_setup.log) 2>&1
+
+# Generate some passwords
+cat > /root/.digitalocean_passwords <<EOM
+NODE_USER=nodejs
+NODE_USER_PASSWORD=$(openssl rand -hex 16)
+EOM
+
+source /root/.digitalocean_passwords
+
+# Set the nodejs user password
+echo "${NODE_USER}:${NODE_USER_PASSWORD}" | chpasswd -
+
+# Remove the ssh force logout command
+sed -e '/Match user root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh

--- a/nodejs/files/var/www/html/hello.js
+++ b/nodejs/files/var/www/html/hello.js
@@ -33,6 +33,7 @@ const helpText = `
     <img src="/assets/sammytheshark.gif" />
     <h2>Things to do with this script</h2>
     <p>This message is coming to you via a simple NodeJS application that's live on your Droplet! This droplet is all set up with NodeJS, PM2 for process management, and nginx.</p>
+    <p>Run all pm2 commands using the nodejs user or a second instance of pm2 will start. The login and password are stored in the <code>NODE_USER*</code> values you see when you call  <code>cat /root/.digitalocean_passwords</code> while logged in over SSH.</p>
     <p>This app is running at port 3000, and is being served to you by nginx, which has mapped port 3000 to be served as the root URI over HTTP (port 80) -- a technique known as a "reverse proxy." We'll be teaching you how to use this technique right here on this page. If you want to kick the tires right now, try some of these things:</p>
     <ul>
       <li>SSH into your Droplet and modify this script at <code>/var/www/html/hello.js</code> and see the results live by calling <code>pm2 restart hello</code></li>

--- a/nodejs/scripts/011-packages.sh
+++ b/nodejs/scripts/011-packages.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-sudo npm install pm2@latest -g --no-optional
-
-pm2 start /var/www/html/hello.js
-pm2 startup systemd
-pm2 save

--- a/nodejs/scripts/011-pm2.sh
+++ b/nodejs/scripts/011-pm2.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+	# Create the nodejs user
+useradd --home-dir /home/nodejs \
+        --shell /bin/bash \
+        --create-home \
+        --system \
+        nodejs
+
+# Setup the home directory
+chown -R nodejs: /home/nodejs
+
+# Setup
+chown -R nodejs: /var/www/html
+
+usermod -aG sudo nodejs
+
+sudo npm install pm2@latest -g --no-optional
+
+su - nodejs -c "pm2 start /var/www/html/hello.js"
+sudo env "PATH=$PATH:/usr/bin" /usr/lib/node_modules/pm2/bin/pm2 startup systemd -u nodejs --hp /home/nodejs
+su - nodejs -c "pm2 save"

--- a/nodejs/template.json
+++ b/nodejs/template.json
@@ -12,7 +12,7 @@
       "type": "digitalocean",
       "api_token": "{{user `do_api_token`}}",
       "image": "ubuntu-20-04-x64",
-      "region": "nyc3",
+      "region": "sfo3",
       "size": "s-1vcpu-1gb",
       "ssh_username": "root",
       "snapshot_name": "{{user `image_name`}}"
@@ -63,7 +63,8 @@
       ],
       "scripts": [
         "common/scripts/010-nodejs.sh",
-        "nodejs/scripts/011-packages.sh",
+        "nodejs/scripts/011-pm2.sh",
+        "common/scripts/012-force-ssh-logout.sh",
         "common/scripts/014-ufw-nginx.sh",
         "common/scripts/020-application-tag.sh",
         "common/scripts/900-cleanup.sh"


### PR DESCRIPTION
A user pointed out the PM2 runs Node as the user who invoked it. We don't want to run our web application as root. Update the Packer build for Node.js to run the web application as the nodejs user.