### PR TITLE
Fix Django admin login

### DIFF
--- a/django-20-04/files/etc/update-motd.d/99-one-click
+++ b/django-20-04/files/etc/update-motd.d/99-one-click
@@ -13,19 +13,24 @@ Welcome to DigitalOcean's 1-Click Django Droplet.
 To keep this Droplet secure, the UFW firewall is enabled.
 All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
 
+Access the Django admin site
+    URL: http://${myip}/admin
+    User: ${DJANGO_USER}
+    Pass: ${DJANGO_USER_PASSWORD}
+
 Use these SFTP credentials to upload files with FileZilla/WinSCP/rsync:
     Host: ${myip}
-    User: django
+    User: ${DJANGO_USER}
     Pass: ${DJANGO_USER_PASSWORD}
 
 Django is configured to use Postgres as its database. Use the following
 credentials to manage the database:
     Database: django
-    User:     django
+    User:     ${DJANGO_USER}
     Pass:     ${DJANGO_POSTGRESS_PASS}
 
 In a web browser, you can view:
- * The Django 1-Click Quickstart guide: http://do.co/django1804#start
+ * The Django 1-Click Quickstart guide: https://do.co/3bY3b67#start
  * The new Django site: http://$myip
 
 On the server:
@@ -33,7 +38,7 @@ On the server:
   * The Django passwords and keys are saved in /root/.digitalocean_passwords
   * Certbot is preinstalled. Run it to configure HTTPS.
 
-For help and more information, visit http://do.co/django1804
+For help and more information, visit https://do.co/3bY3b67
 
 ********************************************************************************
 To delete this message of the day: rm -rf $(readlink -f ${0})

--- a/django-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/django-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -54,8 +54,9 @@ sed -e "s/@DBPASSWORD@/${DJANGO_POSTGRESS_PASS}/" \
     -i "${SETTINGS_FILE}"
 
 # Sync the database
-setuid postgres django \
-    python3 "${PROJECT_DIR}/manage.py" syncdb --noinput
+python3 "${PROJECT_DIR}/manage.py" migrate --noinput
+
+echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('$DJANGO_USER', 'temp@example.com', '$DJANGO_USER_PASSWORD')" | python3 "${PROJECT_DIR}/manage.py" shell
 
 # Now start up gunicorn
 systemctl enable gunicorn


### PR DESCRIPTION
We did not update our migration command after upgrading from Django 1.8
to Django 2.2. This PR fixes the migrations not being run and creates
the admin user.