### PR TITLE
NodeJS: use updated install source for setup

### DIFF
--- a/common/scripts/010-nodejs.sh
+++ b/common/scripts/010-nodejs.sh
@@ -5,21 +5,16 @@
 ##
 ## vi: syntax=sh expandtab ts=4
 
-curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
 
 # Replace with the branch of Node.js or io.js you want to install: node_6.x, node_8.x, etc...
 VERSION=${NODE_VERSION}
-# The below command will set this correctly, but if lsb_release isn't available, you can set it manually:
-# - For Debian distributions: jessie, sid, etc...
-# - For Ubuntu distributions: xenial, bionic, etc...
-# - For Debian or Ubuntu derived distributions your best option is to use the codename corresponding to the upstream release your distribution is based off. This is an advanced scenario and unsupported if your distribution is not listed as supported per earlier in this README.
-DISTRO="$(lsb_release -s -c)"
-echo "deb https://deb.nodesource.com/$VERSION $DISTRO main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-echo "deb-src https://deb.nodesource.com/$VERSION $DISTRO main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list
+
+curl -fsSL "https://deb.nodesource.com/setup_$VERSION" -o nodesource_setup.sh
+sudo -E bash nodesource_setup.sh
 
 # Yarn
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 
-apt-get -qqy update
-apt-get -qqy install nodejs yarn
+sudo apt-get -qqy update
+sudo apt-get -qqy install nodejs yarn

--- a/nodejs-20-04/template.json
+++ b/nodejs-20-04/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "nodejs-20-04-snapshot-{{timestamp}}",
-    "node_version": "node_18.x",
+    "node_version": "lts.x",
     "apt_packages": "nginx",
     "application_name": "Node.js"
   },


### PR DESCRIPTION
Nodesource has moved from an apt source per distro/version to a setup script per version. Use the new method to install the latest stable version of NodeJS.