### PR TITLE
Update Discourse to Ubuntu 22.04

### DIFF
--- a/discourse-22-04/files/etc/update-motd.d/99-one-click
+++ b/discourse-22-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+cat <<EOF
+********************************************************************************
+
+Welcome to the DigitalOcean Discourse 1-Click Application
+
+On your first login you will be prompted to configure your Discourse installation.
+
+All Discourse scripts and files may be found in /var/discourse and the setup
+utility can be run again by launching discourse-setup in that directory.
+
+For help and more information, visit https://do.co/3dmapBw
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/discourse-22-04/files/opt/digitalocean/setup_discourse.sh
+++ b/discourse-22-04/files/opt/digitalocean/setup_discourse.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+clear
+echo "----------------------------------------------------------------------------"
+echo "This script will configure your Discourse installation"
+echo "Please be sure you have the following information to proceed:"
+echo "  - Email Address for your Discourse install"
+echo "  - Domain/Subdomain to use"
+echo "  - Mail server information (SMTP)"
+echo ""
+echo "After being prompted for these details the Discourse installer will"
+echo "download and install the latest version of Discourse and its requirements"
+echo "This process will take approximately 10 minutes"
+echo "----------------------------------------------------------------------------"
+echo "When you are ready to proceed, press Enter"
+echo "To cancel setup, press Ctrl+C and this script will be run again on your next login"
+
+read wait
+cd /var/discourse
+
+if ./discourse-setup; then
+  clear
+  echo "Discourse is now installed.  Log into your admin account in a browser to continue"
+  echo "configuring Discourse."
+
+  cp -f /etc/skel/.bashrc /root/.bashrc
+else
+  echo ""
+  echo "----------------------------------------------------------------------------"
+  echo "The setup script failed with the provided Discourse details"
+  echo "It will rerun. Please address the above issues"
+  echo "----------------------------------------------------------------------------"
+  echo "When you are ready to proceed, press Enter"
+  echo "To cancel setup, press Ctrl+C and this script will be run again on your next login"
+  read wait
+fi

--- a/discourse-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/discourse-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Scripts in this directory will be executed by cloud-init on the first boot of droplets
+# created from your image.  Things like generating passwords, configuration requiring IP address
+# or other items that will be unique to each instance should be done in scripts here.
+
+# Install latest updates on first boot
+cd /var/discourse
+git pull
+
+DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get -qqy upgrade
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh

--- a/discourse-22-04/scripts/010-discourse.sh
+++ b/discourse-22-04/scripts/010-discourse.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Scripts in this directory are run during the build process.
+# each script will be uploaded to /tmp on your build droplet, 
+# given execute permissions and run.  The cleanup process will
+# remove the scripts from your build system after they have run
+# if you use the build_image task.
+#
+mkdir /var/discourse
+git clone https://github.com/discourse/discourse_docker.git /var/discourse
+
+# Add first-login task
+cat >> /root/.bashrc <<EOM
+/opt/digitalocean/setup_discourse.sh
+EOM

--- a/discourse-22-04/template.json
+++ b/discourse-22-04/template.json
@@ -1,0 +1,84 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "discourse-22-04-snapshot-{{timestamp}}",
+    "apt_packages": "apt-transport-https ca-certificates curl git jq linux-image-extra-virtual software-properties-common",
+    "application_name": "Discourse",
+    "application_version": "latest"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-22-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "discourse-22-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "discourse-22-04/files/opt/",
+      "destination": "/opt/"
+    },
+    {
+      "type": "file",
+      "source": "discourse-22-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "common/scripts/010-docker.sh",
+        "discourse-22-04/scripts/010-discourse.sh",
+        "common/scripts/014-ufw-http.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Updated Discourse to run on Ubuntu 22.04
Tested! Works good:

![image](https://user-images.githubusercontent.com/94634250/214891930-9a32f708-a52a-46d1-b55e-209413edf6cf.png)
