### PR TITLE
Add Ghost Ubuntu 24.04 1-click Packer builder

### DIFF
--- a/ghost-24-04/LICENSE
+++ b/ghost-24-04/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013-2024 Andrew Starr-Bochicchio & Ghost Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ghost-24-04/Makefile
+++ b/ghost-24-04/Makefile
@@ -1,0 +1,8 @@
+all: build
+
+# Paths assume this Makefile lives in ghost-24-04/; run `make` from this directory.
+build:
+	cd .. && packer build ghost-24-04/template.json
+
+validate:
+	cd .. && packer validate ghost-24-04/template.json

--- a/ghost-24-04/README.md
+++ b/ghost-24-04/README.md
@@ -1,0 +1,69 @@
+# Ghost (Ubuntu 24.04)
+
+This 1-click builds an image with **Ubuntu 24.04 LTS**, **Ghost 6.x**, **Node.js 22** (via NodeSource), MySQL, nginx (managed by Ghost CLI), Postfix, and fail2ban.
+
+## Prereqs
+
+* [make](https://www.gnu.org/software/make/)
+* [Packer](https://www.packer.io/intro/index.html)
+
+## Build Automation with Packer
+
+[Packer](https://www.packer.io/intro/index.html) drives creating, configuring, validating, and snapshotting the build Droplet. Template file: [`template.json`](template.json).
+
+### Running Packer (repository root)
+
+Provisioner paths are relative to the **repository root**. From the repo root:
+
+```sh
+packer validate ghost-24-04/template.json
+packer build ghost-24-04/template.json
+```
+
+Or use the root Makefile:
+
+```sh
+make validate-ghost-24-04
+make build-ghost-24-04
+```
+
+From this directory (`ghost-24-04/`), `make build` and `make validate` run the same commands by changing to the parent directory first (see [`Makefile`](Makefile)).
+
+### Usage
+
+You need [Packer](https://www.packer.io/intro/getting-started/install.html) and a [DigitalOcean personal access token](https://docs.digitalocean.com/reference/api/create-personal-access-token/) exported as `DIGITALOCEAN_API_TOKEN`. A successful `packer build` creates a temporary Droplet, provisions Ghost and dependencies, runs cleanup, powers off, and saves a snapshot.
+
+> The image validation script `999-img_check.sh` is maintained under [`common/scripts/`](../common/scripts/) in this repository (synced from [marketplace-partners](https://github.com/digitalocean/marketplace-partners)); use the repo copy as canonical.
+
+### Variables (`template.json`)
+
+* `do_api_token` — API token; defaults to `DIGITALOCEAN_API_TOKEN`.
+* `image_name` — Snapshot name; default pattern includes `ghost-24-04-1click-` and a timestamp.
+* `ghost_version` — Ghost npm package version installed on first boot (default matches Ghost 6.x).
+* `ghost_cli_version` — Global `ghost-cli` version.
+* `node_version` — NodeSource stream (e.g. `22.x` for Node 22 LTS).
+
+Override at build time with [Packer `-var`](https://developer.hashicorp.com/packer/docs/templates/hcl/variables).
+
+### Builder Droplet size
+
+[`template.json`](template.json) uses DigitalOcean size **`s-1vcpu-2gb`** (1 vCPU, 2 GB RAM) for the **build** Droplet.
+
+[Ghost’s hosting documentation](https://ghost.org/docs/hosting/) states a supported production server needs **at least 1 GB** of memory for Ghost itself. This image is larger because:
+
+* The 1-click runs **Ghost, MySQL, nginx, Postfix, fail2ban, and the OS** on one Droplet—RAM is shared across all services, not only Node/Ghost.
+* **Provisioning and first boot** (`ghost install`, database setup, migrations) use more memory than steady-state serving; extra RAM avoids OOM or heavy swapping during setup.
+* Marketplace images are typically sized **above the app’s bare minimum** so new Droplets from the snapshot are reliable without an immediate resize.
+
+### Configuration details
+
+This configuration uses [Packer’s DigitalOcean builder](https://developer.hashicorp.com/packer/plugins/builders/digitalocean) and [file](https://developer.hashicorp.com/packer/docs/provisioners/file) / [shell](https://developer.hashicorp.com/packer/docs/provisioners/shell) provisioners. Contents of `files/var/`, `files/etc/`, and `files/opt/` are uploaded to matching paths on the image; see Packer’s notes on destination directories in the provisioner docs.
+
+After changes, validate from the repo root:
+
+```sh
+make validate-ghost-24-04
+# or: cd ghost-24-04 && make validate
+```
+
+More detail: [Packer documentation](https://developer.hashicorp.com/packer/docs).

--- a/ghost-24-04/files/etc/fail2ban/filter.d/ghost-auth.conf
+++ b/ghost-24-04/files/etc/fail2ban/filter.d/ghost-auth.conf
@@ -1,0 +1,2 @@
+[Definition]
+failregex = ^.*"statusCode":403.*"name":"NoPermissionError".*$

--- a/ghost-24-04/files/etc/fail2ban/filter.d/ghost-ratelimit.conf
+++ b/ghost-24-04/files/etc/fail2ban/filter.d/ghost-ratelimit.conf
@@ -1,0 +1,2 @@
+[Definition]
+failregex = ^.*"statusCode":429.*"name":"TooManyRequestsError".*$

--- a/ghost-24-04/files/etc/fail2ban/jail.d/ghost.conf
+++ b/ghost-24-04/files/etc/fail2ban/jail.d/ghost.conf
@@ -1,0 +1,15 @@
+[ghost-auth]
+enabled = true
+filter = ghost-auth
+logpath = /var/www/ghost/content/logs/*.log
+maxretry = 5
+port = http,https
+bantime = 1800
+
+[ghost-ratelimit]
+enabled = true
+filter = ghost-ratelimit
+logpath = /var/www/ghost/content/logs/*.log
+maxretry = 3
+port = http,https
+bantime = 86400

--- a/ghost-24-04/files/etc/update-motd.d/99-one-click
+++ b/ghost-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+. /root/.digitalocean_password
+myip=$(hostname -I | awk '{print$1}')
+export TERM=xterm-256color
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's One-Click Ghost Droplet.
+To keep this Droplet secure, the UFW firewall is enabled. 
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
+
+For help and more information, visit https://marketplace.digitalocean.com/apps/ghost
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/ghost-24-04/files/opt/ghost-setup/99-one-click
+++ b/ghost-24-04/files/opt/ghost-setup/99-one-click
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+. /root/.digitalocean_password
+myip=$(hostname -I | awk '{print$1}')
+export TERM=xterm-256color
+echo "
+-------------------------------------------------------------------------------
+
+The $(tput setaf 6)ufw$(tput sgr0) firewall is enabled. All ports except for 22, 80, and 443 are BLOCKED.
+You can find more information on using this image at: $(tput setaf 6)https://marketplace.digitalocean.com/apps/ghost$(tput sgr0)
+
+------------------------------------------------------------------------------
+
+Please switch to the $(tput setaf 6)ghost-mgr$(tput sgr0) user to manage Ghost via the CLI:
+
+    $(tput setaf 3)sudo -i -u ghost-mgr$(tput sgr0)
+
+For an overview of available Ghost CLI commands, run:
+
+    $(tput setaf 3)ghost help$(tput sgr0)
+
+------------------------------------------------------------------------------
+"

--- a/ghost-24-04/files/opt/ghost-setup/boot_strap.sh
+++ b/ghost-24-04/files/opt/ghost-setup/boot_strap.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+export TERM=xterm-256color
+
+# prevent locale warnings
+touch /var/lib/cloud/instance/locale-check.skip
+
+GHOST_HOST="${DATABASE_HOST:-127.0.0.1}"
+GHOST_PORT="${DATABASE_PORT:-3306}"
+GHOST_DATABASE="${DATABASE_DB:-ghost_production}"
+GHOST_USERNAME="${DATABASE_USERNAME:-root}"
+GHOST_PASSWORD="${DATABASE_PASSWORD:-$(openssl rand -hex 24)}"
+
+myip=$(hostname -I | awk '{print$1}')
+
+# Ensure MySQL is running
+while ! mysqladmin ping -h"$GHOST_HOST" -P $GHOST_PORT --silent; do sleep 1; done
+
+# Save the passwords
+cat > /root/.digitalocean_password <<EOM
+root_mysql_pass="${GHOST_PASSWORD}"
+EOM
+
+# Set up Postfix defaults
+hostname=$(hostname)
+sed -i "s/myhostname \= ghost/myhostname = $hostname/g" /etc/postfix/main.cf;
+sed -i "s/inet_interfaces = all/inet_interfaces = loopback-only/g" /etc/postfix/main.cf;
+systemctl restart postfix &
+
+# If we're running the DB locally, change the DB maintenance user password
+if [ "$GHOST_HOST" = "127.0.0.1" ]; then
+    mysql -u "$GHOST_USERNAME" -h "localhost" \
+        -e "ALTER USER '$GHOST_USERNAME'@'localhost' IDENTIFIED WITH caching_sha2_password BY '${GHOST_PASSWORD}';
+            CREATE USER '$GHOST_USERNAME'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY '${GHOST_PASSWORD}';
+            ALTER USER '$GHOST_USERNAME'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY '${GHOST_PASSWORD}';
+            GRANT ALL PRIVILEGES ON *.* TO '$GHOST_USERNAME'@'127.0.0.1' WITH GRANT OPTION;
+            FLUSH PRIVILEGES;"
+
+    debian_sys_maint_mysql_pass=$(openssl rand -hex 24)
+    mysql -u "$GHOST_USERNAME" -p"$GHOST_PASSWORD" \
+        -e "ALTER USER 'debian-sys-maint'@'localhost' IDENTIFIED BY '${debian_sys_maint_mysql_pass}'" 2>/dev/null
+
+    cat > /etc/mysql/debian.cnf <<EOM
+    # Automatically generated for Debian scripts. DO NOT TOUCH!
+    [client]
+    host     = localhost
+    user     = debian-sys-maint
+    password = ${debian_sys_maint_mysql_pass}
+    socket   = /var/run/mysqld/mysqld.sock
+    [mysql_upgrade]
+    host     = localhost
+    user     = debian-sys-maint
+    password = ${debian_sys_maint_mysql_pass}
+    socket   = /var/run/mysqld/mysqld.sock
+EOM
+else
+    systemctl stop mysql 2>/dev/null
+    systemctl disable mysql 2>/dev/null
+fi
+
+# This is where the magic starts
+
+echo "
+Ghost will prompt you for two details:
+
+1. Your domain
+ - Add an A Record -> $(tput setaf 6)${myip}$(tput sgr0) & ensure the DNS has fully propagated
+ - Or alternatively enter $(tput setaf 6)http://${myip}$(tput sgr0)
+2. Your email address (only used for SSL)
+
+$(tput setaf 2)Press enter when you're ready to get started!$(tput sgr0)
+"
+
+# Make sure the user is ready to install Ghost
+read wait
+
+source /var/lib/digitalocean/application.info
+# Install Ghost
+sudo -iu ghost-mgr ghost install "$application_version" --auto \
+  --db=mysql \
+  --dbhost="$GHOST_HOST" \
+  --dbport="$GHOST_PORT" \
+  --dbname="$GHOST_DATABASE" \
+  --dbuser="$GHOST_USERNAME" \
+  --dbpass="$GHOST_PASSWORD" \
+  --dir=/var/www/ghost \
+  --start
+
+
+# Final cleanup
+cp /opt/ghost-setup/99-one-click /etc/update-motd.d/99-one-click
+chmod 0755 /etc/update-motd.d/99-one-click
+
+# Remove nginx default site
+rm -f /etc/nginx/sites-enabled/default
+systemctl restart nginx

--- a/ghost-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/ghost-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,54 @@
+#!/bin/bash
+## vi: syntax=sh expandtab ts=4
+
+cat >> /root/.bashrc <<"EOM"
+
+export TERM=xterm-256color
+
+if [ ! -f "/var/www/ghost/config.production.json" ]; then
+
+# Run bootstrap during first login
+
+echo "
+-------------------------------------------------------------------------------
+
+Configuring DigitalOcean 1-Click Ghost installation.
+
+Please wait a minute while your 1-Click is configured. 
+
+Once complete, you are encouraged to run $(tput setaf 3)mysql_secure_installation$(tput sgr0) to ready
+your server for production. The root MySQL password has been saved to:
+
+    $(tput setaf 6)root/.digitalocean_password$(tput sgr0)
+
+-------------------------------------------------------------------------------
+
+"
+
+# Perform the actual execution
+bash --norc /opt/ghost-setup/boot_strap.sh
+cp /etc/skel/.bashrc /root/.bashrc
+
+echo "
+------------------------------------------------------------------------------
+
+For any further commands, please switch to the $(tput setaf 6)ghost-mgr$(tput sgr0) user to manage Ghost.
+
+    $(tput setaf 3)sudo -i -u ghost-mgr$(tput sgr0)
+
+------------------------------------------------------------------------------
+
+"
+
+fi
+
+EOM
+
+
+
+# Remove the force command
+sed -e '/Match user root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh

--- a/ghost-24-04/files/var/www/html/index.html
+++ b/ghost-24-04/files/var/www/html/index.html
@@ -1,0 +1,102 @@
+<html>
+  <head>
+    <style>
+      body {
+        font-family: ProximaNova;
+        font-size: 15px;
+        font-style: normal;
+        font-stretch: normal;
+        line-height: 1;
+        letter-spacing: normal;
+        margin: 0;
+      }
+
+      .button {
+        border-radius: 3px;
+        background-color: #0069ff;
+        color: #ffffff;
+        display: flex;
+        flex-direction: column;
+        height: 48px;
+        justify-content: center;
+        text-decoration: none;
+        width: 148px;
+      }
+
+      .content {
+        align-items: center;
+        border: solid 2px #f1f1f1;
+        border-radius: 3px;
+        display: flex;
+        flex-direction: column;
+        margin: 32px auto;
+        padding: 32px;
+        text-align: center;
+        width: 960px;;
+      }
+
+      .copyright {
+        color: #99999999;
+        font-size: 13px;
+        margin-left: 10px;
+      }
+
+      .description {
+        color: #676767;
+      }
+
+      .empty-access {
+        height: 220px;
+        margin-bottom: -20px;
+      }
+
+      .header {
+        align-items: center;
+        display: flex;
+        margin: 15px;
+      }
+
+      .logo {
+        height: 30px;
+        color: #999999;
+        width: 30px;
+      }
+
+      .title {
+        font-family: ProximaNova;
+        font-size: 21px;
+        font-weight: 600;
+        color: #444444;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <svg class="logo" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+      viewBox="0 0 30 30" enable-background="new 0 0 30 30" xml:space="preserve">
+        <g id="XMLID_17_">
+          <g id="XMLID_18_">
+            <g>
+              <g id="XMLID_225_">
+                <g id="XMLID_233_">
+                  <path id="XMLID_234_" fill="#0080FF" d="M15,30v-5.8c6.2,0,10.9-6.1,8.6-12.6c-0.9-2.4-2.8-4.3-5.2-5.2
+                    C11.9,4.1,5.8,8.8,5.8,15l0,0L0,15C0,5.2,9.5-2.5,19.8,0.7c4.5,1.4,8.1,5,9.5,9.5C32.5,20.5,24.8,30,15,30z"/>
+                </g>
+                <polygon id="XMLID_232_" fill="#0080FF" points="15,24.2 9.2,24.2 9.2,18.4 9.2,18.4 15,18.4 15,18.4"/>
+                <polygon id="XMLID_228_" fill="#0080FF" points="9.2,28.7 4.8,28.7 4.8,28.7 4.8,24.2 9.2,24.2"/>
+                <polygon id="XMLID_226_" fill="#0080FF" points="4.8,24.2 1,24.2 1,24.2 1,20.5 1,20.5 4.8,20.5 4.8,20.5"/>
+              </g>
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
+
+    <div class="content">
+          <svg id="svg" class="empty-access" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300"><defs><style>.cls-1,.cls-11,.cls-6,.cls-8{fill:#d7e9ff;}.cls-1{stroke:#d7e9ff;}.cls-1,.cls-10,.cls-13,.cls-14,.cls-15,.cls-16,.cls-17,.cls-18,.cls-2,.cls-3,.cls-4,.cls-6,.cls-7,.cls-9{stroke-linejoin:round;}.cls-1,.cls-13,.cls-14,.cls-2,.cls-3,.cls-6{stroke-width:1.6px;}.cls-1,.cls-5,.cls-7,.cls-8,.cls-9{fill-rule:evenodd;}.cls-12,.cls-2{fill:#8fbeff;}.cls-10,.cls-14,.cls-2,.cls-4,.cls-6,.cls-7{stroke:#8fbeff;}.cls-3{fill:#4894ff;}.cls-13,.cls-3{stroke:#4894ff;}.cls-13,.cls-14,.cls-15,.cls-16,.cls-18,.cls-4,.cls-7,.cls-9{fill:none;}.cls-15,.cls-16,.cls-18,.cls-4,.cls-6,.cls-7,.cls-9{stroke-linecap:round;}.cls-4{stroke-width:6px;}.cls-10,.cls-17,.cls-5{fill:#fff;}.cls-10,.cls-15,.cls-17,.cls-18,.cls-7,.cls-9{stroke-width:2px;}.cls-15,.cls-9{stroke:#0069ff;}.cls-16{stroke:#fff;stroke-width:1.6px;}.cls-17{stroke:#a5d1f7;}.cls-18{stroke:#1f8ced;}</style></defs><path class="cls-1" d="M148.23,190.5a5.31,5.31,0,0,1-5.31-5.31,5.31,5.31,0,0,1-5.31,5.31,5.31,5.31,0,0,1,5.31,5.31A5.31,5.31,0,0,1,148.23,190.5Z"/><path class="cls-1" d="M200.83,166.47a5.31,5.31,0,0,1-5.31-5.31,5.31,5.31,0,0,1-5.31,5.31,5.31,5.31,0,0,1,5.31,5.31A5.31,5.31,0,0,1,200.83,166.47Z"/><circle class="cls-2" cx="187.2" cy="213.07" r="1.11"/><circle class="cls-2" cx="199.83" cy="104.53" r="1.11"/><circle class="cls-3" cx="209.32" cy="188.1" r="1.11"/><circle class="cls-4" cx="166.27" cy="88.39" r="24.99" transform="translate(-0.6 175.63) rotate(-55.6)"/><polygon class="cls-5" points="121.26 188.1 161.43 156.45 176.42 107.55 144.73 85.85 104.56 117.51 89.57 166.4 121.26 188.1"/><rect class="cls-6" x="84.18" y="117.77" width="97.63" height="38.41" transform="translate(-55.16 169.32) rotate(-55.6)"/><polyline class="cls-7" points="161.43 156.45 176.42 107.55 144.73 85.85 104.56 117.51 89.57 166.4 121.26 188.1 153.98 162.32"/><path class="cls-8" d="M193,113a21.74,21.74,0,0,1-7-8.62,21.14,21.14,0,0,0-38.37,0,21.74,21.74,0,0,1-7,8.61,16.4,16.4,0,0,0-6.82,14.78,16,16,0,0,0,5,10.32,9.14,9.14,0,0,1,3,6.62h0a8.84,8.84,0,0,0,8.83,8.84l32.3,0a8.84,8.84,0,0,0,8.84-8.83h0a9.14,9.14,0,0,1,3-6.61,16,16,0,0,0,5-10.32A16.4,16.4,0,0,0,193,113Z"/><path class="cls-9" d="M181.81,98.41a21.14,21.14,0,0,0-34.21,6,21.74,21.74,0,0,1-7,8.61,16.4,16.4,0,0,0-6.82,14.78,16,16,0,0,0,5,10.32,9.14,9.14,0,0,1,3,6.62h0a8.84,8.84,0,0,0,8.83,8.84l32.3,0a8.84,8.84,0,0,0,8.84-8.83h0a9.14,9.14,0,0,1,3-6.61,16,16,0,0,0,5-10.32A16.4,16.4,0,0,0,193,113a20.5,20.5,0,0,1-3.61-3.32"/><circle class="cls-10" cx="166.78" cy="113.3" r="6.55"/><path class="cls-9" d="M166.78,106.75a6.55,6.55,0,0,1,0,13.1"/><path class="cls-5" d="M157.75,153.56l0,60.61a6.43,6.43,0,0,1,6.43,6.43h11.57l0-67h-18Z"/><rect class="cls-11" x="157.75" y="153.56" width="18" height="7.6"/><rect class="cls-11" x="164.16" y="153.56" width="5.14" height="67.04"/><rect class="cls-12" x="164.18" y="153.56" width="5.14" height="7.6"/><rect class="cls-13" x="164.16" y="153.56" width="5.14" height="67.04"/><line class="cls-14" x1="164.18" y1="161.16" x2="164.14" y2="220.6"/><path class="cls-9" d="M175.74,180.6l0-27h-18l0,60.61a6.43,6.43,0,0,1,6.43,6.43h11.57V208.51"/><line class="cls-15" x1="175.73" y1="203.51" x2="175.74" y2="185.6"/><path class="cls-4" d="M166.6,113.38a25,25,0,0,0,13.79-45.61"/><path class="cls-16" d="M166.6,113.38a25,25,0,0,0,13.79-45.61"/><path class="cls-16" d="M176.42,65.55a24.82,24.82,0,0,0-7-2"/><rect class="cls-17" x="152.27" y="130.97" width="29" height="8.5"/><line class="cls-18" x1="181.27" y1="130.97" x2="181.27" y2="139.47"/></svg>
+      <h1 class="title">Please log into your Droplet with SSH to configure the Ghost installation.</h1>
+      <p class="description">See the Ghost One-Click Quickstart guide for detailed assistance.</p>
+      <a class="button" href="https://www.digitalocean.com/community/tutorials?q=Ghost+1-Click">Quickstart Guide</a>
+    </div>
+  </body>
+</html>

--- a/ghost-24-04/listing.md
+++ b/ghost-24-04/listing.md
@@ -1,0 +1,49 @@
+# Ghost
+
+A DigitalOcean 1-Click Droplet running **Ghost** (publishing platform) on **Ubuntu 24.04 LTS** with MySQL, **nginx** (configured by Ghost CLI), Postfix, fail2ban, and UFW. The first time you SSH in as root, the installer finishes Ghost setup interactively; after that, use the **`ghost-mgr`** user for day-to-day Ghost administration.
+
+## System Components
+
+- Ubuntu 24.04 LTS  
+- Ghost (installed via Ghost CLI on first boot; version pinned in the image build)  
+- Node.js 22 LTS (NodeSource)  
+- MySQL 8  
+- nginx (reverse proxy / SSL via Ghost CLI)  
+- Postfix (loopback-only for mail)  
+- fail2ban  
+- UFW (SSH limited; HTTP/HTTPS for nginx)  
+
+## Droplet size
+
+[Ghost’s documentation](https://ghost.org/docs/hosting/) recommends **at least 1 GB of RAM** for Ghost on a supported production server. This Marketplace image is built and tested on a **2 GB** Droplet (`s-1vcpu-2gb`) because Ghost shares the machine with MySQL, nginx, Postfix, and the OS, and first-time setup (`ghost install`, database work) needs more headroom than steady traffic alone. Starting at **2 GB** avoids swapping and out-of-memory issues during provisioning; you can resize later if your traffic grows.
+
+## Getting Started
+
+1. Create a Droplet from this image (2 GB RAM or larger is recommended).  
+2. Optionally point a domain’s **A record** at the Droplet’s public IPv4 address and wait for DNS to propagate.  
+3. SSH in as **root** once. The bootstrap script runs **Ghost install** and will ask for your site URL and SSL details.  
+4. After setup, manage Ghost as **`ghost-mgr`**: `sudo -i -u ghost-mgr`  
+5. Read `/root/.digitalocean_password` for the MySQL password set at first boot, and consider running `mysql_secure_installation` before production use.
+
+## Service Management
+
+Use **`ghost-mgr`** for Ghost (run from `/var/www/ghost` or use `ghost` CLI which knows the install path):
+
+| Action | Command (as `ghost-mgr`, or with `sudo -u ghost-mgr -H bash -lc '...'`) |
+|--------|--------------------------------------------------------------------------|
+| Ghost status | `ghost status` |
+| Stop | `ghost stop` |
+| Start | `ghost start` |
+| Restart | `ghost restart` |
+| Update Ghost | `ghost update` (from the install directory) |
+| Logs | `ghost log` or files under `/var/www/ghost/content/logs/` |
+
+Core stack services (run as root):
+
+| Service | Status example |
+|---------|----------------|
+| nginx | `sudo systemctl status nginx` |
+| MySQL | `sudo systemctl status mysql` |
+| Postfix | `sudo systemctl status postfix` |
+
+System packages update with `sudo apt update && sudo apt upgrade`. After upgrading system Node or MySQL, follow [Ghost’s self-hosting docs](https://ghost.org/docs/hosting/) for any stack-specific steps.

--- a/ghost-24-04/scripts/012-configure_postfix.sh
+++ b/ghost-24-04/scripts/012-configure_postfix.sh
@@ -1,0 +1,8 @@
+################################
+## PART: configure postfix
+##
+## vi: syntax=sh expandtab ts=4
+
+sed -e 's/inet_interfaces = all/inet_interfaces = loopback-only/' \
+    -i /etc/postfix/main.cf
+

--- a/ghost-24-04/scripts/014-configure_ghost.sh
+++ b/ghost-24-04/scripts/014-configure_ghost.sh
@@ -1,0 +1,37 @@
+################################
+## PART: configure Ghost
+##
+## vi: syntax=sh expandtab ts=4
+
+GHOST_CLI_VERSION="${ghost_cli_version}"
+VERSION=${NODE_VERSION}
+
+curl -fsSL "https://deb.nodesource.com/setup_$VERSION" -o nodesource_setup.sh
+sudo -E bash nodesource_setup.sh
+
+# Run update and install
+sudo apt-get update
+sudo apt-get install nodejs -y
+
+useradd --home-dir /home/ghost-mgr \
+        --shell /bin/bash \
+        --create-home \
+        --comment 'Ghost Management User' \
+        --groups sudo \
+        ghost-mgr
+
+cat > /etc/sudoers.d/99-do-ghost <<EOM
+# Created by DigitalOcean 1-Click for Ghost CLI management.
+ghost-mgr ALL=(ALL) NOPASSWD:ALL
+EOM
+
+chmod 755 /var/www
+mkdir -p /var/www/ghost
+chown -R ghost-mgr: /var/www/ghost
+chmod 775 /var/www/ghost
+
+# Install Ghost-CLI
+su ghost-mgr -c "bash -x <<EOM
+sudo npm i -g ghost-cli@${GHOST_CLI_VERSION} > /tmp/npm.log || { tail -n 100 /tmp/npm.log; exit 1; }
+EOM
+"

--- a/ghost-24-04/template.json
+++ b/ghost-24-04/template.json
@@ -1,0 +1,82 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "ghost-24-04-1click-{{timestamp}}",
+    "node_version": "22.x",
+    "ghost_version": "6.27.0",
+    "ghost_cli_version": "1.29.1",
+    "application_name": "Ghost",
+    "apt_packages": "fail2ban cloud-image-utils git jq libguestfs-tools make mysql-server nginx postfix python3-certbot super unzip gnupg2 curl"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "ams3",
+      "size": "s-1vcpu-2gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "ghost-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "ghost-24-04/files/opt/",
+      "destination": "/opt/"
+    },
+    {
+      "type": "file",
+      "source": "ghost-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "cloud-init status --wait",
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "GHOST_VERSION={{user `ghost_version`}}",
+        "application_name={{user `application_name`}}",
+        "application_version={{user `ghost_version`}}",
+        "ghost_cli_version={{user `ghost_cli_version`}}",
+        "NODE_VERSION={{user `node_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "ghost-24-04/scripts/014-configure_ghost.sh",
+        "ghost-24-04/scripts/012-configure_postfix.sh",
+        "common/scripts/014-ufw-nginx.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Introduce ghost-24-04 with DigitalOcean template targeting ubuntu-24-04-x64, Ghost 6.27.0, ghost-cli 1.29.1, and Node.js 22.x via NodeSource. File provisioners and scripts use the ghost-24-04 paths; the builder uses s-1vcpu-2gb for snapshot builds.

Document template usage from the repository root, Makefile and root make targets, and why the image uses 2 GB RAM versus Ghost’s 1 GB minimum. Add listing.md for the marketplace catalog and refresh the placeholder Quickstart link.

closes #293 

Made-with: Cursor