### PR TITLE
Update LAMP version

### DIFF
--- a/lamp-20-04/template.json
+++ b/lamp-20-04/template.json
@@ -3,7 +3,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "lamp-20-04-snapshot-{{timestamp}}",
-    "apt_packages": "apache2 expect fail2ban lamp-server^ libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-gd php8.0-mysql postfix python3-certbot-apache software-properties-common",
+    "apt_packages": "apache2 expect fail2ban lamp-server^ libapache2-mod-php8.1 mysql-server php8.1 php8.1-apcu php8.1-gd php8.1-mysql postfix python3-certbot-apache software-properties-common",
     "application_name": "LAMP",
     "application_version": ""
   },


### PR DESCRIPTION
After checking the versions of all tools, it was revealed that only the PHP version needed to be updated, the new image has been checked and is awaiting approval on the vendor portal. 
Last versions of tools:
Apache
<img width="1127" alt="Screenshot 2022-07-29 at 11 44 11" src="https://user-images.githubusercontent.com/25306765/181817043-4ada9af7-b9a1-4c59-9092-6e2d73548be8.png">

PHP
<img width="837" alt="Screenshot 2022-07-29 at 11 45 09" src="https://user-images.githubusercontent.com/25306765/181817087-6974c018-e46e-4b4b-8e4d-517d6a3a673d.png">

MySQL
<img width="1285" alt="Screenshot 2022-07-29 at 12 02 08" src="https://user-images.githubusercontent.com/25306765/181817127-05c98fb1-a0c3-4835-bd02-2cbb324c652f.png">


Versions from new image:
<img width="738" alt="versions" src="https://user-images.githubusercontent.com/25306765/181817183-dc2d9e93-057c-4c66-870a-ceb2e82ebb42.png">
