### PR TITLE
Add $4 droplet support for django and flask

### DIFF
--- a/django-22-04/template.json
+++ b/django-22-04/template.json
@@ -5,7 +5,7 @@
     "image_name": "django-22-04-snapshot-{{timestamp}}",
     "apt_packages": "gunicorn nginx postfix postgresql python3 python3-certbot python3-certbot-nginx python3-dev python3-gevent python3-gunicorn python3-netifaces python3-pip python3-psycopg2 python3-setuptools python3-venv super",
     "application_name": "Django",
-    "django_version": "4.1.1"
+    "django_version": "5.0"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -14,7 +14,7 @@
       "api_token": "{{user `do_api_token`}}",
       "image": "ubuntu-22-04-x64",
       "region": "sfo3",
-      "size": "s-1vcpu-1gb",
+      "size": "s-1vcpu-512mb-10gb",
       "ssh_username": "root",
       "snapshot_name": "{{user `image_name`}}"
     }

--- a/flask-22-04/template.json
+++ b/flask-22-04/template.json
@@ -4,7 +4,7 @@
     "image_name": "flask-22-04-snapshot-{{timestamp}}",
     "apt_packages": "gunicorn nginx postfix python3 python3-certbot python3-certbot-nginx python3-dev python3-gunicorn python3-netifaces python3-pip python3-setuptools python3-venv python3-gevent",
     "application_name": "Flask",
-    "flask_version": "2.2.3"
+    "flask_version": "3.0.0"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -12,8 +12,8 @@
       "type": "digitalocean",
       "api_token": "{{user `do_api_token`}}",
       "image": "ubuntu-22-04-x64",
-      "region": "nyc3",
-      "size": "s-1vcpu-1gb",
+      "region": "sfo3",
+      "size": "s-1vcpu-512mb-10gb",
       "ssh_username": "root",
       "snapshot_name": "{{user `image_name`}}"
     }


### PR DESCRIPTION
This PR updates packer scripts for Django and Flask to support $4 droplets. Also both applications are updated to the latest versions