### PR TITLE
mp-3164 - add support for dbaas credentials (cont)

### DIFF
--- a/wordpress-20-04/files/opt/digitalocean/wp_setup.sh
+++ b/wordpress-20-04/files/opt/digitalocean/wp_setup.sh
@@ -6,13 +6,52 @@
 # provided by the user and offer the option to set up
 # LetsEncrypt as well.
 
-# Enable WordPress on firstlogin
+# Enable WordPress on first login
 if [[ -d /var/www/wordpress ]]
 then
   mv /var/www/html /var/www/html.old
   mv /var/www/wordpress /var/www/html
 fi
 chown -Rf www-data:www-data /var/www/html
+
+# if applicable, configure wordpress to use mysql dbaas
+if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
+  # grab all the data from the password file
+  username=$(sed -n "s/^mysql_username=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  password=$(sed -n "s/^mysql_password=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  host=$(sed -n "s/^mysql_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  port=$(sed -n "s/^mysql_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  database=$(sed -n "s/^mysql_database=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+
+  # update the wp-config.php with stored credentials
+  sed -i "s/'DB_USER', '.*'/'DB_USER', '$username'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_NAME', '.*'/'DB_NAME', '$database'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_PASSWORD', '.*'/'DB_PASSWORD', '$password'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_HOST', '.*'/'DB_HOST', '$host:$port'/g" /var/www/html/wp-config.php;
+
+  # add required SSL flag
+  cat >> /var/www/html/wp-config.php <<EOM
+/** Connect to MySQL cluster over SSL **/
+define( 'MYSQL_CLIENT_FLAGS', MYSQLI_CLIENT_SSL );
+EOM
+
+  # wait for db to become available
+  echo -e "\nWaiting for your database to become available (this may take a few minutes)"
+  while ! mysqladmin ping -h "$host" -P "$port" --silent; do
+      printf .
+      sleep 2
+  done
+  echo -e "\nDatabase available!\n"
+
+  # cleanup
+  unset username password host port database
+  rm -f /root/.digitalocean_dbaas_credentials
+
+  # disable the local MySQL instance
+  systemctl stop mysql.service
+  systemctl disable mysql.service
+fi
+
 echo "This script will copy the WordPress installation into"
 echo "Your web root and move the existing one to /var/www/html.old"
 echo "--------------------------------------------------"
@@ -22,6 +61,7 @@ echo "--------------------------------------------------"
 echo "Enter the domain name for your new WordPress site."
 echo "(ex. example.org or test.example.org) do not include www or http/s"
 echo "--------------------------------------------------"
+
 a=0
 while [ $a -eq 0 ]
 do

--- a/wordpress-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/wordpress-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -26,37 +26,12 @@ systemctl restart postfix &
 mysqladmin -u root -h localhost create wordpress
 mysqladmin -u root -h localhost password ${root_mysql_pass}
 
-if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
-  # grab all the data from the password file
-  username=$(sed -n "s/^mysql_username=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-  password=$(sed -n "s/^mysql_password=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-  host=$(sed -n "s/^mysql_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-  port=$(sed -n "s/^mysql_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-  database=$(sed -n "s/^mysql_database=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-
-  # update the wp-config.php with stored credentials
-  sed -i "s/'DB_USER', '.*'/'DB_USER', '$username'/g" /var/www/html/wp-config.php;
-  sed -i "s/'DB_NAME', '.*'/'DB_NAME', '$database'/g" /var/www/html/wp-config.php;
-  sed -i "s/'DB_PASSWORD', '.*'/'DB_PASSWORD', '$password'/g" /var/www/html/wp-config.php;
-  sed -i "s/'DB_HOST', '.*'/'DB_HOST', '$host:$port'/g" /var/www/html/wp-config.php;
-
-  # finally, add required SSL flag
-  cat >> /var/www/html/wp-config.php <<EOM
-
-/** Connect to MySQL cluster over SSL **/
-define( 'MYSQL_CLIENT_FLAGS', MYSQLI_CLIENT_SSL );
-
-EOM
-
-else
-  # populate the wordpress config file with local db credentials.
-  cp /var/www/wordpress/wp-config-sample.php /var/www/wordpress/wp-config.php
-  sed -e "s/'DB_NAME', 'database_name_here'/'DB_NAME', 'wordpress'/g" \
-      -e "s/'DB_USER', 'username_here'/'DB_USER', 'wordpress'/g" \
-      -e "s/'DB_PASSWORD', 'password_here'/'DB_PASSWORD', '${wordpress_mysql_pass}'/g" \
-      -i /var/www/wordpress/wp-config.php
-fi
-
+# populate the wordpress config file
+cp /var/www/wordpress/wp-config-sample.php /var/www/wordpress/wp-config.php
+sed -e "s/'DB_NAME', 'database_name_here'/'DB_NAME', 'wordpress'/g" \
+    -e "s/'DB_USER', 'username_here'/'DB_USER', 'wordpress'/g" \
+    -e "s/'DB_PASSWORD', 'password_here'/'DB_PASSWORD', '${wordpress_mysql_pass}'/g" \
+    -i /var/www/wordpress/wp-config.php
 
 chown -Rf www-data:www-data /var/www/wordpress
 
@@ -102,12 +77,6 @@ user     = debian-sys-maint
 password = ${debian_sys_maint_mysql_pass}
 socket   = /var/run/mysqld/mysqld.sock
 EOM
-
-# with everything done, if we are using dbaas, disable the local MySQL instance.
-if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
-  systemctl stop mysql.service # turn off mysql
-  systemctl disable mysql.service # prevent it from turning back on
-fi
 
 # WordPress Salts
 for i in `seq 1 8`


### PR DESCRIPTION
See https://github.com/digitalocean/droplet-1-clicks/compare/tmp...wordpress for a diff between this branch and the wordpress image pre dbaas work.

Now, the script will wait for dbaas to be available before kicking off the setup process:

![image](https://user-images.githubusercontent.com/155981/102351391-5f25c880-3f74-11eb-8f1d-b0fa1499f5ff.png)
