### PR TITLE
feat: update dokku to latest released version

### DIFF
--- a/dokku-20-04/template.json
+++ b/dokku-20-04/template.json
@@ -5,7 +5,7 @@
     "image_name": "dokku-20-04-snapshot-{{timestamp}}",
     "apt_packages": "apt-transport-https nginx python3 python3-apt python3-pycurl software-properties-common",
     "application_name": "Dokku",
-    "application_version": "0.30.5",
+    "application_version": "0.30.6",
     "docker_compose_version": "2.18.1"
   },
   "sensitive-variables": ["do_api_token"],

--- a/dokku-20-04/template.json
+++ b/dokku-20-04/template.json
@@ -5,8 +5,8 @@
     "image_name": "dokku-20-04-snapshot-{{timestamp}}",
     "apt_packages": "apt-transport-https nginx python3 python3-apt python3-pycurl software-properties-common",
     "application_name": "Dokku",
-    "application_version": "0.21.4",
-    "docker_compose_version": "1.27.4"
+    "application_version": "0.30.5",
+    "docker_compose_version": "2.18.1"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [


### PR DESCRIPTION
While the Dokku project has started building it's own images[1], until those get promoted to own the Dokku namespace, updating the image upstream is the next best bet.

Note that the current version is _years_ old and has been causing support issues upstream.

[1] https://github.com/dokku/dokku/actions/runs/5087653752/jobs/9143563652