### PR TITLE
Update php version to 8.0 in lemp

### DIFF
--- a/lemp-18-04/files/etc/nginx/sites-available/digitalocean
+++ b/lemp-18-04/files/etc/nginx/sites-available/digitalocean
@@ -43,7 +43,7 @@ server {
 
 	location ~ \.php$ {
         include snippets/fastcgi-php.conf;
-        fastcgi_pass unix:/run/php/php7.2-fpm.sock;
+        fastcgi_pass unix:/run/php/php8.0-fpm.sock;
 	}
 
 	# deny access to .htaccess files, if Apache's document root

--- a/lemp-18-04/template.json
+++ b/lemp-18-04/template.json
@@ -3,7 +3,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "lemp-18-04-snapshot-{{timestamp}}",
-    "apt_packages": "fail2ban mysql-server nginx php-apcu php-curl php-mysql php-fpm postfix python-certbot-nginx software-properties-common",
+    "apt_packages": "fail2ban mysql-server nginx php8.0-apcu php8.0-curl php8.0-mysql php8.0-fpm postfix python-certbot-nginx software-properties-common",
     "application_name": "LEMP",
     "application_version": ""
   },
@@ -52,6 +52,8 @@
       "inline": [
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install software-properties-common",
+        "add-apt-repository -y ppa:ondrej/php",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
         "apt-get -qqy clean"
       ]

--- a/lemp-20-04/files/etc/nginx/sites-available/digitalocean
+++ b/lemp-20-04/files/etc/nginx/sites-available/digitalocean
@@ -43,7 +43,7 @@ server {
 
 	location ~ \.php$ {
         include snippets/fastcgi-php.conf;
-        fastcgi_pass unix:/run/php/php7.4-fpm.sock;
+        fastcgi_pass unix:/run/php/php8.0-fpm.sock;
 	}
 
 	# deny access to .htaccess files, if Apache's document root

--- a/lemp-20-04/template.json
+++ b/lemp-20-04/template.json
@@ -3,7 +3,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "lemp-20-04-snapshot-{{timestamp}}",
-    "apt_packages": "fail2ban mysql-server nginx php-apcu php-curl php-mysql php-fpm postfix python3-certbot-nginx software-properties-common",
+    "apt_packages": "fail2ban mysql-server nginx php8.0-apcu php8.0-curl php8.0-mysql php8.0-fpm postfix python3-certbot-nginx software-properties-common",
     "application_name": "LEMP",
     "application_version": ""
   },

--- a/lemp-20-04/template.json
+++ b/lemp-20-04/template.json
@@ -52,6 +52,8 @@
       "inline": [
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install software-properties-common",
+        "add-apt-repository -y ppa:ondrej/php",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
         "apt-get -qqy clean"
       ]


### PR DESCRIPTION
**Description**

This PR updates droplet-1-clicks installations for lemp: php8.0 will be installed with lemp 18-04 and lemp 20-04

<img width="400" alt="Screenshot 2021-07-02 at 11 04 13" src="https://user-images.githubusercontent.com/24397578/124252905-258f6600-db30-11eb-9b70-445c0408db43.png">
<img width="400" alt="Screenshot 2021-07-02 at 12 21 55" src="https://user-images.githubusercontent.com/24397578/124252909-27592980-db30-11eb-9be2-f7dadf500d5c.png">
