### PR TITLE
MP-7909 : Fix for Issue with PhpMyAdmin MarketPlace Image

### DIFF
--- a/phpmyadmin-24-04/scripts/010-php-my-admin.sh
+++ b/phpmyadmin-24-04/scripts/010-php-my-admin.sh
@@ -6,9 +6,14 @@ chown -R www-data: /etc/apache2
 chown -R www-data: /var/www
 
 # Manually update phpmyadmin to latest version
-wget -O /tmp/phpmyadmin.tar.gz "https://www.phpmyadmin.net/downloads/phpMyAdmin-latest-all-languages.tar.gz"
-mv /usr/share/phpmyadmin /usr/share/phpmyadmin.bak
-mkdir /usr/share/phpmyadmin
+wget https://www.phpmyadmin.net/downloads/phpMyAdmin-latest-all-languages.tar.gz
+tar xvf phpMyAdmin-latest-all-languages.tar.gz
+sudo mkdir -p /usr/share/phpmyadmin
+sudo mv phpMyAdmin-*-all-languages/* /usr/share/phpmyadmin/
+
+# Set up Apache/Nginx alias (Apache example)
+echo 'Include /etc/phpmyadmin/apache.conf' | sudo tee /etc/apache2/conf-enabled/phpmyadmin.conf
+sudo systemctl reload apache2
 
 tar xzf /tmp/phpmyadmin.tar.gz -C /tmp
 mv /tmp/phpMyAdmin-${phpmyadmin_version}-all-languages/* /usr/share/phpmyadmin


### PR DESCRIPTION
Issue : 
When creating a droplet from this image and accessing `http://<IP>/phpmyadmin`, the page throws a `Forbidden` error. Upon checking inside the droplet, the phpmyadmin package was present but not correctly installed (missing core files). The issue is resolved by reinstalling the package

RCA : 
Looks like during the upgrade to `Ubuntu 24.04`, the phpmyadmin package did not upgrade cleanly — its configuration remained, but its core application files were removed or not copied over due to package restructuring/dependency changes.

This left Apache/Nginx with a phpMyAdmin alias pointing to a path that no longer contained the required files, which resulted in a `403 Forbidden error`.

Reinstalling phpmyadmin restored the missing files and re-linked the configuration properly

Fix : 

- Change in copying the files
- `reload apache2` post copy

