### PR TITLE
Fix Jitsi Prosody repo apt key handling

### DIFF
--- a/jitsi-22-04/scripts/01-packages.sh
+++ b/jitsi-22-04/scripts/01-packages.sh
@@ -19,7 +19,7 @@ sudo apt-add-repository universe
 sudo apt update
 
 # Add the Prosody package repository
-sudo curl -sL https://prosody.im/files/prosody-debian-packages.key -o /etc/apt/keyrings/prosody-debian-packages.key
+curl -sL https://prosody.im/files/prosody-debian-packages.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/prosody-debian-packages.key
 echo "deb [signed-by=/etc/apt/keyrings/prosody-debian-packages.key] http://packages.prosody.im/debian $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/prosody-debian-packages.list
 sudo apt install lua5.2
 

--- a/jitsi-24-04/scripts/01-packages.sh
+++ b/jitsi-24-04/scripts/01-packages.sh
@@ -19,7 +19,7 @@ sudo apt-add-repository universe
 sudo apt update
 
 # Add the Prosody package repository
-sudo curl -sL https://prosody.im/files/prosody-debian-packages.key -o /etc/apt/keyrings/prosody-debian-packages.key
+curl -sL https://prosody.im/files/prosody-debian-packages.key | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/prosody-debian-packages.key
 echo "deb [signed-by=/etc/apt/keyrings/prosody-debian-packages.key] http://packages.prosody.im/debian $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/prosody-debian-packages.list
 sudo apt install lua5.2
 


### PR DESCRIPTION
Apt 2.4+ rejects signed-by entries that reference raw ASCII keys, triggering `NO_PUBKEY F7A37EB33D0B25D7` for the Prosody repo.

Pipe the downloaded key through `gpg --dearmor` so droplet builds keep a binary keyring apt accepts, and add `--batch --yes` so reruns can overwrite the file without gpg errors.

This pull request updates the way the Prosody package signing key is added in both the `jitsi-22-04` and `jitsi-24-04` setup scripts. The new approach uses `gpg --dearmor` for improved security and compatibility.

GitHub Copilot Summary:

> **Improved repository key handling:**
> * Replaced the direct download of the Prosody signing key with a pipeline that fetches the key and converts it to a GPG keyring format using `gpg --dearmor` in both `jitsi-22-04/scripts/01-packages.sh` and `jitsi-24-04/scripts/01-packages.sh`. This enhances security and aligns with best practices for managing APT repository keys.