### PR TITLE
Fix the supabase 1-click application

### DIFF
--- a/supabase-22-04/files/etc/nginx/sites-available/supabase
+++ b/supabase-22-04/files/etc/nginx/sites-available/supabase
@@ -2,9 +2,6 @@ map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
 }
-upstream supabase {
-        server localhost:3000;
-}
 upstream kong {
         server localhost:8000;
 }
@@ -47,7 +44,7 @@ server {
     # Studio
         location / {
         proxy_set_header Host $host;
-            proxy_pass http://supabase;
+            proxy_pass http://kong;
             proxy_redirect off;
             proxy_set_header Upgrade $http_upgrade;
         }

--- a/supabase-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/supabase-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -6,7 +6,14 @@
 
 # Install latest updates on first boot
 cd /srv/supabase/supabase/docker
-git pull
+
+#git pull  ### it was broken two times because of updates, so this process should be manual
+
+export SUPABASE_PASSWORD=`openssl rand -base64 12`
+cat >> /srv/supabase/supabase/docker/.env <<EOM
+DASHBOARD_USERNAME=supabase
+DASHBOARD_PASSWORD=${SUPABASE_PASSWORD}
+EOM
 
 docker compose up -d
 

--- a/supabase-22-04/files/var/supabase/supabase_ssl
+++ b/supabase-22-04/files/var/supabase/supabase_ssl
@@ -2,9 +2,6 @@ map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
 }
-upstream supabase {
-  	server localhost:3000;
-}
 upstream kong {
   	server localhost:8000;
 }
@@ -70,7 +67,7 @@ server {
     # Studio
 	location / {
     	proxy_set_header Host $host;
-	    proxy_pass http://supabase;
+	    proxy_pass http://kong;
 	    proxy_redirect off;
 	    proxy_set_header Upgrade $http_upgrade;
   	}

--- a/supabase-22-04/scripts/011-supabase.sh
+++ b/supabase-22-04/scripts/011-supabase.sh
@@ -23,4 +23,3 @@ chmod +x /var/supabase/supabase-setup.sh
 cat >> /root/.bashrc <<EOM
 /var/supabase/supabase-setup.sh
 EOM
-


### PR DESCRIPTION
New supabase repo update broke our supabase app (https://github.com/supabase/supabase/commit/e974bcc02876b1706f31d37e28f41b6f3f22989e#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L26). Also we had found other problem with supabase korn, it was failing cause of missed credentials in the configs (https://github.com/supabase/supabase/commit/b3114508d0043fa92b01068d9a0848b7e2115732).

This PR fixes both problems and turns off auto update for supabase docker compose files