### PR TITLE
Use ufw scripts for firewall

### DIFF
--- a/discourse-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/discourse-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -4,12 +4,6 @@
 # created from your image.  Things like generating passwords, configuration requiring IP address
 # or other items that will be unique to each instance should be done in scripts here.
 
-# Enable Firewall
-ufw limit ssh
-ufw allow http
-ufw allow https
-ufw --force enable
-
 # Install latest updates on first boot
 cd /var/discourse
 git pull

--- a/discourse-20-04/template.json
+++ b/discourse-20-04/template.json
@@ -74,6 +74,7 @@
       "scripts": [
         "common/scripts/010-docker.sh",
         "discourse-20-04/scripts/010-discourse.sh",
+        "common/scripts/014-ufw-http.sh",
         "common/scripts/018-force-ssh-logout.sh",
         "common/scripts/020-application-tag.sh",
         "common/scripts/900-cleanup.sh"

--- a/mysql-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/mysql-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -5,13 +5,6 @@ export LC_ALL=C
 export LANG=en_US.UTF-8
 export LC_CTYPE=en_US.UTF-8
 
-# Protect the droplet
-ufw limit ssh
-ufw allow https
-ufw allow http
-ufw allow mysql
-ufw --force enable
-
 #Generate Mysql root password.
 root_mysql_pass=$(openssl rand -hex 24)
 admin_mysql_pass=$(openssl rand -hex 24)


### PR DESCRIPTION
Instead of configuring the firewall on boot, configure the firewall
when the image is being built using the existing ufw scripts.