### PR TITLE
droplet-1-clicks/lamp: update lamp to work with dbaas

### DIFF
--- a/lamp-18-04/files/etc/update-motd.d/99-one-click
+++ b/lamp-18-04/files/etc/update-motd.d/99-one-click
@@ -16,7 +16,12 @@ In a web browser, you can view:
 
 On the server:
  * The default web root is located at /var/www/html
- * The MySQL root password is saved in /root/.digitalocean_password
+ * If you're using the embedded database, the MySQL root password
+   is saved in /root/.digitalocean_password. If you've opted in to
+   using a DBaaS instance with DigitalOcean, you will find your
+   credentials written to /root/.digitalocean_dbaas_credentials
+   and you will have access to a DATABASE_URL environment variable
+   holding your database connection string.
  * Certbot is preinstalled. Run it to configure HTTPS. See
    https://do.co/3gY97ha#enable-https for more detail.
 

--- a/lamp-18-04/scripts/011-lamp.sh
+++ b/lamp-18-04/scripts/011-lamp.sh
@@ -4,3 +4,26 @@ chown -R www-data: /etc/apache2
 chown -R www-data: /var/log/apache2
 chown -R www-data: /var/www
 chown -R www-data: /var/www/html
+
+# if applicable, configure lamp to use & wait for a mysql dbaas instance.
+if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
+  # grab host & port to block until database connection is ready
+  host=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  port=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+
+  # wait for db to become available
+  echo -e "\nWaiting for your database to become available (this may take a few minutes)"
+  while ! mysqladmin ping -h "$host" -P "$port" --silent; do
+      printf .
+      sleep 2
+  done
+  echo -e "\nDatabase available!\n"
+
+  # disable the local MySQL instance
+  systemctl stop mysql.service
+  systemctl disable mysql.service
+
+  # cleanup
+  unset host port
+  rm -rf /etc/mysql
+fi

--- a/lamp-20-04/files/etc/update-motd.d/99-one-click
+++ b/lamp-20-04/files/etc/update-motd.d/99-one-click
@@ -16,7 +16,12 @@ In a web browser, you can view:
 
 On the server:
  * The default web root is located at /var/www/html
- * The MySQL root password is saved in /root/.digitalocean_password
+ * If you're using the embedded database, the MySQL root password
+   is saved in /root/.digitalocean_password. If you've opted in to
+   using a DBaaS instance with DigitalOcean, you will find your
+   credentials written to /root/.digitalocean_dbaas_credentials
+   and you will have access to a DATABASE_URL environment variable
+   holding your database connection string.
  * Certbot is preinstalled. Run it to configure HTTPS. See
    https://do.co/3gY97ha#enable-https for more detail.
 

--- a/lamp-20-04/scripts/011-lamp.sh
+++ b/lamp-20-04/scripts/011-lamp.sh
@@ -4,3 +4,26 @@ chown -R www-data: /etc/apache2
 chown -R www-data: /var/log/apache2
 chown -R www-data: /var/www
 chown -R www-data: /var/www/html
+
+# if applicable, configure lamp to use & wait for a mysql dbaas instance.
+if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
+  # grab host & port to block until database connection is ready
+  host=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  port=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+
+  # wait for db to become available
+  echo -e "\nWaiting for your database to become available (this may take a few minutes)"
+  while ! mysqladmin ping -h "$host" -P "$port" --silent; do
+      printf .
+      sleep 2
+  done
+  echo -e "\nDatabase available!\n"
+
+  # disable the local MySQL instance
+  systemctl stop mysql.service
+  systemctl disable mysql.service
+
+  # cleanup
+  unset host port
+  rm -rf /etc/mysql
+fi


### PR DESCRIPTION
This set of changes should allow lamp to be used with
predeploy/dbaas. It will look for the credentials 
that predeploy writes to disk, and if they’re there
this means the user has requested a dbaas instance.
This will also ensure the local mysql instance on
the droplet is turned off, and it will also ping
the dbaas instance until it is ready.