### PR TITLE
Add RDP server to Ubuntu Desktop

### DIFF
--- a/ubuntu-desktop-22-04/scripts/010-ubuntu-desktop.sh
+++ b/ubuntu-desktop-22-04/scripts/010-ubuntu-desktop.sh
@@ -9,6 +9,8 @@
 
 # open default VNC port
 ufw allow 5900
+# open default RDP port
+ufw allow 3389
 # Add first-login task
 cat >> /root/.bashrc <<EOM
 /opt/digitalocean_desktop/setup_vnc.sh

--- a/ubuntu-desktop-22-04/template.json
+++ b/ubuntu-desktop-22-04/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "ubuntu-desktop-22-04-snapshot-{{timestamp}}",
-    "apt_packages": "x11vnc sddm",
+    "apt_packages": "x11vnc sddm xrdp",
     "application_name": "UbuntuDesktop",
     "application_version": "1.524"
   },


### PR DESCRIPTION
This PR updates Ubuntu Desktop application with RDP server. So windows users will be able to use our application without additional installations