### PR TITLE
Phpmyadmin Config Fix and Update

### DIFF
--- a/phpmyadmin-22-04/scripts/010-php-my-admin.sh
+++ b/phpmyadmin-22-04/scripts/010-php-my-admin.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Own the bits
+chown -R www-data: /var/log/apache2
+chown -R www-data: /etc/apache2
+chown -R www-data: /var/www
+
+# Manually update phpmyadmin to latest version
+wget -O /tmp/phpmyadmin.tar.gz "https://files.phpmyadmin.net/phpMyAdmin/${phpmyadmin_version}/phpMyAdmin-${phpmyadmin_version}-all-languages.tar.gz"
+mv /usr/share/phpmyadmin /usr/share/phpmyadmin.bak
+mkdir /usr/share/phpmyadmin
+
+tar xzf /tmp/phpmyadmin.tar.gz -C /tmp
+mv /tmp/phpMyAdmin-${phpmyadmin_version}-all-languages/* /usr/share/phpmyadmin
+
+# Use sample config as main config
+cp /usr/share/phpmyadmin/config.sample.inc.php /usr/share/phpmyadmin/config.inc.php
+# Substitute password placeholder with an actual generated password
+sed -i "s+\$cfg\['blowfish_secret'\] = ''; \/\* YOU MUST FILL IN THIS FOR COOKIE AUTH! \*\/+$(echo "\$cfg['blowfish_secret'] = '$(openssl rand -base64 22)';")+g" /usr/share/phpmyadmin/config.inc.php
+
+chmod -Rf 755 /usr/share/phpmyadmin
+
+# Remove auto.cnf so a unique UUID is generated at first boot
+rm -f /var/lib/mysql/auto.cnf

--- a/phpmyadmin-22-04/template.json
+++ b/phpmyadmin-22-04/template.json
@@ -5,7 +5,7 @@
     "image_name": "phpmyadmin-22-04-snapshot-{{timestamp}}",
     "apt_packages": "apache2 apache2-utils mysql-server php php-gd php-mysql phpmyadmin python3-certbot-apache libapache2-mod-php lamp-server^",
     "application_name": "phpMyAdmin",
-    "application_version": "5.2.0"
+    "application_version": "5.2.1"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -68,7 +68,7 @@
         "LC_CTYPE=en_US.UTF-8"
       ],
       "scripts": [
-        "mysql-20-04/scripts/010-php-my-admin.sh",
+        "phpmyadmin-22-04/scripts/010-php-my-admin.sh",
         "common/scripts/014-ufw-apache.sh",
         "common/scripts/014-ufw-mysql.sh",
         "common/scripts/018-force-ssh-logout.sh",


### PR DESCRIPTION
- Update phpMyAdmin 5.2.0 -> 5.2.1
- Created copy of phpMyAdmin setup scripts to separate `phpMyAdmin` from phpMyAdmin Droplet from `phpMyAdmin` from MySQL droplet
- As for now, phpMyAdmin droplet ships no configuration file at all. Decided to use sample configuration as main 
- Added blowfish secret generation


Before:
![image](https://user-images.githubusercontent.com/94634250/220900877-cf5af655-d67b-45d7-8bd8-14199d590721.png)

After:
![image](https://user-images.githubusercontent.com/94634250/220904297-1adae70c-42dc-49cb-b531-64e0b3d9e020.png)

Tested on remote DB. Works just fine!
![image](https://user-images.githubusercontent.com/94634250/220907583-9b464b0e-cf11-418b-ab9c-06f6a010a48e.png)
![image](https://user-images.githubusercontent.com/94634250/220907660-0ccffd80-87e4-4fbf-abfd-705cc72150c1.png)

