### PR TITLE
MP-3758: Update php version

### DIFF
--- a/lamp-18-04/template.json
+++ b/lamp-18-04/template.json
@@ -3,7 +3,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "lamp-18-04-snapshot-{{timestamp}}",
-    "apt_packages": "apache2 expect fail2ban lamp-server^ libapache2-mod-php mysql-server php php-apcu php-gd php-mysql postfix python-certbot-apache software-properties-common",
+    "apt_packages": "apache2 expect fail2ban lamp-server^ libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-gd php8.0-mysql postfix python-certbot-apache software-properties-common",
     "application_name": "lamp",
     "application_version": ""
   },
@@ -53,6 +53,7 @@
         "add-apt-repository ppa:certbot/certbot",
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "add-apt-repository -y ppa:ondrej/php",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
         "apt-get -qqy clean"
       ]

--- a/lamp-20-04/template.json
+++ b/lamp-20-04/template.json
@@ -3,7 +3,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "lamp-20-04-snapshot-{{timestamp}}",
-    "apt_packages": "apache2 expect fail2ban lamp-server^ libapache2-mod-php mysql-server php php-apcu php-gd php-mysql postfix python3-certbot-apache software-properties-common",
+    "apt_packages": "apache2 expect fail2ban lamp-server^ libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-gd php8.0-mysql postfix python3-certbot-apache software-properties-common",
     "application_name": "LAMP",
     "application_version": ""
   },
@@ -52,6 +52,7 @@
       "inline": [
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "add-apt-repository -y ppa:ondrej/php",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
         "apt-get -qqy clean"
       ]


### PR DESCRIPTION
Update php version 7.4 -> 8.0 on ubuntu 20-04 and 18-04:
<img width="657" alt="Screenshot 2021-07-07 at 16 13 32" src="https://user-images.githubusercontent.com/25306765/124765649-d9349380-df3e-11eb-9804-16334fedc0be.png">
<img width="636" alt="Screenshot 2021-07-07 at 16 08 44" src="https://user-images.githubusercontent.com/25306765/124765659-dc2f8400-df3e-11eb-81bd-21c4573bce29.png">

