### PR TITLE
Add clickhouse app

### DIFF
--- a/clickhouse-22-04/files/etc/clickhouse-server/users.d/default-password.xml
+++ b/clickhouse-22-04/files/etc/clickhouse-server/users.d/default-password.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+    <users>
+        <default>
+            <password remove='1' />
+            <password_sha256_hex>146b66a93255426bc108302e479d57f2f3df30f59d86dfd1236e7411633a8993</password_sha256_hex>
+        </default>
+    </users>
+</clickhouse>

--- a/clickhouse-22-04/files/etc/clickhouse-server/users.d/default-password.xml
+++ b/clickhouse-22-04/files/etc/clickhouse-server/users.d/default-password.xml
@@ -2,7 +2,7 @@
     <users>
         <default>
             <password remove='1' />
-            <password_sha256_hex>146b66a93255426bc108302e479d57f2f3df30f59d86dfd1236e7411633a8993</password_sha256_hex>
+            <password_sha256_hex>INCORRECT</password_sha256_hex>
         </default>
     </users>
 </clickhouse>

--- a/clickhouse-22-04/files/opt/digitalocean_clickhouse/setup_password.sh
+++ b/clickhouse-22-04/files/opt/digitalocean_clickhouse/setup_password.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+PASSWORD=$(base64 < /dev/urandom | head -c8)
+HASHED=$(echo -n "$PASSWORD" | sha256sum | tr -d '-')
+HASHED=$(echo -n "$HASHED" | xargs)
+
+echo "ClickHouse is now installed and configure. Enjoy it!"
+echo ""
+echo "----------------------------------------------------------------------------"
+echo "Your default password is \"$PASSWORD\". To update it you can run:"
+echo "PASSWORD=\$(base64 < /dev/urandom | head -c8); echo \"\$PASSWORD\"; echo -n \"\$PASSWORD\" | sha256sum | tr -d '-'"
+echo "First line is the new password, second is hashed password."
+echo "Update section 'password_sha256_hex' value with generated in the file '/etc/clickhouse-server/users.d/default-password.xml'"
+echo "----------------------------------------------------------------------------"
+
+cp -f /etc/skel/.bashrc /root/.bashrc
+
+sed -e "s/<password_sha256_hex>.*<\/password_sha256_hex>/<password_sha256_hex>${HASHED}<\/password_sha256_hex>/" \
+    -i /etc/clickhouse-server/users.d/default-password.xml
+
+sudo service clickhouse-server start

--- a/clickhouse-22-04/files/opt/digitalocean_clickhouse/setup_password.sh
+++ b/clickhouse-22-04/files/opt/digitalocean_clickhouse/setup_password.sh
@@ -9,8 +9,8 @@ echo ""
 echo "----------------------------------------------------------------------------"
 echo "Your default password is \"$PASSWORD\". To update it you can run:"
 echo "PASSWORD=\$(base64 < /dev/urandom | head -c8); echo \"\$PASSWORD\"; echo -n \"\$PASSWORD\" | sha256sum | tr -d '-'"
-echo "First line is the new password, second is hashed password."
-echo "Update section 'password_sha256_hex' value with generated in the file '/etc/clickhouse-server/users.d/default-password.xml'"
+echo "First line is the new password, second is the hashed password can be used in clickhouse conf file."
+echo "Update section 'password_sha256_hex' value with generated hash in the file '/etc/clickhouse-server/users.d/default-password.xml'"
 echo "----------------------------------------------------------------------------"
 
 cp -f /etc/skel/.bashrc /root/.bashrc

--- a/clickhouse-22-04/scripts/010-clickhouse.sh
+++ b/clickhouse-22-04/scripts/010-clickhouse.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Scripts in this directory are run during the build process.
+# each script will be uploaded to /tmp on your build droplet, 
+# given execute permissions and run.  The cleanup process will
+# remove the scripts from your build system after they have run
+# if you use the build_image task.
+#
+
+# Add first-login task
+cat >> /root/.bashrc <<EOM
+/opt/digitalocean_clickhouse/setup_password.sh
+EOM
+

--- a/clickhouse-22-04/scripts/010-clickhouse.sh
+++ b/clickhouse-22-04/scripts/010-clickhouse.sh
@@ -11,4 +11,3 @@
 cat >> /root/.bashrc <<EOM
 /opt/digitalocean_clickhouse/setup_password.sh
 EOM
-

--- a/clickhouse-22-04/template.json
+++ b/clickhouse-22-04/template.json
@@ -56,7 +56,7 @@
         "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754",
         "echo 'deb https://packages.clickhouse.com/deb stable main' | sudo tee /etc/apt/sources.list.d/clickhouse.list",
         "apt-get -qqy update",
-        "echo 'update' | apt-get install -qqy clickhouse-server clickhouse-client",
+        "apt-get install -qqy clickhouse-server clickhouse-client",
         "apt-get -qqy clean"
       ]
     },

--- a/clickhouse-22-04/template.json
+++ b/clickhouse-22-04/template.json
@@ -1,4 +1,3 @@
-
 {
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",

--- a/clickhouse-22-04/template.json
+++ b/clickhouse-22-04/template.json
@@ -1,0 +1,81 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "clickhouse-22-04-snapshot-{{timestamp}}",
+    "apt_packages": "apt-transport-https ca-certificates dirmngr",
+    "application_name": "ClickHouse",
+    "application_version": "10.6.12"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-22-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "clickhouse-22-04/files/opt/",
+      "destination": "/opt/"
+    },
+    {
+      "type": "file",
+      "source": "clickhouse-22-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 8919F6BD2B48D754",
+        "echo 'deb https://packages.clickhouse.com/deb stable main' | sudo tee /etc/apt/sources.list.d/clickhouse.list",
+        "apt-get -qqy update",
+        "echo 'update' | apt-get install -qqy clickhouse-server clickhouse-client",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "clickhouse-22-04/scripts/010-clickhouse.sh",
+        "common/scripts/014-ufw-http.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the new 1click application packer files - Clickhouse. It's fully functional.

Note: server is started after `setup_password.sh`'s generated the new password for the current droplet