### PR TITLE
fetch latest version for docker-compose

### DIFF
--- a/common/scripts/011-docker-compose.sh
+++ b/common/scripts/011-docker-compose.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
 mkdir -p ~/.docker/cli-plugins/;
+if [ -z "${docker_compose_version}" ]; then
+  docker_compose_version=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | jq -r '.tag_name');
+fi
 curl -SL https://github.com/docker/compose/releases/download/${docker_compose_version}/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose;
 chmod +x ~/.docker/cli-plugins/docker-compose;

--- a/docker-22-04/template.json
+++ b/docker-22-04/template.json
@@ -5,7 +5,7 @@
     "apt_packages": "apt-transport-https ca-certificates curl jq linux-image-extra-virtual software-properties-common ",
     "application_name": "Docker",
     "application_version": "23.0.6",
-    "docker_compose_version": "v2.17.2"
+    "docker_compose_version": ""
   },
   "sensitive-variables": [
     "do_api_token"


### PR DESCRIPTION
If no docker compose version is provided, fetch the latest version. Also removes the version from the docker-22-04 template to allow autoupdate compatibility.