### PR TITLE
Update WordPress to Ubuntu 22.04

### DIFF
--- a/wordpress-22-04/files/etc/apache2/conf-available/block-xmlrpc.conf
+++ b/wordpress-22-04/files/etc/apache2/conf-available/block-xmlrpc.conf
@@ -1,0 +1,5 @@
+<IfModule mod_rewrite.c>
+    <Directory / >
+        Redirect 301 /xmlrpc.php /
+    </Directory>
+</IfModule>

--- a/wordpress-22-04/files/etc/apache2/sites-available/000-default.conf
+++ b/wordpress-22-04/files/etc/apache2/sites-available/000-default.conf
@@ -1,0 +1,20 @@
+# Added to mitigate CVE-2017-8295 vulnerability
+UseCanonicalName On
+
+<VirtualHost *:80>
+        ServerAdmin webmaster@localhost
+        
+        ServerName $domain
+        ServerAlias www.$domain
+        
+        DocumentRoot /var/www/html
+
+        <Directory /var/www/html/>
+            Options FollowSymLinks
+            AllowOverride All
+            Require all granted
+        </Directory>
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/wordpress-22-04/files/etc/fail2ban/jail.d/wordpress-digitalocean.conf
+++ b/wordpress-22-04/files/etc/fail2ban/jail.d/wordpress-digitalocean.conf
@@ -1,0 +1,15 @@
+[wordpress-hard]
+enabled = true
+filter = wordpress-hard
+logpath = /var/log/auth.log
+maxretry = 3
+port = http,https
+bantime = 86400
+
+[wordpress-soft]
+enabled = true
+filter = wordpress-soft
+logpath = /var/log/auth.log
+maxretry = 5
+port = http,https
+bantime = 1800

--- a/wordpress-22-04/files/etc/update-motd.d/99-one-click
+++ b/wordpress-22-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's One-Click WordPress Droplet.
+To keep this Droplet secure, the UFW firewall is enabled.
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
+
+In a web browser, you can view:
+ * The WordPress One-Click Quickstart guide: https://do.co/34TfYn8#start
+ * The new WordPress site: http://$myip
+
+On the server:
+ * The default web root is located at /var/www/html
+ * If you're using the embedded database, the MySQL root password
+   and MySQL wordpress user password are saved in /root/.digitalocean_password
+   If you've opted in to using a DBaaS instance with DigitalOcean, you will
+   find your credentials written to /root/.digitalocean_dbaas_credentials and
+   you will have access to a DATABASE_URL environment variable holding your
+   database connection string.
+ * The must-use WordPress security plugin, fail2ban, is located at
+   /var/www/html/wp-content/mu-plugins/fail2ban.php
+ * Certbot is preinstalled. Run it to configure HTTPS. See
+   https://do.co/34TfYn8#enable-https for more detail.
+ * For security, xmlrpc calls are blocked by default.  This block can be
+    disabled by running "a2disconf block-xmlrpc" in the terminal.
+
+IMPORTANT:
+   After connecting to the Droplet for the first time,
+   immediately add the WordPress administrator at http://$myip.
+
+For help and more information, visit https://do.co/34TfYn8
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/wordpress-22-04/files/root/wp_setup.sh
+++ b/wordpress-22-04/files/root/wp_setup.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# WordPress activation script
+#
+# This script will configure Apache with the domain
+# provided by the user and offer the option to set up
+# LetsEncrypt as well.
+
+# Enable WordPress on first login
+if [[ -d /var/www/wordpress ]]
+then
+  mv /var/www/html /var/www/html.old
+  mv /var/www/wordpress /var/www/html
+fi
+chown -Rf www-data:www-data /var/www/html
+
+# if applicable, configure wordpress to use mysql dbaas
+if [ -f "/root/.digitalocean_dbaas_credentials" ] && [ "$(sed -n "s/^db_protocol=\"\([^:]*\):.*\"$/\1/p" /root/.digitalocean_dbaas_credentials)" = "mysql" ]; then
+  # grab all the data from the password file
+  username=$(sed -n "s/^db_username=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  password=$(sed -n "s/^db_password=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  host=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  port=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  database=$(sed -n "s/^db_database=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+
+  # update the wp-config.php with stored credentials
+  sed -i "s/'DB_USER', '.*'/'DB_USER', '$username'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_NAME', '.*'/'DB_NAME', '$database'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_PASSWORD', '.*'/'DB_PASSWORD', '$password'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_HOST', '.*'/'DB_HOST', '$host:$port'/g" /var/www/html/wp-config.php;
+
+  # add required SSL flag
+  cat >> /var/www/html/wp-config.php <<EOM
+/** Connect to MySQL cluster over SSL **/
+define( 'MYSQL_CLIENT_FLAGS', MYSQLI_CLIENT_SSL );
+EOM
+
+  # wait for db to become available
+  echo -e "\nWaiting for your database to become available (this may take a few minutes)"
+  while ! mysqladmin ping -h "$host" -P "$port" --silent; do
+      printf .
+      sleep 2
+  done
+  echo -e "\nDatabase available!\n"
+
+  # cleanup
+  unset username password host port database
+  rm -f /root/.digitalocean_dbaas_credentials
+
+  # disable the local MySQL instance
+  systemctl stop mysql.service
+  systemctl disable mysql.service
+fi
+
+echo "This script will copy the WordPress installation into"
+echo "Your web root and move the existing one to /var/www/html.old"
+echo "--------------------------------------------------"
+echo "This setup requires a domain name.  If you do not have one yet, you may"
+echo "cancel this setup, press Ctrl+C.  This script will run again on your next login"
+echo "--------------------------------------------------"
+echo "Enter the domain name for your new WordPress site."
+echo "(ex. example.org or test.example.org) do not include www or http/s"
+echo "--------------------------------------------------"
+
+a=0
+while [ $a -eq 0 ]
+do
+ read -p "Domain/Subdomain name: " dom
+ if [ -z "$dom" ]
+ then
+  a=0
+  echo "Please provide a valid domain or subdomain name to continue to press Ctrl+C to cancel"
+ else
+  a=1
+fi
+done
+sed -i "s/\$domain/$dom/g"  /etc/apache2/sites-enabled/000-default.conf
+a2enconf block-xmlrpc
+
+service apache2 restart
+
+echo -en "Now we will create your new admin user account for WordPress."
+
+function wordpress_admin_account(){
+
+  while [ -z $email ]
+  do
+    echo -en "\n"
+    read -p "Your Email Address: " email
+  done
+
+  while [ -z $username ]
+  do
+    echo -en "\n"
+    read -p  "Username: " username
+  done
+
+  while [ -z $pass ]
+  do
+    echo -en "\n"
+    read -s -p "Password: " pass
+    echo -en "\n"
+  done
+
+  while [ -z "$title" ]
+  do
+    echo -en "\n"
+    read -p "Blog Title: " title
+  done
+}
+
+wordpress_admin_account
+
+while true
+do
+    echo -en "\n"
+    read -p "Is the information correct? [Y/n] " confirmation
+    confirmation=${confirmation,,}
+    if [[ "${confirmation}" =~ ^(yes|y)$ ]] || [ -z $confirmation ]
+    then
+      break
+    else
+      unset email username pass title confirmation
+      wordpress_admin_account
+    fi
+done
+
+echo -en "\n\n\n"
+echo "Next, you have the option of configuring LetsEncrypt to secure your new site.  Before doing this, be sure that you have pointed your domain or subdomain to this server's IP address.  You can also run LetsEncrypt certbot later with the command 'certbot --apache'"
+echo -en "\n\n\n"
+ read -p "Would you like to use LetsEncrypt (certbot) to configure SSL(https) for your new site? (y/n): " yn
+    case $yn in
+        [Yy]* ) certbot --apache; echo "WordPress has been enabled at https://$dom  Please open this URL in a browser to complete the setup of your site.";break;;
+        [Nn]* ) echo "Skipping LetsEncrypt certificate generation";break;;
+        * ) echo "Please answer y or n.";;
+    esac
+
+echo "Finalizing installation..."
+wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O /usr/bin/wp
+chmod +x /usr/bin/wp
+
+echo -en "Completing the configuration of WordPress."
+wp core install --allow-root --path="/var/www/html" --title="$title" --url="$dom" --admin_email="$email"  --admin_password="$pass" --admin_user="$username"
+
+wp plugin install wp-fail2ban --allow-root --path="/var/www/html"
+wp plugin activate wp-fail2ban --allow-root --path="/var/www/html"
+chown -Rf www-data.www-data /var/www/
+cp /etc/skel/.bashrc /root
+
+echo "Installation complete. Access your new WordPress site in a browser to continue."

--- a/wordpress-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/wordpress-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+#Generate Mysql root password.
+root_mysql_pass=$(openssl rand -hex 24)
+wordpress_mysql_pass=$(openssl rand -hex 24)
+debian_sys_maint_mysql_pass=$(openssl rand -hex 24)
+
+# Don't enable WordPress until first login
+cat >> /root/.bashrc <<EOM
+chmod +x /root/wp_setup.sh
+/root/wp_setup.sh
+EOM
+
+# Save the passwords
+cat > /root/.digitalocean_password <<EOM
+root_mysql_pass="${root_mysql_pass}"
+wordpress_mysql_pass="${wordpress_mysql_pass}"
+EOM
+
+# there are no available memory for WP on tiny droplets sometimes. Simple fix: turn off mysql 
+# perfomance schema for these droplets
+dropletMemory=$(LANG=C free|awk '/^Mem:/{print $2}')
+if [ $dropletMemory -lt 2000000 ]; then
+	echo "[mysqld]
+performance_schema=off" > /etc/mysql/mysql.conf.d/performance.cnf
+	systemctl restart mysql
+fi
+
+# Set up Postfix defaults
+hostname=$(hostname)
+sed -i "s/myhostname \= wp-build/myhostname = $hostname/g" /etc/postfix/main.cf;
+sed -i "s/inet_interfaces = all/inet_interfaces = loopback-only/g" /etc/postfix/main.cf;
+systemctl restart postfix &
+
+mysqladmin -u root -h localhost create wordpress
+mysqladmin -u root -h localhost password ${root_mysql_pass}
+
+# populate the wordpress config file
+cp /var/www/wordpress/wp-config-sample.php /var/www/wordpress/wp-config.php
+sed -e "s/'DB_NAME', 'database_name_here'/'DB_NAME', 'wordpress'/g" \
+    -e "s/'DB_USER', 'username_here'/'DB_USER', 'wordpress'/g" \
+    -e "s/'DB_PASSWORD', 'password_here'/'DB_PASSWORD', '${wordpress_mysql_pass}'/g" \
+    -i /var/www/wordpress/wp-config.php
+
+chown -Rf www-data:www-data /var/www/wordpress
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "CREATE USER 'wordpress'@'localhost' IDENTIFIED BY '${wordpress_mysql_pass}'"
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "GRANT ALL PRIVILEGES ON wordpress.* TO wordpress@localhost"
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "ALTER USER 'debian-sys-maint'@'localhost' IDENTIFIED BY '${debian_sys_maint_mysql_pass}'"
+
+MYSQL_ROOT_PASSWORD=${wordpress_mysql_pass}
+
+SECURE_MYSQL=$(expect -c "
+set timeout 10
+spawn mysql_secure_installation
+expect \"Enter current password for root (enter for none):\"
+send \"$MYSQL_ROOT_PASSWORD\r\"
+expect \"Change the root password?\"
+send \"n\r\"
+expect \"Remove anonymous users?\"
+send \"y\r\"
+expect \"Disallow root login remotely?\"
+send \"y\r\"
+expect \"Remove test database and access to it?\"
+send \"y\r\"
+expect \"Reload privilege tables now?\"
+send \"y\r\"
+expect eof
+")
+
+cat > /etc/mysql/debian.cnf <<EOM
+# Automatically generated for Debian scripts. DO NOT TOUCH!
+[client]
+host     = localhost
+user     = debian-sys-maint
+password = ${debian_sys_maint_mysql_pass}
+socket   = /var/run/mysqld/mysqld.sock
+[mysql_upgrade]
+host     = localhost
+user     = debian-sys-maint
+password = ${debian_sys_maint_mysql_pass}
+socket   = /var/run/mysqld/mysqld.sock
+EOM
+
+# WordPress Salts
+for i in `seq 1 8`
+do
+    wp_salt=$(</dev/urandom tr -dc 'a-zA-Z0-9!@#$%^&*()\-_ []{}<>~`+=,.;:/?|' | head -c 64 | sed -e 's/[\/&]/\\&/g')
+    sed -e "0,/put your unique phrase here/s/put your unique phrase here/${wp_salt}/" \
+        -i /var/www/wordpress/wp-config.php;
+done
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh

--- a/wordpress-22-04/files/var/www/html/index.html
+++ b/wordpress-22-04/files/var/www/html/index.html
@@ -1,0 +1,122 @@
+<html>
+  <head>
+    <style>
+      body {
+        font-family: ProximaNova;
+        font-size: 15px;
+        font-style: normal;
+        font-stretch: normal;
+        line-height: 1;
+        letter-spacing: normal;
+        margin: 0;
+      }
+
+      .button {
+        border-radius: 3px;
+        background-color: #0069ff;
+        color: #ffffff;
+        display: flex;
+        flex-direction: column;
+        height: 48px;
+        justify-content: center;
+        text-decoration: none;
+        width: 148px;
+      }
+
+      .content {
+        align-items: center;
+        border: solid 2px #f1f1f1;
+        border-radius: 3px;
+        display: flex;
+        flex-direction: column;
+        margin: 32px auto;
+        padding: 32px;
+        text-align: center;
+        width: 960px;
+      }
+      
+      .content_min {
+        align-items: center;
+        border: solid 2px #f3f3f3;
+        background-color: #fdfdfd;
+        border-radius: 3px;
+        display: flex;
+        flex-direction: column;
+        margin: 8px auto;
+        padding: 8px;
+        text-align: center;
+        width: 860px;
+      }
+
+      .copyright {
+        color: #99999999;
+        font-size: 13px;
+        margin-left: 10px;
+      }
+
+      .description {
+        color: #676767;
+      }
+
+      .empty-access {
+        height: 220px;
+        margin-bottom: -20px;
+      }
+
+      .header {
+        align-items: center;
+        display: flex;
+        margin: 15px;
+      }
+
+      .logo {
+        height: 30px;
+        color: #999999;
+        width: 30px;
+      }
+
+      .title {
+        font-family: ProximaNova;
+        font-size: 21px;
+        font-weight: 600;
+        color: #444444;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <svg class="logo" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+      viewBox="0 0 30 30" enable-background="new 0 0 30 30" xml:space="preserve">
+        <g id="XMLID_17_">
+          <g id="XMLID_18_">
+            <g>
+              <g id="XMLID_225_">
+                <g id="XMLID_233_">
+                  <path id="XMLID_234_" fill="#0080FF" d="M15,30v-5.8c6.2,0,10.9-6.1,8.6-12.6c-0.9-2.4-2.8-4.3-5.2-5.2
+                    C11.9,4.1,5.8,8.8,5.8,15l0,0L0,15C0,5.2,9.5-2.5,19.8,0.7c4.5,1.4,8.1,5,9.5,9.5C32.5,20.5,24.8,30,15,30z"/>
+                </g>
+                <polygon id="XMLID_232_" fill="#0080FF" points="15,24.2 9.2,24.2 9.2,18.4 9.2,18.4 15,18.4 15,18.4"/>
+                <polygon id="XMLID_228_" fill="#0080FF" points="9.2,28.7 4.8,28.7 4.8,28.7 4.8,24.2 9.2,24.2"/>
+                <polygon id="XMLID_226_" fill="#0080FF" points="4.8,24.2 1,24.2 1,24.2 1,20.5 1,20.5 4.8,20.5 4.8,20.5"/>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+      <div class="copyright">&copy; 2018 DigitalOcean, LLC. All rights reserved.</div>
+    </div>
+
+    <div class="content">
+          <svg id="svg" class="empty-access" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300"><defs><style>.cls-1,.cls-11,.cls-6,.cls-8{fill:#d7e9ff;}.cls-1{stroke:#d7e9ff;}.cls-1,.cls-10,.cls-13,.cls-14,.cls-15,.cls-16,.cls-17,.cls-18,.cls-2,.cls-3,.cls-4,.cls-6,.cls-7,.cls-9{stroke-linejoin:round;}.cls-1,.cls-13,.cls-14,.cls-2,.cls-3,.cls-6{stroke-width:1.6px;}.cls-1,.cls-5,.cls-7,.cls-8,.cls-9{fill-rule:evenodd;}.cls-12,.cls-2{fill:#8fbeff;}.cls-10,.cls-14,.cls-2,.cls-4,.cls-6,.cls-7{stroke:#8fbeff;}.cls-3{fill:#4894ff;}.cls-13,.cls-3{stroke:#4894ff;}.cls-13,.cls-14,.cls-15,.cls-16,.cls-18,.cls-4,.cls-7,.cls-9{fill:none;}.cls-15,.cls-16,.cls-18,.cls-4,.cls-6,.cls-7,.cls-9{stroke-linecap:round;}.cls-4{stroke-width:6px;}.cls-10,.cls-17,.cls-5{fill:#fff;}.cls-10,.cls-15,.cls-17,.cls-18,.cls-7,.cls-9{stroke-width:2px;}.cls-15,.cls-9{stroke:#0069ff;}.cls-16{stroke:#fff;stroke-width:1.6px;}.cls-17{stroke:#a5d1f7;}.cls-18{stroke:#1f8ced;}</style></defs><path class="cls-1" d="M148.23,190.5a5.31,5.31,0,0,1-5.31-5.31,5.31,5.31,0,0,1-5.31,5.31,5.31,5.31,0,0,1,5.31,5.31A5.31,5.31,0,0,1,148.23,190.5Z"/><path class="cls-1" d="M200.83,166.47a5.31,5.31,0,0,1-5.31-5.31,5.31,5.31,0,0,1-5.31,5.31,5.31,5.31,0,0,1,5.31,5.31A5.31,5.31,0,0,1,200.83,166.47Z"/><circle class="cls-2" cx="187.2" cy="213.07" r="1.11"/><circle class="cls-2" cx="199.83" cy="104.53" r="1.11"/><circle class="cls-3" cx="209.32" cy="188.1" r="1.11"/><circle class="cls-4" cx="166.27" cy="88.39" r="24.99" transform="translate(-0.6 175.63) rotate(-55.6)"/><polygon class="cls-5" points="121.26 188.1 161.43 156.45 176.42 107.55 144.73 85.85 104.56 117.51 89.57 166.4 121.26 188.1"/><rect class="cls-6" x="84.18" y="117.77" width="97.63" height="38.41" transform="translate(-55.16 169.32) rotate(-55.6)"/><polyline class="cls-7" points="161.43 156.45 176.42 107.55 144.73 85.85 104.56 117.51 89.57 166.4 121.26 188.1 153.98 162.32"/><path class="cls-8" d="M193,113a21.74,21.74,0,0,1-7-8.62,21.14,21.14,0,0,0-38.37,0,21.74,21.74,0,0,1-7,8.61,16.4,16.4,0,0,0-6.82,14.78,16,16,0,0,0,5,10.32,9.14,9.14,0,0,1,3,6.62h0a8.84,8.84,0,0,0,8.83,8.84l32.3,0a8.84,8.84,0,0,0,8.84-8.83h0a9.14,9.14,0,0,1,3-6.61,16,16,0,0,0,5-10.32A16.4,16.4,0,0,0,193,113Z"/><path class="cls-9" d="M181.81,98.41a21.14,21.14,0,0,0-34.21,6,21.74,21.74,0,0,1-7,8.61,16.4,16.4,0,0,0-6.82,14.78,16,16,0,0,0,5,10.32,9.14,9.14,0,0,1,3,6.62h0a8.84,8.84,0,0,0,8.83,8.84l32.3,0a8.84,8.84,0,0,0,8.84-8.83h0a9.14,9.14,0,0,1,3-6.61,16,16,0,0,0,5-10.32A16.4,16.4,0,0,0,193,113a20.5,20.5,0,0,1-3.61-3.32"/><circle class="cls-10" cx="166.78" cy="113.3" r="6.55"/><path class="cls-9" d="M166.78,106.75a6.55,6.55,0,0,1,0,13.1"/><path class="cls-5" d="M157.75,153.56l0,60.61a6.43,6.43,0,0,1,6.43,6.43h11.57l0-67h-18Z"/><rect class="cls-11" x="157.75" y="153.56" width="18" height="7.6"/><rect class="cls-11" x="164.16" y="153.56" width="5.14" height="67.04"/><rect class="cls-12" x="164.18" y="153.56" width="5.14" height="7.6"/><rect class="cls-13" x="164.16" y="153.56" width="5.14" height="67.04"/><line class="cls-14" x1="164.18" y1="161.16" x2="164.14" y2="220.6"/><path class="cls-9" d="M175.74,180.6l0-27h-18l0,60.61a6.43,6.43,0,0,1,6.43,6.43h11.57V208.51"/><line class="cls-15" x1="175.73" y1="203.51" x2="175.74" y2="185.6"/><path class="cls-4" d="M166.6,113.38a25,25,0,0,0,13.79-45.61"/><path class="cls-16" d="M166.6,113.38a25,25,0,0,0,13.79-45.61"/><path class="cls-16" d="M176.42,65.55a24.82,24.82,0,0,0-7-2"/><rect class="cls-17" x="152.27" y="130.97" width="29" height="8.5"/><line class="cls-18" x1="181.27" y1="130.97" x2="181.27" y2="139.47"/></svg>
+      <h1 class="title">Please log into your Droplet with SSH to configure the WordPress installation.</h1>
+      <div class="content_min">
+        <p class="description">See the WordPress One-Click Quickstart guide for detailed assistance.</p>
+        <a class="button" href="https://do.co/wordpress1804#start">Quickstart Guide</a>
+      </div>
+      <div class="content_min">
+        <p class="description">Problem? Submit a question to our Q&A platform and get help from the community.</p>
+        <a class="button" href="https://www.digitalocean.com/community/questions/new">Ask a Question</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/wordpress-22-04/scripts/010-php.sh
+++ b/wordpress-22-04/scripts/010-php.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+sed -e "s|upload_max_filesize.*|upload_max_filesize = 16M|g" \
+    -e "s|post_max_size.*|post_max_size = 16M|g" \
+    -e "s|max_execution_time.*|max_execution_time = 60|g" \
+    -i /etc/php/8.0/apache2/php.ini

--- a/wordpress-22-04/scripts/011-wordpress.sh
+++ b/wordpress-22-04/scripts/011-wordpress.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Download the WordPress bits and cache them on disk
+wget "https://wordpress.org/wordpress-${application_version}.tar.gz" \
+     -O /tmp/wordpress.tar.gz
+
+# Extract the bits and stage up
+mkdir -p /var/www
+tar -C /var/www \
+    -xvvf /tmp/wordpress.tar.gz
+
+wpfail2ban="wp-fail2ban.${fail2ban_version}.zip"
+wget https://downloads.wordpress.org/plugin/${wpfail2ban} -O /tmp/wp-fail2ban.zip
+unzip /tmp/wp-fail2ban.zip -d /tmp/
+
+# install the fail2ban bits (plugin itself installed in first-login script)
+mkdir -p /etc/fail2ban/filter.d
+cp -auv  /tmp/wp-fail2ban/filters.d/* /etc/fail2ban/filter.d

--- a/wordpress-22-04/scripts/012-apache.sh
+++ b/wordpress-22-04/scripts/012-apache.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+chown -R www-data: /var/log/apache2
+chown -R www-data: /etc/apache2
+chown -R www-data: /var/www
+
+# Enable re-write
+(cd /etc/apache2/mods-enabled/ &&
+ ln -vs ../mods-available/rewrite.load . )

--- a/wordpress-22-04/template.json
+++ b/wordpress-22-04/template.json
@@ -1,0 +1,90 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "wordpress-22-04-snapshot-{{timestamp}}",
+    "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python3-certbot-apache software-properties-common unzip",
+    "application_name": "WordPress",
+    "application_version": "6.1.1",
+    "fail2ban_version": "4.4.0.9"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-22-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-22-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-22-04/files/root/",
+      "destination": "/root/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-22-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "add-apt-repository -y ppa:ondrej/php",
+        "wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb",
+        "dpkg -i mysql-apt-config_0.8.22-1_all.deb",
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "fail2ban_version={{user `fail2ban_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "wordpress-22-04/scripts/010-php.sh",
+        "wordpress-22-04/scripts/011-wordpress.sh",
+        "wordpress-22-04/scripts/012-apache.sh",
+        "common/scripts/014-ufw-apache.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Updated WordPress to run on Ubuntu 22.04

WordPress updated from 6.0 to 6.1.1
Fail2Ban from 4.4.0.4 to 4.4.0.9

![image](https://user-images.githubusercontent.com/94634250/215489376-89610979-eb3d-4971-8148-8de2a84e08f2.png)

![image](https://user-images.githubusercontent.com/94634250/215489767-5e801f43-60ec-44c4-aa81-a396a01db17a.png)

![image](https://user-images.githubusercontent.com/94634250/215489797-5a2e7073-54b8-4266-9882-095cf0eaea4f.png)

