### PR TITLE
Add Goose 24.04 1-Click Packer template

### DIFF
--- a/goose-24-04/files/etc/systemd/system/ttyd-goose.service
+++ b/goose-24-04/files/etc/systemd/system/ttyd-goose.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Web terminal for Goose (ttyd, localhost only)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ttyd -i 127.0.0.1 -p 7681 -W bash -l
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/goose-24-04/files/etc/update-motd.d/99-one-click
+++ b/goose-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,93 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+
+if [ -f /root/.goose-web-console-disabled ]; then
+    cat <<EOF
+********************************************************************************
+
+Welcome to Goose on DigitalOcean!
+
+Goose is an open source, extensible AI agent (CLI and more) for coding, automation,
+and general tasks with the LLM providers you configure.
+
+WEB CONSOLE
+===========
+
+You chose not to enable the HTTPS browser terminal (nginx) during first-time setup.
+
+To turn it on later (password prompt, nginx, Basic Auth, Let's Encrypt for this IP):
+
+  /opt/goose/enable-web-console.sh
+
+ttyd still listens on 127.0.0.1:7681 for local use (e.g. SSH port forwarding).
+
+USEFUL PATHS
+============
+
+  Quick reference:       /opt/goose/README.txt
+  Enable web console:    /opt/goose/enable-web-console.sh
+  Certbot (venv):        /opt/certbot-venv/bin/certbot
+
+DOCUMENTATION
+=============
+
+  Project: https://github.com/aaif-goose/goose
+
+Run 'goose --help' after installation. Configure providers with 'goose configure'.
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF
+else
+    cat <<EOF
+********************************************************************************
+
+Welcome to Goose on DigitalOcean!
+
+Goose is an open source, extensible AI agent (CLI and more) for coding, automation,
+and general tasks with the LLM providers you configure.
+
+FIRST-TIME SETUP
+================
+
+On your first SSH login as root, you can set a web console password or leave it
+empty to skip nginx entirely. See /opt/goose/README.txt.
+
+WEB CONSOLE (nginx + ttyd)
+==========================
+
+After setup with a non-empty password, open in a browser:
+
+  https://${myip}/
+
+Use HTTP Basic username 'goose' and the password you chose. To enable the web
+console later if you skipped it:
+
+  /opt/goose/enable-web-console.sh
+
+A copy of your web password may be stored at (delete when no longer needed):
+
+  /root/.goose_web_console_password.txt
+
+USEFUL PATHS
+============
+
+  Quick reference:       /opt/goose/README.txt
+  Enable web console:    /opt/goose/enable-web-console.sh
+  First-login script:    /opt/goose/first-login-setup.sh
+  Certbot (venv):        /opt/certbot-venv/bin/certbot
+
+DOCUMENTATION
+=============
+
+  Project: https://github.com/aaif-goose/goose
+
+Run 'goose --help' after installation. Configure providers with 'goose configure'.
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF
+fi

--- a/goose-24-04/files/opt/goose/README.txt
+++ b/goose-24-04/files/opt/goose/README.txt
@@ -1,0 +1,69 @@
+Welcome to Goose on DigitalOcean!
+
+Goose is an open source, extensible AI agent for install / execute / edit / test
+workflows with the models and providers you choose.
+
+FIRST SSH LOGIN
+===============
+
+The first time you log in as root, /opt/goose/first-login-setup.sh runs automatically.
+
+  1. Web console password (HTTPS in the browser, nginx + HTTP Basic Auth -> ttyd).
+     Leave the password empty (press Enter twice) if you do not want nginx or a
+     public HTTPS terminal. You can enable the web UI later with:
+
+       /opt/goose/enable-web-console.sh
+
+     If you set a password (8+ characters), a copy is saved at
+     /root/.goose_web_console_password.txt (mode 600). Remove it when appropriate.
+
+  2. Install the Goose CLI:
+
+       curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash
+
+     (The wizard sets GOOSE_BIN_DIR=/usr/local/bin and CONFIGURE=false; run
+     "goose configure" when you want interactive provider setup.)
+
+  3. If you chose a web password: Let's Encrypt for this Droplet's public IPv4
+     (Certbot shortlived IP profile) and nginx TLS updates. If you skipped the web
+     console, Certbot/nginx for the browser are not started until you run
+     enable-web-console.sh.
+
+ENABLE WEB CONSOLE LATER
+========================
+
+Run as root, from an interactive SSH session:
+
+  /opt/goose/enable-web-console.sh
+
+You will be prompted for the web password (min 8 characters). The script writes
+nginx config, starts nginx, obtains a Let's Encrypt IP certificate when possible,
+and installs the renewal cron job.
+
+WEB TERMINAL (when nginx is enabled)
+====================================
+
+ttyd serves a shell on 127.0.0.1:7681. nginx listens on 80/443, proxies WebSockets
+to ttyd, and enforces HTTP Basic authentication (user: goose).
+
+When the web console was skipped, nginx is stopped and disabled; ttyd may still
+run for local forwarding.
+
+TLS AND RENEWAL
+===============
+
+Certbot is in /opt/certbot-venv. Renewal cron: /etc/cron.d/goose-certbot-renew
+(only installed when the web console with TLS has been set up).
+
+FIREWALL
+========
+
+UFW allows SSH and HTTP/HTTPS. If you never enable the web console, you may
+remove unused HTTP rules with "ufw delete ..." if desired.
+
+DOCUMENTATION
+===============
+
+  https://github.com/aaif-goose/goose
+
+For questions, use the upstream project community resources.

--- a/goose-24-04/files/opt/goose/enable-web-console.sh
+++ b/goose-24-04/files/opt/goose/enable-web-console.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Enable or re-enable the HTTPS web console (nginx -> ttyd + Basic Auth + Let's Encrypt).
+# Run as root, from an interactive terminal:  /opt/goose/enable-web-console.sh
+
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Run as root."
+    exit 1
+fi
+
+if [ ! -t 0 ]; then
+    echo "This script must be run interactively (TTY)."
+    exit 1
+fi
+
+if ! systemctl is-active --quiet ttyd-goose; then
+    echo "Starting ttyd (localhost web terminal backend)..."
+    systemctl enable --now ttyd-goose
+fi
+
+echo ""
+echo "=== Goose: HTTPS web console setup ==="
+echo "nginx will listen on ports 80 and 443, proxy to ttyd on 127.0.0.1:7681, and use HTTP Basic Auth."
+echo ""
+
+while true; do
+    read -r -s -p "Choose a web console password (user 'goose', min 8 characters): " WEB_PASS
+    echo ""
+    read -r -s -p "Confirm password: " WEB_PASS2
+    echo ""
+    if [ "$WEB_PASS" != "$WEB_PASS2" ]; then
+        echo "Passwords do not match. Try again."
+        continue
+    fi
+    if [ -z "$WEB_PASS" ]; then
+        echo "Password cannot be empty. To skip the web console, leave nginx disabled (do not run this script)."
+        continue
+    fi
+    if [ "${#WEB_PASS}" -lt 8 ]; then
+        echo "Use at least 8 characters."
+        continue
+    fi
+    break
+done
+
+umask 077
+install -d -m 0700 /root
+printf '%s\n' "$WEB_PASS" >/root/.goose_web_console_password.txt
+chmod 600 /root/.goose_web_console_password.txt
+echo "Saved password copy at /root/.goose_web_console_password.txt (mode 600). Delete when no longer needed."
+
+htpasswd -cb /etc/nginx/.goose-ttyd.htpasswd goose "$WEB_PASS"
+chmod 640 /etc/nginx/.goose-ttyd.htpasswd
+chown root:www-data /etc/nginx/.goose-ttyd.htpasswd
+
+PUBLIC_IP="$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+    http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+if [ -z "$PUBLIC_IP" ]; then
+    PUBLIC_IP="$(hostname -I | awk '{print $1}')"
+fi
+
+mkdir -p /etc/ssl/goose /var/www/html/.well-known/acme-challenge
+
+if [ ! -f /etc/ssl/goose/selfsigned.crt ] || [ ! -f /etc/ssl/goose/selfsigned.key ]; then
+    openssl req -newkey rsa:2048 -nodes -x509 -days 30 \
+        -subj "/CN=${PUBLIC_IP}" \
+        -addext "subjectAltName=IP:${PUBLIC_IP}" \
+        -keyout /etc/ssl/goose/selfsigned.key \
+        -out /etc/ssl/goose/selfsigned.crt 2>/dev/null
+    chmod 640 /etc/ssl/goose/selfsigned.key
+    chmod 644 /etc/ssl/goose/selfsigned.crt
+fi
+
+SSL_CERT=/etc/ssl/goose/selfsigned.crt
+SSL_KEY=/etc/ssl/goose/selfsigned.key
+
+sed -e "s/__DROPLET_IP__/${PUBLIC_IP}/g" \
+    -e "s|__SSL_CERT__|${SSL_CERT}|g" \
+    -e "s|__SSL_KEY__|${SSL_KEY}|g" \
+    /opt/goose/nginx-active.conf.tpl >/etc/nginx/sites-available/goose-ttyd
+
+rm -f /etc/nginx/sites-enabled/default /etc/nginx/sites-enabled/goose-bootstrap
+ln -sf /etc/nginx/sites-available/goose-ttyd /etc/nginx/sites-enabled/goose-ttyd
+
+nginx -t
+systemctl enable nginx
+systemctl start nginx
+systemctl reload nginx
+
+echo ""
+echo "Requesting Let's Encrypt certificate for ${PUBLIC_IP} (short-lived IP profile)..."
+set +e
+/opt/certbot-venv/bin/certbot certonly \
+    --webroot -w /var/www/html \
+    --preferred-profile shortlived \
+    --agree-tos --register-unsafely-without-email \
+    --non-interactive \
+    --ip-address "${PUBLIC_IP}"
+CERT_STATUS=$?
+set -e
+
+LE_DIR="/etc/letsencrypt/live/${PUBLIC_IP}"
+if [ "$CERT_STATUS" -eq 0 ] && [ ! -f "${LE_DIR}/fullchain.pem" ]; then
+    LE_DIR=""
+    newest=""
+    for d in /etc/letsencrypt/live/*/; do
+        [ -f "${d}fullchain.pem" ] || continue
+        ts=$(stat -c %Y "${d}fullchain.pem" 2>/dev/null || stat -f %m "${d}fullchain.pem" 2>/dev/null || echo 0)
+        if [ -z "$newest" ] || [ "$ts" -gt "$newest" ]; then
+            newest=$ts
+            LE_DIR=$(dirname "${d}fullchain.pem")
+        fi
+    done
+fi
+if [ "$CERT_STATUS" -eq 0 ] && [ -n "$LE_DIR" ] && [ -f "${LE_DIR}/fullchain.pem" ]; then
+    SSL_CERT="${LE_DIR}/fullchain.pem"
+    SSL_KEY="${LE_DIR}/privkey.pem"
+    sed -e "s/__DROPLET_IP__/${PUBLIC_IP}/g" \
+        -e "s|__SSL_CERT__|${SSL_CERT}|g" \
+        -e "s|__SSL_KEY__|${SSL_KEY}|g" \
+        /opt/goose/nginx-active.conf.tpl >/etc/nginx/sites-available/goose-ttyd
+    nginx -t
+    systemctl reload nginx
+    echo "Let's Encrypt certificate installed."
+else
+    echo "Let's Encrypt issuance did not complete (exit ${CERT_STATUS}). Using self-signed TLS under /etc/ssl/goose/."
+    echo "Retry when port 80 is reachable:"
+    echo "  /opt/certbot-venv/bin/certbot certonly --webroot -w /var/www/html --preferred-profile shortlived --agree-tos --register-unsafely-without-email --ip-address ${PUBLIC_IP}"
+fi
+
+cat >/etc/cron.d/goose-certbot-renew <<CRON
+# Renew Let's Encrypt IP certificate (short-lived profile); reload nginx on success
+0 2,14 * * * root /opt/certbot-venv/bin/certbot renew -q --deploy-hook "systemctl reload nginx" >>/var/log/goose-certbot.log 2>&1
+CRON
+chmod 644 /etc/cron.d/goose-certbot-renew
+
+rm -f /root/.goose-web-console-disabled
+
+echo ""
+echo "=== Web console enabled ==="
+echo "Open: https://${PUBLIC_IP}/  (Basic Auth user: goose)"
+echo ""

--- a/goose-24-04/files/opt/goose/first-login-setup.sh
+++ b/goose-24-04/files/opt/goose/first-login-setup.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+set -euo pipefail
+
+MARKER=/root/.goose-first-login-done
+if [ -f "$MARKER" ]; then
+    exit 0
+fi
+
+if [ ! -t 0 ]; then
+    exit 0
+fi
+
+echo ""
+echo "=== Goose 1-Click: first-time setup ==="
+echo ""
+echo "Web console: HTTPS in the browser via nginx (HTTP Basic Auth) -> ttyd."
+echo "Leave the password empty (press Enter twice) if you do not want nginx or a browser terminal."
+echo "You can enable it later with:  /opt/goose/enable-web-console.sh"
+echo ""
+
+WEB_SKIP=0
+while true; do
+    read -r -s -p "Web console password (empty = skip nginx / no HTTPS web UI): " WEB_PASS
+    echo ""
+    read -r -s -p "Confirm password: " WEB_PASS2
+    echo ""
+    if [ "$WEB_PASS" != "$WEB_PASS2" ]; then
+        echo "Passwords do not match. Try again."
+        continue
+    fi
+    if [ -z "$WEB_PASS" ]; then
+        WEB_SKIP=1
+        break
+    fi
+    if [ "${#WEB_PASS}" -lt 8 ]; then
+        echo "Use at least 8 characters, or leave both empty to skip the web console."
+        continue
+    fi
+    WEB_SKIP=0
+    break
+done
+
+PUBLIC_IP="$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+    http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+if [ -z "$PUBLIC_IP" ]; then
+    PUBLIC_IP="$(hostname -I | awk '{print $1}')"
+fi
+
+if [ "$WEB_SKIP" -eq 1 ]; then
+    echo ""
+    echo "Skipping nginx and TLS web setup (no HTTP/HTTPS reverse proxy)."
+    rm -f /root/.goose_web_console_password.txt
+    rm -f /etc/nginx/sites-enabled/goose-ttyd /etc/nginx/sites-enabled/goose-bootstrap /etc/nginx/sites-enabled/default
+    systemctl disable nginx --now 2>/dev/null || true
+    systemctl stop nginx 2>/dev/null || true
+    rm -f /etc/cron.d/goose-certbot-renew
+    touch /root/.goose-web-console-disabled
+else
+    umask 077
+    install -d -m 0700 /root
+    printf '%s\n' "$WEB_PASS" >/root/.goose_web_console_password.txt
+    chmod 600 /root/.goose_web_console_password.txt
+    echo "Saved plain-text copy for your records: /root/.goose_web_console_password.txt (mode 600). Delete it after you store the password elsewhere."
+
+    htpasswd -cb /etc/nginx/.goose-ttyd.htpasswd goose "$WEB_PASS"
+    chmod 640 /etc/nginx/.goose-ttyd.htpasswd
+    chown root:www-data /etc/nginx/.goose-ttyd.htpasswd
+
+    SSL_CERT=/etc/ssl/goose/selfsigned.crt
+    SSL_KEY=/etc/ssl/goose/selfsigned.key
+
+    sed -e "s/__DROPLET_IP__/${PUBLIC_IP}/g" \
+        -e "s|__SSL_CERT__|${SSL_CERT}|g" \
+        -e "s|__SSL_KEY__|${SSL_KEY}|g" \
+        /opt/goose/nginx-active.conf.tpl >/etc/nginx/sites-available/goose-ttyd
+
+    rm -f /etc/nginx/sites-enabled/default /etc/nginx/sites-enabled/goose-bootstrap
+    ln -sf /etc/nginx/sites-available/goose-ttyd /etc/nginx/sites-enabled/goose-ttyd
+
+    nginx -t
+    systemctl enable nginx
+    systemctl start nginx
+    systemctl reload nginx
+
+    rm -f /root/.goose-web-console-disabled
+
+    echo ""
+    echo "Requesting Let's Encrypt certificate for this Droplet's public IP (${PUBLIC_IP})..."
+    echo "Using Certbot short-lived IP profile (renewal is configured automatically)."
+    set +e
+    /opt/certbot-venv/bin/certbot certonly \
+        --webroot -w /var/www/html \
+        --preferred-profile shortlived \
+        --agree-tos --register-unsafely-without-email \
+        --non-interactive \
+        --ip-address "${PUBLIC_IP}"
+    CERT_STATUS=$?
+    set -e
+
+    LE_DIR="/etc/letsencrypt/live/${PUBLIC_IP}"
+    if [ "$CERT_STATUS" -eq 0 ] && [ ! -f "${LE_DIR}/fullchain.pem" ]; then
+        LE_DIR=""
+        newest=""
+        for d in /etc/letsencrypt/live/*/; do
+            [ -f "${d}fullchain.pem" ] || continue
+            ts=$(stat -c %Y "${d}fullchain.pem" 2>/dev/null || stat -f %m "${d}fullchain.pem" 2>/dev/null || echo 0)
+            if [ -z "$newest" ] || [ "$ts" -gt "$newest" ]; then
+                newest=$ts
+                LE_DIR=$(dirname "${d}fullchain.pem")
+            fi
+        done
+    fi
+    if [ "$CERT_STATUS" -eq 0 ] && [ -n "$LE_DIR" ] && [ -f "${LE_DIR}/fullchain.pem" ]; then
+        SSL_CERT="${LE_DIR}/fullchain.pem"
+        SSL_KEY="${LE_DIR}/privkey.pem"
+        sed -e "s/__DROPLET_IP__/${PUBLIC_IP}/g" \
+            -e "s|__SSL_CERT__|${SSL_CERT}|g" \
+            -e "s|__SSL_KEY__|${SSL_KEY}|g" \
+            /opt/goose/nginx-active.conf.tpl >/etc/nginx/sites-available/goose-ttyd
+        nginx -t
+        systemctl reload nginx
+        echo "Let's Encrypt certificate installed. HTTPS uses a publicly trusted chain (short-lived profile)."
+    else
+        echo "Let's Encrypt issuance did not complete (exit ${CERT_STATUS})."
+        echo "The web console still uses the temporary self-signed certificate in /etc/ssl/goose/."
+        echo "Ensure port 80 is reachable from the internet for HTTP-01 validation, then run:"
+        echo "  /opt/certbot-venv/bin/certbot certonly --webroot -w /var/www/html --preferred-profile shortlived --agree-tos --register-unsafely-without-email --ip-address ${PUBLIC_IP}"
+    fi
+
+    cat >/etc/cron.d/goose-certbot-renew <<CRON
+# Renew Let's Encrypt IP certificate (short-lived profile); reload nginx on success
+0 2,14 * * * root /opt/certbot-venv/bin/certbot renew -q --deploy-hook "systemctl reload nginx" >>/var/log/goose-certbot.log 2>&1
+CRON
+    chmod 644 /etc/cron.d/goose-certbot-renew
+fi
+
+echo ""
+echo "Installing Goose CLI (official install script; non-interactive configure)..."
+export GOOSE_BIN_DIR=/usr/local/bin
+export CONFIGURE=false
+curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash
+
+if ! command -v goose >/dev/null 2>&1; then
+    echo "Warning: goose not found on PATH after install. Check /usr/local/bin and ~/.local/bin."
+else
+    echo "Goose installed: $(goose --version 2>/dev/null || true)"
+fi
+
+touch "$MARKER"
+sed -i '/# goose-24-04 first-login/,/first-login-setup.sh/d' /root/.bashrc
+
+echo ""
+echo "=== Setup complete ==="
+if [ "$WEB_SKIP" -eq 1 ]; then
+    echo "Web console: disabled (nginx not running)."
+    echo "To enable HTTPS + Basic Auth + Let's Encrypt later, run:  /opt/goose/enable-web-console.sh"
+else
+    echo "Web console: https://${PUBLIC_IP}/  (HTTP Basic user: goose)"
+fi
+echo "Run 'goose configure' to connect providers, then use the 'goose' command as usual."
+echo ""

--- a/goose-24-04/files/opt/goose/nginx-active.conf.tpl
+++ b/goose-24-04/files/opt/goose/nginx-active.conf.tpl
@@ -1,0 +1,40 @@
+# Web console: HTTPS + Basic Auth -> ttyd (Goose 1-Click)
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name __DROPLET_IP__;
+    root /var/www/html;
+
+    location /.well-known/acme-challenge/ {
+        try_files $uri =404;
+    }
+
+    location / {
+        return 302 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    server_name __DROPLET_IP__;
+
+    ssl_certificate __SSL_CERT__;
+    ssl_certificate_key __SSL_KEY__;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    auth_basic "Goose web console";
+    auth_basic_user_file /etc/nginx/.goose-ttyd.htpasswd;
+
+    location / {
+        proxy_pass http://127.0.0.1:7681;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+    }
+}

--- a/goose-24-04/files/opt/goose/nginx-pending.conf.tpl
+++ b/goose-24-04/files/opt/goose/nginx-pending.conf.tpl
@@ -1,0 +1,30 @@
+# Replaced after first SSH login with the active console config (see /opt/goose/)
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name __DROPLET_IP__;
+    root /var/www/html;
+
+    location /.well-known/acme-challenge/ {
+        try_files $uri =404;
+    }
+
+    location / {
+        return 302 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    server_name __DROPLET_IP__;
+
+    ssl_certificate /etc/ssl/goose/selfsigned.crt;
+    ssl_certificate_key /etc/ssl/goose/selfsigned.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    location / {
+        default_type text/plain;
+        return 503 "Complete first-time setup: SSH to this Droplet as root. A short wizard will set your web console password, install Goose, and obtain a Let's Encrypt certificate.\n";
+    }
+}

--- a/goose-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/goose-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -e
+
+# Allow normal SSH sessions on the customer Droplet (DO marketplace images)
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+systemctl restart ssh
+
+meta() {
+    curl -fsS --retry 10 --retry-connrefused --max-time 3 "$1" 2>/dev/null || true
+}
+
+DROPLET_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)"
+if [ -z "$DROPLET_IP" ]; then
+    DROPLET_IP="$(hostname -I | awk '{print $1}')"
+fi
+
+mkdir -p /etc/ssl/goose /var/www/html/.well-known/acme-challenge
+
+openssl req -newkey rsa:2048 -nodes -x509 -days 30 \
+    -subj "/CN=${DROPLET_IP}" \
+    -addext "subjectAltName=IP:${DROPLET_IP}" \
+    -keyout /etc/ssl/goose/selfsigned.key \
+    -out /etc/ssl/goose/selfsigned.crt 2>/dev/null
+
+chmod 640 /etc/ssl/goose/selfsigned.key
+chmod 644 /etc/ssl/goose/selfsigned.crt
+
+# Pending site is available for first-login or enable-web-console.sh; nginx stays off until then.
+sed "s/__DROPLET_IP__/${DROPLET_IP}/g" /opt/goose/nginx-pending.conf.tpl \
+    >/etc/nginx/sites-available/goose-ttyd
+
+rm -f /etc/nginx/sites-enabled/default /etc/nginx/sites-enabled/goose-bootstrap /etc/nginx/sites-enabled/goose-ttyd
+
+systemctl stop nginx 2>/dev/null || true
+systemctl disable nginx 2>/dev/null || true
+
+systemctl daemon-reload
+systemctl enable ttyd-goose
+systemctl start ttyd-goose
+
+if ! grep -q 'goose-24-04 first-login' /root/.bashrc 2>/dev/null; then
+    cat >> /root/.bashrc <<'EOM'
+
+# goose-24-04 first-login
+[ -x /opt/goose/first-login-setup.sh ] && /opt/goose/first-login-setup.sh
+EOM
+fi

--- a/goose-24-04/listing.md
+++ b/goose-24-04/listing.md
@@ -1,0 +1,114 @@
+# Goose 1-Click Application
+
+Deploy [Goose](https://github.com/aaif-goose/goose), an open source, extensible AI agent for the terminal and beyond. This image installs **nginx** and **ttyd** during the build. On first **SSH** login as **root** you can set a **web console password** (nginx + HTTP Basic Auth + **Let's Encrypt** for the Droplet's **public IPv4**) or leave the password **empty** to **skip nginx** entirely and use **CLI-only** until you run **`/opt/goose/enable-web-console.sh`** later.
+
+## What is Goose?
+
+Goose is an AI agent framework for real work: install packages, run commands, edit files, and iterate with the LLM providers you configure. It supports many providers and extensions (including MCP) and is distributed as a CLI you can install from upstream releases.
+
+## What this 1-Click configures
+
+| Component | Role |
+|-----------|------|
+| **ttyd** | Web terminal bound to `127.0.0.1:7681` (not exposed directly). |
+| **nginx** | Listens on 80/443, terminates TLS, enforces **HTTP Basic Auth**, reverse-proxies WebSockets to ttyd. |
+| **Certbot (venv)** | `/opt/certbot-venv` with Certbot 5.4+ for **IP address** certificates using Let's Encrypt's **shortlived** profile (six-day lifetime; renewal is scheduled). |
+| **First-login script** | `/opt/goose/first-login-setup.sh` (hooked from `/root/.bashrc` until setup completes). |
+| **Enable web later** | `/opt/goose/enable-web-console.sh` — prompts for password, starts nginx, TLS, Certbot, renewal cron. |
+
+## System requirements
+
+| Use case | RAM | CPU |
+|----------|-----|-----|
+| CLI + web console, cloud models | 1 GB | 1 vCPU |
+| Heavier local tooling / large repos | 2–4 GB+ | 2 vCPU+ |
+
+## Getting started
+
+### 1. Create the Droplet
+
+Choose this 1-Click in the DigitalOcean Marketplace and wait for provisioning.
+
+### 2. SSH as root (required once)
+
+```bash
+ssh root@YOUR_DROPLET_IPV4
+```
+
+The first interactive login runs the setup wizard. It will:
+
+1. **Prompt for a web console password.** Enter the same password twice, **minimum 8 characters**, to enable nginx, HTTP Basic Auth, and the browser terminal. **Leave both prompts empty** (press Enter twice each time) if you **do not** want nginx or a public HTTPS web UI; **Goose CLI** is still installed, and you can enable the web console later with **`/opt/goose/enable-web-console.sh`**.
+2. If you set a password: a **local copy** is saved at `/root/.goose_web_console_password.txt` (mode `600`). Delete this file after you store the password elsewhere.
+3. Install the **Goose CLI** using the official script:
+
+   ```bash
+   curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash
+   ```
+
+   The wizard exports `GOOSE_BIN_DIR=/usr/local/bin` and `CONFIGURE=false` so install is non-interactive; run `goose configure` when you want provider setup.
+
+4. **Only if you set a web password:** run **Certbot** for a **Let's Encrypt** certificate on the Droplet's **public IPv4** and configure renewal. nginx stays **stopped and disabled** when you skip the web password.
+
+### 3. Open the web console (if enabled)
+
+If you set a web password at first login, or you already ran **`/opt/goose/enable-web-console.sh`**, open in a browser:
+
+```text
+https://YOUR_DROPLET_IPV4/
+```
+
+- **Username:** `goose`  
+- **Password:** the value you chose  
+
+Your browser may briefly show a warning if the temporary **self-signed** certificate is still in use (for example, if Let's Encrypt issuance failed). After a successful issuance, the certificate chain is publicly trusted (short-lived IP profile).
+
+### 3b. Enable the web console later
+
+If you skipped the web password on first login, run as **root** over SSH:
+
+```bash
+/opt/goose/enable-web-console.sh
+```
+
+You will be prompted for a password (8+ characters). The script configures nginx, starts it, requests a Let's Encrypt IP certificate when possible, and installs the renewal cron job.
+
+### 4. Use Goose on the CLI
+
+```bash
+goose configure    # add API keys / providers when you are ready
+goose --help
+```
+
+## TLS, Let's Encrypt, and IP addresses
+
+Let's Encrypt issues **IP address** certificates only under the **shortlived** profile (about **six days**). This image:
+
+- Installs Certbot in `/opt/certbot-venv` (newer than the Ubuntu `apt` Certbot, so `--ip-address` and `--preferred-profile shortlived` work with **webroot** while nginx keeps serving port 80).
+- Adds `/etc/cron.d/goose-certbot-renew` to run `certbot renew` twice daily with a **deploy hook** that reloads nginx (only after the web console has been enabled with a password).
+
+If issuance fails (firewall, rate limits, or connectivity), nginx continues using `/etc/ssl/goose/selfsigned.crt` until you fix the issue and re-run Certbot manually (see `/opt/goose/README.txt`).
+
+## Firewall and ports
+
+UFW is configured via `014-ufw-nginx.sh`: **SSH**, **HTTP**, and **HTTPS** are allowed. ttyd is **not** exposed on a public port; only nginx is (when nginx is running). If you never use the web console, you may tighten UFW if you prefer.
+
+## Files and paths
+
+| Path | Purpose |
+|------|---------|
+| `/opt/goose/README.txt` | Operator quick reference |
+| `/opt/goose/first-login-setup.sh` | First-login wizard |
+| `/opt/goose/enable-web-console.sh` | Prompt for password; start nginx, TLS, Certbot, cron |
+| `/root/.goose-web-console-disabled` | Present if you skipped the web password at first login |
+| `/opt/goose/nginx-*.conf.tpl` | nginx templates used during boot / setup |
+| `/etc/nginx/.goose-ttyd.htpasswd` | HTTP Basic credentials for the web console |
+| `/root/.goose_web_console_password.txt` | Plain-text copy of the web password (remove when appropriate) |
+| `/root/.goose-first-login-done` | Marker that first-login completed |
+| `/opt/certbot-venv/bin/certbot` | Certbot for issuance and renewal |
+
+## Documentation and support
+
+- **Upstream project:** https://github.com/aaif-goose/goose  
+- **DigitalOcean Community:** https://www.digitalocean.com/community  
+
+This Marketplace image is maintained for convenience; for product bugs and features, use the upstream Goose project.

--- a/goose-24-04/scripts/goose.sh
+++ b/goose-24-04/scripts/goose.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+mkdir -p /var/www/html/.well-known/acme-challenge
+
+python3 -m venv /opt/certbot-venv
+/opt/certbot-venv/bin/pip install --disable-pip-version-check --no-cache-dir 'certbot>=5.4,<6'
+
+rm -f /etc/nginx/sites-enabled/default
+
+cat >/etc/nginx/sites-available/goose-bootstrap <<'NGINX'
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    root /var/www/html;
+    location /.well-known/acme-challenge/ {
+        try_files $uri =404;
+    }
+    location / {
+        return 200 "Image build: replace this Droplet from snapshot for the full Goose console.\n";
+        add_header Content-Type text/plain;
+    }
+}
+NGINX
+
+ln -sf /etc/nginx/sites-available/goose-bootstrap /etc/nginx/sites-enabled/goose-bootstrap
+nginx -t
+systemctl enable nginx
+systemctl restart nginx
+
+systemctl daemon-reload
+systemctl enable ttyd-goose
+
+chmod +x /etc/update-motd.d/99-one-click
+chmod +x /opt/goose/first-login-setup.sh
+chmod +x /opt/goose/enable-web-console.sh
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot

--- a/goose-24-04/template.json
+++ b/goose-24-04/template.json
@@ -1,0 +1,81 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "goose-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "apt-transport-https ca-certificates curl software-properties-common git jq unzip tar openssl nginx ttyd apache2-utils python3 python3-venv python3-pip lsb-release",
+    "application_name": "goose",
+    "application_version": "stable"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "goose-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "goose-24-04/files/opt/",
+      "destination": "/opt/"
+    },
+    {
+      "type": "file",
+      "source": "goose-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "common/scripts/014-ufw-nginx.sh",
+        "goose-24-04/scripts/goose.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Summary**
Adds goose-24-04, a Ubuntu 24.04 Marketplace image for [Goose](https://github.com/aaif-goose/goose): ttyd on localhost, optional nginx reverse proxy with HTTP Basic Auth and Let’s Encrypt (IP + short-lived profile via Certbot in /opt/certbot-venv), and first-login setup that installs the official Goose CLI.

**Highlights**
First SSH: wizard for web password (or empty to skip nginx entirely); installs Goose via upstream download_cli.sh with CONFIGURE=false.
Later: /opt/goose/enable-web-console.sh turns on nginx + TLS + auth if the user skipped the web UI at first login.
Docs: listing.md, MOTD, and /opt/goose/README.txt describe behavior, paths, and TLS renewal.