### PR TITLE
Turn off performance scheme on tiny droplets for WordPress

### DIFF
--- a/wordpress-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/wordpress-20-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -17,6 +17,15 @@ root_mysql_pass="${root_mysql_pass}"
 wordpress_mysql_pass="${wordpress_mysql_pass}"
 EOM
 
+# there are no available memory for WP on tiny droplets sometimes. Simple fix: turn off mysql 
+# perfomance schema for these droplets
+dropletMemory=$(LANG=C free|awk '/^Mem:/{print $2}')
+if [ $dropletMemory -lt 2000000 ]; then
+	echo "[mysqld]
+performance_schema=off" > /etc/mysql/mysql.conf.d/performance.cnf
+	systemctl restart mysql
+fi
+
 # Set up Postfix defaults
 hostname=$(hostname)
 sed -i "s/myhostname \= wp-build/myhostname = $hostname/g" /etc/postfix/main.cf;


### PR DESCRIPTION
**Description**

After receiving couple of report related to memory issues with wordpress on tiny droplets our team decided to turn off performance scheme in this case. This PR updates wordpress packer file to implement planned fix


<img width="618" alt="Screenshot 2022-08-15 at 10 51 45" src="https://user-images.githubusercontent.com/24397578/184611958-6bb4ab60-1bca-4b87-b12a-f4298b33c0da.png">
<img width="642" alt="Screenshot 2022-08-15 at 12 28 41" src="https://user-images.githubusercontent.com/24397578/184611980-346270e9-f6c6-4432-8e31-daac80154acd.png">
