### PR TITLE
Added sql privileges needed for SnapShooter

### DIFF
--- a/wordpress-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/wordpress-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -51,6 +51,9 @@ mysql -uroot -p${root_mysql_pass} \
       -e "GRANT ALL PRIVILEGES ON wordpress.* TO wordpress@localhost"
 
 mysql -uroot -p${root_mysql_pass} \
+      -e "GRANT RELOAD,PROCESS ON *.* TO wordpress@localhost"
+
+mysql -uroot -p${root_mysql_pass} \
       -e "ALTER USER 'debian-sys-maint'@'localhost' IDENTIFIED BY '${debian_sys_maint_mysql_pass}'"
 
 MYSQL_ROOT_PASSWORD=${wordpress_mysql_pass}


### PR DESCRIPTION
SnapShooter fails to run a backup for MySQL in WordPress droplet.

Apparently, a recent MySQL update introduced problems with the backup process:
https://github.com/mysql/mysql-server/commit/022e73ba6976b984658a1c2652178cd4b81aec28

This PR fixes the issue by providing `wordpress` MySQL user necessary privileges.

PR was tested, and both WordPress and SnapShooter work fine!

Tagging: @mrsimonbennett