### PR TITLE
MP-3489: update Wordpress tools

### DIFF
--- a/wordpress-18-04/scripts/010-php.sh
+++ b/wordpress-18-04/scripts/010-php.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-update-alternatives --set php /usr/bin/php7.4
+update-alternatives --set php /usr/bin/php8.0
 
 sed -e "s|upload_max_filesize.*|upload_max_filesize = 16M|g" \
     -e "s|post_max_size.*|post_max_size = 16M|g" \
     -e "s|max_execution_time.*|max_execution_time = 60|g" \
-    -i /etc/php/7.4/apache2/php.ini
+    -i /etc/php/8.0/apache2/php.ini

--- a/wordpress-18-04/template.json
+++ b/wordpress-18-04/template.json
@@ -3,7 +3,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "wordpress-18-04-snapshot-{{timestamp}}",
-    "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python-certbot-apache software-properties-common unzip",
+    "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python3-certbot-apache software-properties-common unzip",
     "application_name": "WordPress",
     "application_version": "5.5.1",
     "fail2ban_version": "4.3.0.8"

--- a/wordpress-18-04/template.json
+++ b/wordpress-18-04/template.json
@@ -3,7 +3,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "wordpress-18-04-snapshot-{{timestamp}}",
-    "apt_packages": "apache2 fail2ban libapache2-mod-php mysql-server php7.4 php7.4-apcu php7.4-bz2 php7.4-curl php7.4-gd php7.4-gmp php7.4-intl php7.4-json php7.4-mbstring php7.4-mysql php7.4-pspell php7.4-soap php7.4-tidy php7.4-xml php7.4-xmlrpc php7.4-xsl php7.4-zip postfix python-certbot-apache software-properties-common unzip",
+    "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python-certbot-apache software-properties-common unzip",
     "application_name": "WordPress",
     "application_version": "5.5.1",
     "fail2ban_version": "4.3.0.8"
@@ -58,6 +58,8 @@
       "inline": [
         "add-apt-repository ppa:certbot/certbot",
         "add-apt-repository -y ppa:ondrej/php",
+        "wget -c https://repo.mysql.com//mysql-apt-config_0.8.13-1_all.deb",
+        "dpkg -i mysql-apt-config_0.8.13-1_all.deb",
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",

--- a/wordpress-20-04/scripts/010-php.sh
+++ b/wordpress-20-04/scripts/010-php.sh
@@ -3,4 +3,4 @@
 sed -e "s|upload_max_filesize.*|upload_max_filesize = 16M|g" \
     -e "s|post_max_size.*|post_max_size = 16M|g" \
     -e "s|max_execution_time.*|max_execution_time = 60|g" \
-    -i /etc/php/7.4/apache2/php.ini
+    -i /etc/php/8.0/apache2/php.ini

--- a/wordpress-20-04/template.json
+++ b/wordpress-20-04/template.json
@@ -3,7 +3,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "wordpress-20-04-snapshot-{{timestamp}}",
-    "apt_packages": "apache2 fail2ban libapache2-mod-php mysql-server php php-apcu php-bz2 php-curl php-gd php-gmp php-intl php-json php-mbstring php-mysql php-pspell php-soap php-tidy php-xml php-xmlrpc php-xsl php-zip postfix python3-certbot-apache software-properties-common unzip",
+    "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python3-certbot-apache software-properties-common unzip",
     "application_name": "WordPress",
     "application_version": "5.5.1",
     "fail2ban_version": "4.3.0.8"
@@ -56,6 +56,9 @@
         "LC_CTYPE=en_US.UTF-8"
       ],
       "inline": [
+        "add-apt-repository -y ppa:ondrej/php",
+        "wget -c https://repo.mysql.com//mysql-apt-config_0.8.13-1_all.deb",
+        "dpkg -i mysql-apt-config_0.8.13-1_all.deb",
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",


### PR DESCRIPTION
Updates
- Wordpress-ubuntu-20-04:
   mySQL: 7.4 -> 8.0
<img width="256" alt="Screenshot 2021-07-07 at 15 28 07" src="https://user-images.githubusercontent.com/25306765/124762918-12b7cf80-df3c-11eb-9f1d-b0ae8f3dcc0e.png">
  php: 7.4 -> 8.0
<img width="682" alt="Screenshot 2021-07-07 at 15 47 35" src="https://user-images.githubusercontent.com/25306765/124763330-8063fb80-df3c-11eb-8935-6e0c3a282f63.png">

- Wordpress-ubuntu-18-04:
      mySQL: 7.4 -> 8.0
<img width="256" alt="Screenshot 2021-07-07 at 15 28 07" src="https://user-images.githubusercontent.com/25306765/124763101-44c93180-df3c-11eb-8224-4e0d7ceb73ec.png">
       php: 7.4 -> 8.0
<img width="671" alt="Screenshot 2021-07-07 at 15 28 35" src="https://user-images.githubusercontent.com/25306765/124763213-67f3e100-df3c-11eb-85c1-01dd7b4f70bc.png">

