### PR TITLE
updated message of the day to include mongo goodness

### DIFF
--- a/nodejs-20-04/files/etc/update-motd.d/99-one-click
+++ b/nodejs-20-04/files/etc/update-motd.d/99-one-click
@@ -5,6 +5,15 @@
 # Read in the passwords....
 . /root/.digitalocean_passwords
 
+dbaas_text=""
+if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
+    dbaas_text="* The MongoDB credentials are saved in /root/.digitalocean_dbaas_credentials
+
+When using a managed MongoDB cluster, the database may take up to 5 minutes
+after creation before it's ready for use.
+"
+fi
+
 myip=$(hostname -I | awk '{print$1}')
 cat <<EOF
 ********************************************************************************
@@ -23,7 +32,7 @@ In a web browser, you can view the Node site at: http://$myip
 On the server:
   * The Node.js application is served from /var/www/html
   * The Node.js passwords and keys are saved in /root/.digitalocean_passwords
-
+  ${dbaas_text}
 For help and more information, visit https://do.co/313ycRT
 
 ********************************************************************************


### PR DESCRIPTION
updated message of the day to include mongo creds location and warning about cluster ready time

example with no creds present (notice the `On the server` section):
```
Welcome to Ubuntu 20.04 LTS (GNU/Linux 5.4.0-37-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Tue Jun 15 12:26:05 UTC 2021

  System load:  0.0               Users logged in:       0
  Usage of /:   4.7% of 48.29GB   IPv4 address for eth0: 159.89.184.236
  Memory usage: 17%               IPv4 address for eth0: 10.17.0.7
  Swap usage:   0%                IPv4 address for eth1: 10.108.0.4
  Processes:    114

132 updates can be installed immediately.
0 of these updates are security updates.
To see these additional updates run: apt list --upgradable


*** System restart required ***
********************************************************************************

Welcome to DigitalOcean's 1-Click Node.js Droplet.
To keep this Droplet secure, the UFW firewall is enabled.
All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).

Use these SFTP credentials to upload files with FileZilla/WinSCP/rsync:
    Host: 159.89.184.236
    User: nodejs
    Pass: 2c7a68d117ed22c6556db024f30d5cd7

In a web browser, you can view the Node site at: http://159.89.184.236

On the server:
  * The Node.js application is served from /var/www/html
  * The Node.js passwords and keys are saved in /root/.digitalocean_passwords

For help and more information, visit https://do.co/313ycRT

********************************************************************************
To delete this message of the day: rm -rf /etc/update-motd.d/99-one-click
```

example of creds being present  (notice the `On the server` section): 
```
Welcome to Ubuntu 20.04 LTS (GNU/Linux 5.4.0-37-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Tue Jun 15 12:26:05 UTC 2021

  System load:  0.0               Users logged in:       0
  Usage of /:   4.7% of 48.29GB   IPv4 address for eth0: 159.89.184.236
  Memory usage: 17%               IPv4 address for eth0: 10.17.0.7
  Swap usage:   0%                IPv4 address for eth1: 10.108.0.4
  Processes:    114

132 updates can be installed immediately.
0 of these updates are security updates.
To see these additional updates run: apt list --upgradable


*** System restart required ***
********************************************************************************

Welcome to DigitalOcean's 1-Click Node.js Droplet.
To keep this Droplet secure, the UFW firewall is enabled.
All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).

Use these SFTP credentials to upload files with FileZilla/WinSCP/rsync:
    Host: 159.89.184.236
    User: nodejs
    Pass: 2c7a68d117ed22c6556db024f30d5cd7

In a web browser, you can view the Node site at: http://159.89.184.236

On the server:
  * The Node.js application is served from /var/www/html
  * The Node.js passwords and keys are saved in /root/.digitalocean_passwords
  * The MongoDB credentials are saved in /root/.digitalocean_dbaas_credentials

When using a managed MongoDB cluster, the database may take up to 5 minutes
after creation before it's ready for use

For help and more information, visit https://do.co/313ycRT

********************************************************************************
To delete this message of the day: rm -rf /etc/update-motd.d/99-one-click
Last login: Tue Jun 15 12:22:02 2021 from 70.253.59.240
```