### PR TITLE
Added "sudo" to the MOTD

### DIFF
--- a/jitsi-22-04/files/etc/update-motd.d/99-one-click
+++ b/jitsi-22-04/files/etc/update-motd.d/99-one-click
@@ -12,7 +12,7 @@ https://github.com/digitalocean/droplet-1-clicks/tree/master/jitsi-22-04
 I you want to use this image, you agree to the Apache License.
 See https://github.com/jitsi/jitsi/blob/master/LICENSE.
 
-Type 'bash /var/complete-jitsi-setup.sh' to complete Jitsi setup if and only if you
+Type 'sudo bash /var/complete-jitsi-setup.sh' to complete Jitsi setup if and only if you
 agree to the Jitsi License.
 
 ********************************************************************************


### PR DESCRIPTION
Added "sudo" to the beginning of the MOTD instructions for initial setup on first connect for Jitsi / Digital Ocean 1-Click.

I think this is the fix to Issue 165 https://github.com/digitalocean/droplet-1-clicks/issues/165 but I'm not sure.