### PR TITLE
Remove unnecessary force ssh logout

### DIFF
--- a/docker-18-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/docker-18-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Remove the ssh force logout command
-sed -e '/Match User root/d' \
-    -e '/.*ForceCommand.*droplet.*/d' \
-    -i /etc/ssh/sshd_config
-
-systemctl restart ssh

--- a/docker-18-04/template.json
+++ b/docker-18-04/template.json
@@ -39,11 +39,6 @@
       "destination": "/etc/"
     },
     {
-      "type": "file",
-      "source": "docker-18-04/files/var/",
-      "destination": "/var/"
-    },
-    {
       "type": "shell",
       "environment_vars": [
         "DEBIAN_FRONTEND=noninteractive",
@@ -75,7 +70,6 @@
         "common/scripts/012-grub-opts.sh",
         "common/scripts/013-docker-dns.sh",
         "common/scripts/014-ufw-docker.sh",
-        "common/scripts/018-force-ssh-logout.sh",
         "common/scripts/020-application-tag.sh",
         "common/scripts/900-cleanup.sh"
       ]

--- a/docker-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/docker-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Remove the ssh force logout command
-sed -e '/Match User root/d' \
-    -e '/.*ForceCommand.*droplet.*/d' \
-    -i /etc/ssh/sshd_config
-
-systemctl restart ssh

--- a/docker-20-04/template.json
+++ b/docker-20-04/template.json
@@ -39,11 +39,6 @@
       "destination": "/etc/"
     },
     {
-      "type": "file",
-      "source": "docker-20-04/files/var/",
-      "destination": "/var/"
-    },
-    {
       "type": "shell",
       "environment_vars": [
         "DEBIAN_FRONTEND=noninteractive",
@@ -75,7 +70,6 @@
         "common/scripts/012-grub-opts.sh",
         "common/scripts/013-docker-dns.sh",
         "common/scripts/014-ufw-docker.sh",
-        "common/scripts/018-force-ssh-logout.sh",
         "common/scripts/020-application-tag.sh",
         "common/scripts/900-cleanup.sh"
       ]

--- a/dokku-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/dokku-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# Remove the ssh force logout command
-sed -e '/Match User root/d' \
-    -e '/.*ForceCommand.*droplet.*/d' \
-    -i /etc/ssh/sshd_config
-
-systemctl restart ssh

--- a/dokku-20-04/template.json
+++ b/dokku-20-04/template.json
@@ -72,7 +72,6 @@
         "common/scripts/013-docker-dns.sh",
         "common/scripts/014-ufw-docker.sh",
         "common/scripts/014-ufw-nginx.sh",
-        "common/scripts/018-force-ssh-logout.sh",
         "common/scripts/020-application-tag.sh",
         "common/scripts/900-cleanup.sh"
       ]


### PR DESCRIPTION
Fixes:
https://github.com/digitalocean/terraform-provider-digitalocean/issues/508

Some droplet 1-clicks don't need to configure the droplet before the user
can log in, and disabling ssh until cloud init finishes executing breaks
terraform for the docker 1-Clicks.