### PR TITLE
MP-7535 : LEMP Marketplace image creates with wrong OS

### DIFF
--- a/lemp-24-04/template.json
+++ b/lemp-24-04/template.json
@@ -33,12 +33,12 @@
     },
     {
       "type": "file",
-      "source": "lemp-22-04/files/etc/",
+      "source": "lemp-24-04/files/etc/",
       "destination": "/etc/"
     },
     {
       "type": "file",
-      "source": "lemp-22-04/files/var/",
+      "source": "lemp-24-04/files/var/",
       "destination": "/var/"
     },
     {
@@ -69,7 +69,7 @@
         "LC_CTYPE=en_US.UTF-8"
       ],
       "scripts": [
-        "lemp-22-04/scripts/011-lemp.sh",
+        "lemp-24-04/scripts/011-lemp.sh",
         "common/scripts/014-ufw-nginx.sh",
         "common/scripts/018-force-ssh-logout.sh",
         "common/scripts/020-application-tag.sh",


### PR DESCRIPTION
Updated the paths in the template to use the correct file path

<img width="725" alt="Screenshot 2025-03-26 at 9 53 38 PM" src="https://github.com/user-attachments/assets/aa887ea6-0b7f-4ad4-85a9-7164857499cb" />

