### PR TITLE
Fix wordpress install in AMS3 region

### DIFF
--- a/wordpress-22-04/files/root/wp_setup.sh
+++ b/wordpress-22-04/files/root/wp_setup.sh
@@ -141,8 +141,12 @@ chmod +x /usr/bin/wp
 
 echo -en "Completing the configuration of WordPress."
 wp core install --allow-root --path="/var/www/html" --title="$title" --url="$dom" --admin_email="$email"  --admin_password="$pass" --admin_user="$username"
-
+#looks like ams3 region is a little slow and wp-cli times out, so we will add the timeout
+sleep 1
+echo -en "Installing fail2ban plugin."
 wp plugin install wp-fail2ban --allow-root --path="/var/www/html"
+sleep 1
+echo -en "Activating fail2ban plugin."
 wp plugin activate wp-fail2ban --allow-root --path="/var/www/html"
 chown -Rf www-data.www-data /var/www/
 cp /etc/skel/.bashrc /root


### PR DESCRIPTION
Our customers found that wordpress installation faults in AMS3 region. After successful reproduction our team started investigation why it's happening. Resolution was very strange - some of the wp processes run in background and install scripts should wait to avoid the problem. Probably, AMS3 is slow and it causes problems.
This PR adds sleeps in necessary places. Solution was tested