### PR TITLE
Update nodejs version from 16 to 18

### DIFF
--- a/nodejs-20-04/template.json
+++ b/nodejs-20-04/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "nodejs-20-04-snapshot-{{timestamp}}",
-    "node_version": "node_16.x",
+    "node_version": "node_18.x",
     "apt_packages": "nginx",
     "application_name": "Node.js"
   },


### PR DESCRIPTION
**Description**

This PR updates NodeJS from version 16 to 18 in 1-click-droplet app

before:
<img width="650" alt="Screenshot 2022-07-29 at 15 00 18" src="https://user-images.githubusercontent.com/24397578/181757009-8af75ff0-f8ce-4a15-83be-c908fc1c428c.png">
after:
<img width="708" alt="Screenshot 2022-07-29 at 15 11 56" src="https://user-images.githubusercontent.com/24397578/181757024-243800c1-65be-4735-8109-cb64d4d84305.png">

https://nodejs.org/en/about/releases/
<img width="781" alt="Screenshot 2022-07-29 at 15 12 10" src="https://user-images.githubusercontent.com/24397578/181757038-70f1ef38-cbac-496d-b06d-482cafaaefa2.png">
