### PR TITLE
Modernize Valkey 1-click

### DIFF
--- a/valkey-22-04/files/etc/update-motd.d/99-one-click
+++ b/valkey-22-04/files/etc/update-motd.d/99-one-click
@@ -10,21 +10,28 @@ Welcome to the DigitalOcean Valkey 1-Click Application
 
 Valkey is a high-performance data structure server that primarily serves key/value 
 workloads. It supports a wide range of native structures and an extensible plugin 
-system for adding new data structures and access patterns.ion.
+system for adding new data structures and access patterns.
 
-All Valkey scripts and files may be found in /srv/valkey and the setup
-utility can be run again by executing 'make install' in that directory.
+Valkey is running as a systemd service and can be managed with:
+ - systemctl start valkey
+ - systemctl stop valkey
+ - systemctl restart valkey
+ - systemctl status valkey
+
+Configuration file: /etc/valkey/valkey.conf
+Log file: /var/log/valkey/valkey.log
+Data directory: /var/lib/valkey
 
 To keep this Droplet secure, the UFW firewall is enabled.
 All ports are BLOCKED except:
  - 22 (SSH)
  - 6379
 
-A strong password has been set for your Valkey instance, and can be found in the file 
+A strong password has been set for your Valkey instance, and can be found in the file:
 /root/.digitalocean_passwords
 
-Valkey is bound to the droplet IP address and localhost.  To change this, edit the 
-configuration here /srv/valkey/6379.conf
+Valkey is bound to localhost by default for security. To change this, edit the 
+configuration file at /etc/valkey/valkey.conf and restart the service.
 
 For help and more information, visit https://marketplace.digitalocean.com/apps/valkey
 

--- a/valkey-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/valkey-22-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,22 +1,29 @@
 #!/bin/sh
 
-# Generate root passwords.
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh
+
+# Generate root password for Valkey
 admin_valkey_pass=$(openssl rand -hex 32)
 
-# Generate some passwords
+# Generate password file
 cat > /root/.digitalocean_passwords << EOM
-admin_valkey_password="${admin_valkey_pass}"
+valkey_password="${admin_valkey_pass}"
 EOM
 
-source /root/.digitalocean_passwords
+chmod 600 /root/.digitalocean_passwords
 
-# Use sed to update redis.conf password_required
-echo "requirepass ${admin_valkey_pass}" >> /srv/valkey/6379.conf
+# Update valkey configuration with the generated password
+sed -i "s/requirepass .*/requirepass ${admin_valkey_pass}/" /etc/valkey/valkey.conf
 
-# bind valkey to the droplet IP
+# Get droplet IP and add binding (optional - for external access)
 droplet_ip=$(hostname -I | awk '{print$1}') 
-echo "bind ${droplet_ip}" >> /srv/valkey/6379.conf
+# Uncomment the next line if you want to bind to droplet IP for external access
+# sed -i "s/bind 127.0.0.1/bind 127.0.0.1 ${droplet_ip}/" /etc/valkey/valkey.conf
 
-# restart valkey
-/etc/init.d/redis_6379 stop
-/etc/init.d/redis_6379 start
+# Restart valkey service
+systemctl restart valkey


### PR DESCRIPTION
The old builder stopped working, and Valkey has matured quite a bit since we created it.  This uses the same basic strategy, but is modernized to be more secure, and use systemd.

• Modernized systemd service management: Replaced legacy install_server.sh script with manual systemd service configuration for better compatibility with modern Ubuntu versions

• Updated configuration paths and structure: Changed from /srv/valkey/6379.conf to standard /etc/valkey/valkey.conf location following Linux filesystem hierarchy standards

• Fixed service management commands: Updated onboot script to use systemctl restart valkey instead of legacy /etc/init.d/redis_6379 commands

• Enhanced MOTD documentation: Updated message of the day to reflect new systemd service management commands and proper configuration file paths