### PR TITLE
Fix mysql installation in wordpress app

### DIFF
--- a/wordpress-18-04/template.json
+++ b/wordpress-18-04/template.json
@@ -5,8 +5,8 @@
     "image_name": "wordpress-18-04-snapshot-{{timestamp}}",
     "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python3-certbot-apache software-properties-common unzip",
     "application_name": "WordPress",
-    "application_version": "5.8",
-    "fail2ban_version": "4.3.0.9"
+    "application_version": "6.0",
+    "fail2ban_version": "4.4.0.4"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -58,8 +58,8 @@
       "inline": [
         "add-apt-repository ppa:certbot/certbot",
         "add-apt-repository -y ppa:ondrej/php",
-        "wget -c https://repo.mysql.com//mysql-apt-config_0.8.13-1_all.deb",
-        "dpkg -i mysql-apt-config_0.8.13-1_all.deb",
+        "wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb",
+        "dpkg -i mysql-apt-config_0.8.22-1_all.deb",
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",

--- a/wordpress-20-04/scripts/011-wordpress.sh
+++ b/wordpress-20-04/scripts/011-wordpress.sh
@@ -8,7 +8,6 @@ wget "https://wordpress.org/wordpress-${application_version}.tar.gz" \
 mkdir -p /var/www
 tar -C /var/www \
     -xvvf /tmp/wordpress.tar.gz
-
 wpfail2ban="wp-fail2ban.${fail2ban_version}.zip"
 wget https://downloads.wordpress.org/plugin/${wpfail2ban} -O /tmp/wp-fail2ban.zip
 unzip /tmp/wp-fail2ban.zip -d /tmp/

--- a/wordpress-20-04/scripts/011-wordpress.sh
+++ b/wordpress-20-04/scripts/011-wordpress.sh
@@ -8,6 +8,7 @@ wget "https://wordpress.org/wordpress-${application_version}.tar.gz" \
 mkdir -p /var/www
 tar -C /var/www \
     -xvvf /tmp/wordpress.tar.gz
+
 wpfail2ban="wp-fail2ban.${fail2ban_version}.zip"
 wget https://downloads.wordpress.org/plugin/${wpfail2ban} -O /tmp/wp-fail2ban.zip
 unzip /tmp/wp-fail2ban.zip -d /tmp/

--- a/wordpress-20-04/template.json
+++ b/wordpress-20-04/template.json
@@ -5,8 +5,8 @@
     "image_name": "wordpress-20-04-snapshot-{{timestamp}}",
     "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python3-certbot-apache software-properties-common unzip",
     "application_name": "WordPress",
-    "application_version": "5.8",
-    "fail2ban_version": "4.3.0.9"
+    "application_version": "6.0",
+    "fail2ban_version": "4.4.0.4"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -57,8 +57,8 @@
       ],
       "inline": [
         "add-apt-repository -y ppa:ondrej/php",
-        "wget -c https://repo.mysql.com//mysql-apt-config_0.8.13-1_all.deb",
-        "dpkg -i mysql-apt-config_0.8.13-1_all.deb",
+        "wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb",
+        "dpkg -i mysql-apt-config_0.8.22-1_all.deb",
         "apt -qqy update",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
         "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",


### PR DESCRIPTION
**Description**

After some updates (again), we found broken mysql installation in wordpress app. This PR fixes the problem (app is updated too)

**Screenshots***
How it was
<img width="1734" alt="Screenshot 2022-06-16 at 11 10 57" src="https://user-images.githubusercontent.com/24397578/174062746-8d4fd892-b985-41f3-8c72-c7c122489dac.png">


After:
<img width="651" alt="Screenshot 2022-06-16 at 13 28 19" src="https://user-images.githubusercontent.com/24397578/174062952-43867351-58c1-483e-a0d7-811091983f90.png">

<img width="660" alt="Screenshot 2022-06-16 at 14 27 58" src="https://user-images.githubusercontent.com/24397578/174062967-f18a44d4-c0c1-4476-91e5-61759ad1ce3c.png">
