### PR TITLE
Update wordpress and PHP

### DIFF
--- a/wordpress-22-04/scripts/010-php.sh
+++ b/wordpress-22-04/scripts/010-php.sh
@@ -3,4 +3,4 @@
 sed -e "s|upload_max_filesize.*|upload_max_filesize = 16M|g" \
     -e "s|post_max_size.*|post_max_size = 16M|g" \
     -e "s|max_execution_time.*|max_execution_time = 60|g" \
-    -i /etc/php/8.0/apache2/php.ini
+    -i /etc/php/8.3/apache2/php.ini

--- a/wordpress-22-04/scripts/011-wordpress.sh
+++ b/wordpress-22-04/scripts/011-wordpress.sh
@@ -9,6 +9,10 @@ mkdir -p /var/www
 tar -C /var/www \
     -xvvf /tmp/wordpress.tar.gz
 
+# Update WordPress core to the latest version
+cd /var/www/wordpress
+wp core update
+
 wpfail2ban="wp-fail2ban.${fail2ban_version}.zip"
 wget https://downloads.wordpress.org/plugin/${wpfail2ban} -O /tmp/wp-fail2ban.zip
 unzip /tmp/wp-fail2ban.zip -d /tmp/

--- a/wordpress-22-04/template.json
+++ b/wordpress-22-04/template.json
@@ -3,9 +3,9 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "wordpress-22-04-snapshot-{{timestamp}}",
-    "apt_packages": "apache2 fail2ban libapache2-mod-php8.0 mysql-server php8.0 php8.0-apcu php8.0-bz2 php8.0-curl php8.0-gd php8.0-gmp php8.0-intl php8.0-mbstring php8.0-mysql php8.0-pspell php8.0-soap php8.0-tidy php8.0-xml php8.0-xmlrpc php8.0-xsl php8.0-zip postfix python3-certbot-apache software-properties-common unzip",
+    "apt_packages": "apache2 fail2ban libapache2-mod-php8.3 mysql-server php8.3 php8.3-apcu php8.3-bz2 php8.3-curl php8.3-gd php8.3-gmp php8.3-intl php8.3-mbstring php8.3-mysql php8.3-pspell php8.3-soap php8.3-tidy php8.3-xml php8.3-xmlrpc php8.3-xsl php8.3-zip postfix python3-certbot-apache software-properties-common unzip",
     "application_name": "WordPress",
-    "application_version": "6.4.1",
+    "application_version": "6.8.1",
     "fail2ban_version": "5.2.1"
   },
   "sensitive-variables": ["do_api_token"],


### PR DESCRIPTION
Makes the following updates to the 1-click:

- WP 6.8.1
- Auto update WP on install
- Update PHP to 8.3