### PR TITLE
[MP-3976] Update wordpress version to 5.8

### DIFF
--- a/wordpress-18-04/template.json
+++ b/wordpress-18-04/template.json
@@ -5,8 +5,8 @@
     "image_name": "wordpress-18-04-snapshot-{{timestamp}}",
     "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python3-certbot-apache software-properties-common unzip",
     "application_name": "WordPress",
-    "application_version": "5.5.1",
-    "fail2ban_version": "4.3.0.8"
+    "application_version": "5.8",
+    "fail2ban_version": "4.3.0.9"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [

--- a/wordpress-20-04/template.json
+++ b/wordpress-20-04/template.json
@@ -5,8 +5,8 @@
     "image_name": "wordpress-20-04-snapshot-{{timestamp}}",
     "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python3-certbot-apache software-properties-common unzip",
     "application_name": "WordPress",
-    "application_version": "5.5.1",
-    "fail2ban_version": "4.3.0.8"
+    "application_version": "5.8",
+    "fail2ban_version": "4.3.0.9"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [


### PR DESCRIPTION
**Description**
A customer found that wordpress works with errors, for example it's not possible to change themes in admin area. Also that customer found the solution - wordpress 5.8 doesn't have this problem

**What PR does**
Upgrade wordpress version to 5.8

**PR test results**
<img width="400" alt="Screenshot 2021-08-05 at 09 04 29" src="https://user-images.githubusercontent.com/24397578/128302069-6c39975e-c227-4cfd-a11f-c36c23f009ff.png">
<img width="400" alt="Screenshot 2021-08-05 at 09 24 38" src="https://user-images.githubusercontent.com/24397578/128302091-cb44a41b-367b-43f2-bfb9-bb366e422b8e.png">
<img width="400" alt="Screenshot 2021-08-05 at 09 24 59" src="https://user-images.githubusercontent.com/24397578/128302096-abb4d560-29f9-4de1-9daa-1659713d1977.png">
<img width="400" alt="Screenshot 2021-08-05 at 09 32 24" src="https://user-images.githubusercontent.com/24397578/128302617-9e346e61-7872-4463-a8fa-f9c563585283.png">
