### PR TITLE
LAMP: point at 24-04 instead of 20-04

### DIFF
--- a/lamp-24-04/template.json
+++ b/lamp-24-04/template.json
@@ -33,12 +33,12 @@
     },
     {
       "type": "file",
-      "source": "lamp-20-04/files/etc/",
+      "source": "lamp-24-04/files/etc/",
       "destination": "/etc/"
     },
     {
       "type": "file",
-      "source": "lamp-20-04/files/var/",
+      "source": "lamp-24-04/files/var/",
       "destination": "/var/"
     },
     {
@@ -68,7 +68,7 @@
         "LC_CTYPE=en_US.UTF-8"
       ],
       "scripts": [
-        "lamp-20-04/scripts/011-lamp.sh",
+        "lamp-24-04/scripts/011-lamp.sh",
         "common/scripts/014-ufw-apache.sh",
         "common/scripts/018-force-ssh-logout.sh",
         "common/scripts/020-application-tag.sh",


### PR DESCRIPTION
Updates files to point at 24-04 instead of the now-removed 20-04