### PR TITLE
Dokku Droplet 1-Click Update

### DIFF
--- a/dokku-22-04/files/etc/update-motd.d/99-one-click
+++ b/dokku-22-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's 1-Click Dokku Droplet.
+To keep this Droplet secure, the UFW firewall is enabled.
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), 443 (HTTPS),
+2375 (Docker) and 2376 (Docker).
+
+In a web browser, you can view:
+ * The Dokku 1-Click Quickstart guide: https://do.co/3nzKhrp#start
+ * Your Dokku setup page: http://$myip
+
+For help and more information, visit https://do.co/3nzKhrp
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/dokku-22-04/scripts/010-dokku.sh
+++ b/dokku-22-04/scripts/010-dokku.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+wget "https://raw.githubusercontent.com/dokku/dokku/v${dokku_version}/bootstrap.sh"
+DOKKU_TAG="v${dokku_version}" bash bootstrap.sh

--- a/dokku-22-04/template.json
+++ b/dokku-22-04/template.json
@@ -34,7 +34,7 @@
     },
     {
       "type": "file",
-      "source": "dokku-20-04/files/etc/",
+      "source": "dokku-22-04/files/etc/",
       "destination": "/etc/"
     },
     {
@@ -67,7 +67,7 @@
       "scripts": [
         "common/scripts/010-docker.sh",
         "common/scripts/011-docker-compose.sh",
-        "dokku-20-04/scripts/010-dokku.sh",
+        "dokku-22-04/scripts/010-dokku.sh",
         "common/scripts/012-grub-opts.sh",
         "common/scripts/013-docker-dns.sh",
         "common/scripts/014-ufw-docker.sh",

--- a/dokku-22-04/template.json
+++ b/dokku-22-04/template.json
@@ -1,0 +1,80 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "dokku-20-04-snapshot-{{timestamp}}",
+    "apt_packages": "apt-transport-https nginx python3 python3-apt python3-pycurl software-properties-common",
+    "application_name": "Dokku",
+    "application_version": "0.30.6",
+    "docker_compose_version": "2.18.1"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-22-04-x64",
+      "region": "sfo3",
+      "size": "s-1vcpu-512mb-10gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "dokku-20-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "dokku_version={{user `application_version`}}",
+        "docker_compose_version={{user `docker_compose_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "common/scripts/010-docker.sh",
+        "common/scripts/011-docker-compose.sh",
+        "dokku-20-04/scripts/010-dokku.sh",
+        "common/scripts/012-grub-opts.sh",
+        "common/scripts/013-docker-dns.sh",
+        "common/scripts/014-ufw-docker.sh",
+        "common/scripts/014-ufw-nginx.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}

--- a/dokku-22-04/template.json
+++ b/dokku-22-04/template.json
@@ -2,7 +2,7 @@
 {
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
-    "image_name": "dokku-20-04-snapshot-{{timestamp}}",
+    "image_name": "dokku-22-04-snapshot-{{timestamp}}",
     "apt_packages": "apt-transport-https nginx python3 python3-apt python3-pycurl software-properties-common",
     "application_name": "Dokku",
     "application_version": "0.30.6",


### PR DESCRIPTION
- Updated Dokku OS Ubuntu 20.04 -> 22.04
- Updated Dokku app version  0.21.4 -> 0.30.6
- Updated Docker-Compose version 1.27.4 -> 2.18.1

Tested successfully :
![image](https://github.com/digitalocean/droplet-1-clicks/assets/94634250/ceeca0de-09cc-4501-b86c-628f53c42d75)
