### PR TITLE
wordpress/{18-04,20-04}: update wp images to look for new predeploy variables

### DIFF
--- a/wordpress-18-04/files/etc/update-motd.d/99-one-click
+++ b/wordpress-18-04/files/etc/update-motd.d/99-one-click
@@ -16,8 +16,12 @@ In a web browser, you can view:
 
 On the server:
  * The default web root is located at /var/www/html
- * The MySQL root password and MySQL wordpress user password are saved
-   in /root/.digitalocean_password
+ * If you're using the embedded database, the MySQL root password
+   and MySQL wordpress user password are saved in /root/.digitalocean_password
+   If you've opted in to using a Dbaas instance with DigitalOcean, you will
+   find your credentials written to /root/.digitalocean_dbaas_credentials and
+   you will have access to a DATABASE_URL environment variable holding your
+   database connection string.
  * The must-use WordPress security plugin, fail2ban, is located at
    /var/www/html/wp-content/mu-plugins/fail2ban.php
  * Certbot is preinstalled. Run it to configure HTTPS. See

--- a/wordpress-18-04/files/etc/update-motd.d/99-one-click
+++ b/wordpress-18-04/files/etc/update-motd.d/99-one-click
@@ -18,7 +18,7 @@ On the server:
  * The default web root is located at /var/www/html
  * If you're using the embedded database, the MySQL root password
    and MySQL wordpress user password are saved in /root/.digitalocean_password
-   If you've opted in to using a Dbaas instance with DigitalOcean, you will
+   If you've opted in to using a DBaaS instance with DigitalOcean, you will
    find your credentials written to /root/.digitalocean_dbaas_credentials and
    you will have access to a DATABASE_URL environment variable holding your
    database connection string.

--- a/wordpress-20-04/files/etc/update-motd.d/99-one-click
+++ b/wordpress-20-04/files/etc/update-motd.d/99-one-click
@@ -16,8 +16,12 @@ In a web browser, you can view:
 
 On the server:
  * The default web root is located at /var/www/html
- * The MySQL root password and MySQL wordpress user password are saved
-   in /root/.digitalocean_password
+ * If you're using the embedded database, the MySQL root password
+   and MySQL wordpress user password are saved in /root/.digitalocean_password
+   If you've opted in to using a Dbaas instance with DigitalOcean, you will
+   find your credentials written to /root/.digitalocean_dbaas_credentials and
+   you will have access to a DATABASE_URL environment variable holding your
+   database connection string.
  * The must-use WordPress security plugin, fail2ban, is located at
    /var/www/html/wp-content/mu-plugins/fail2ban.php
  * Certbot is preinstalled. Run it to configure HTTPS. See

--- a/wordpress-20-04/files/etc/update-motd.d/99-one-click
+++ b/wordpress-20-04/files/etc/update-motd.d/99-one-click
@@ -18,7 +18,7 @@ On the server:
  * The default web root is located at /var/www/html
  * If you're using the embedded database, the MySQL root password
    and MySQL wordpress user password are saved in /root/.digitalocean_password
-   If you've opted in to using a Dbaas instance with DigitalOcean, you will
+   If you've opted in to using a DBaaS instance with DigitalOcean, you will
    find your credentials written to /root/.digitalocean_dbaas_credentials and
    you will have access to a DATABASE_URL environment variable holding your
    database connection string.

--- a/wordpress-20-04/files/opt/digitalocean/wp_setup.sh
+++ b/wordpress-20-04/files/opt/digitalocean/wp_setup.sh
@@ -17,11 +17,11 @@ chown -Rf www-data:www-data /var/www/html
 # if applicable, configure wordpress to use mysql dbaas
 if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
   # grab all the data from the password file
-  username=$(sed -n "s/^mysql_username=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-  password=$(sed -n "s/^mysql_password=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-  host=$(sed -n "s/^mysql_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-  port=$(sed -n "s/^mysql_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
-  database=$(sed -n "s/^mysql_database=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  username=$(sed -n "s/^db_username=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  password=$(sed -n "s/^db_password=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  host=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  port=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  database=$(sed -n "s/^db_database=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
 
   # update the wp-config.php with stored credentials
   sed -i "s/'DB_USER', '.*'/'DB_USER', '$username'/g" /var/www/html/wp-config.php;


### PR DESCRIPTION
We are making updates within Marketplace->Predeploy to be more dynamic. Those changes make the
credentials written to file look slightly different. The changes in this PR will allow Wordpress/Dbaas to
continue to work, by looking for the updated variable names.