### PR TITLE
MP-8078 : MERN Build Failure Fix

### DIFF
--- a/common/scripts/010-nodejs.sh
+++ b/common/scripts/010-nodejs.sh
@@ -5,16 +5,16 @@
 ##
 ## vi: syntax=sh expandtab ts=4
 
-# Replace with the branch of Node.js or io.js you want to install: node_6.x, node_8.x, etc...
+# Replace with the branch of Node.js you want to install: 18.x, 20.x, 22.x, lts.x, etc...
 VERSION=${NODE_VERSION}
 
-curl -fsSL "https://deb.nodesource.com/setup_$VERSION" -o nodesource_setup.sh
-sudo -E bash nodesource_setup.sh
+# Use the new NodeSource installation method
+curl -fsSL "https://deb.nodesource.com/setup_$VERSION" | sudo -E bash -
 
 sudo apt -qqy update
-sudo apt -qqy install nodejs 
-sudo apt -qqy npm
+sudo apt -qqy install nodejs
 
+# npm comes with nodejs, no separate install needed
 npm install --global yarn
 
 node -v

--- a/mern-22-04/template.json
+++ b/mern-22-04/template.json
@@ -7,7 +7,7 @@
     "application_name": "MERN",
     "mongo_version": "6.0.4",
     "mongo_repo_version": "6.0",
-    "node_version": "node_19.x",
+    "node_version": "20.x",
     "application_version": ""
   },
   "sensitive-variables": ["do_api_token"],


### PR DESCRIPTION
NodeSource setup script is failing with a 404 error, casuing MERN build failure

Reason for errors:

- The old NodeSource setup URL structure returned a 404
- Node.js 19.x is no longer supported and the repository doesn't exist
- The script tried to install npm separately, but it's now included with nodejs

Changes :

1. Updated the Node.js installation script (`010-nodejs.sh`)
2. Changed from node_19.x (outdated and unsupported) to 20.x (current LTS version)


