### PR TITLE
MyPHPAdmin Ubuntu 22.04 update

### DIFF
--- a/phpmyadmin-22-04/template.json
+++ b/phpmyadmin-22-04/template.json
@@ -33,12 +33,12 @@
     },
     {
       "type": "file",
-      "source": "mysql-22-04/files/etc/",
+      "source": "mysql-20-04/files/etc/",
       "destination": "/etc/"
     },
     {
       "type": "file",
-      "source": "mysql-22-04/files/var/",
+      "source": "mysql-20-04/files/var/",
       "destination": "/var/"
     },
     {
@@ -68,7 +68,7 @@
         "LC_CTYPE=en_US.UTF-8"
       ],
       "scripts": [
-        "mysql-22-04/scripts/010-php-my-admin.sh",
+        "mysql-20-04/scripts/010-php-my-admin.sh",
         "common/scripts/014-ufw-apache.sh",
         "common/scripts/014-ufw-mysql.sh",
         "common/scripts/018-force-ssh-logout.sh",

--- a/phpmyadmin-22-04/template.json
+++ b/phpmyadmin-22-04/template.json
@@ -5,7 +5,7 @@
     "image_name": "phpmyadmin-22-04-snapshot-{{timestamp}}",
     "apt_packages": "apache2 apache2-utils mysql-server php php-gd php-mysql phpmyadmin python3-certbot-apache libapache2-mod-php lamp-server^",
     "application_name": "phpMyAdmin",
-    "application_version": "5.0.3"
+    "application_version": "5.2.0"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [

--- a/phpmyadmin-22-04/template.json
+++ b/phpmyadmin-22-04/template.json
@@ -1,0 +1,80 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "phpmyadmin-22-04-snapshot-{{timestamp}}",
+    "apt_packages": "apache2 apache2-utils mysql-server php php-gd php-mysql phpmyadmin python3-certbot-apache libapache2-mod-php lamp-server^",
+    "application_name": "phpMyAdmin",
+    "application_version": "5.0.3"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-22-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "mysql-22-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "mysql-22-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "phpmyadmin_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "mysql-22-04/scripts/010-php-my-admin.sh",
+        "common/scripts/014-ufw-apache.sh",
+        "common/scripts/014-ufw-mysql.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Updated MyPHPAdmin Ubuntu version to 22.04
Also updated MyPHPAdmin from 5.0.3 to 5.2.0 because 5.0.3 was dropping a lot of `depricated` warnings.
Tested! Works good!

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/94634250/214328621-c30c1eed-45b4-4257-a0f6-3da0afaf9660.png">
