### PR TITLE
Fix memory problems with wordpress on tiny droplets

### DIFF
--- a/wordpress-18-04/files/etc/mysql/mysql.conf.d/performance.cnf
+++ b/wordpress-18-04/files/etc/mysql/mysql.conf.d/performance.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+performance_schema=off

--- a/wordpress-20-04/files/etc/mysql/mysql.conf.d/performance.cnf
+++ b/wordpress-20-04/files/etc/mysql/mysql.conf.d/performance.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+performance_schema=off


### PR DESCRIPTION
**Description**

Some of the our clients informed us about memory problems with wordpress on tiny droplets. We decided to investigate and fix problem if it's possible.

**Solution**

For for all, running wordpress on tiny droplet is not a good idea, because there are some big apps consuming memory - apache2, mysql, python (for fail2ban pluging), etc. 
As we found mysql takes about 400M of memory and this problems can be fixed simple - just turn off `perfomance_schema`. This PR modifies mysql configuration to use less memory

**Screenshots**
With performance schema ON:

<img width="814" alt="Screenshot 2022-07-18 at 14 49 32" src="https://user-images.githubusercontent.com/24397578/179519185-02d87a42-b82f-46d2-8683-29fe657fa129.png">
<img width="830" alt="Screenshot 2022-07-18 at 15 10 36" src="https://user-images.githubusercontent.com/24397578/179519212-cfd164d7-1152-41b7-ac82-5a857619d2e6.png">
<img width="680" alt="Screenshot 2022-07-18 at 15 24 51" src="https://user-images.githubusercontent.com/24397578/179519243-29a2fa4c-864a-433f-83cb-2dff9f280dea.png">

Without: 
<img width="696" alt="Screenshot 2022-07-18 at 15 02 51" src="https://user-images.githubusercontent.com/24397578/179519289-92f9e01d-37af-4757-a9a3-695025d98b35.png">
<img width="787" alt="Screenshot 2022-07-18 at 15 15 20" src="https://user-images.githubusercontent.com/24397578/179519317-0b4c091a-026b-4205-9c53-bdaed42439f2.png">
