### PR TITLE
Add codex support in openclaw 1click and fix UI

### DIFF
--- a/openclaw-24-04/files/etc/setup_wizard.sh
+++ b/openclaw-24-04/files/etc/setup_wizard.sh
@@ -1,15 +1,64 @@
 #!/bin/bash
 
-# OpenClaw Token Setup Script
-# Run this script to configure OpenClaw with a AI API key
+# OpenClaw first-login setup (DigitalOcean 1-Click)
+# Configures models and gateway; see authoritative docs at the URLs printed below.
 
-DROPL_IP=$(hostname -I | awk '{print$1}')
-PS3="Select a provider (1-5): "
-options=("GradientAI" "OpenAI" "Anthropic" "OpenRouter" "OpenClaw Model Setup")
+DOCS_MAIN="https://docs.clawd.bot/"
+DOCS_OPENAI="https://github.com/openclaw/openclaw/blob/main/docs/providers/openai.md"
+DOCS_REPO="https://github.com/openclaw/openclaw"
+
+# Public IPv4 from DO metadata (matches browser URL). Private IP is often first in
+# hostname -I — using only that caused gateway.controlUi.allowedOrigins mismatches
+# ("origin not allowed") when users opened https://<public-ip>/.
+droplet_public_ip() {
+  curl -fsS --retry 5 --retry-connrefused --max-time 3 \
+    http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true
+}
+
+DROPL_PRIVATE_IP=$(hostname -I | awk '{print $1}')
+DROPL_PUBLIC_IP=$(droplet_public_ip)
+if [ -n "$DROPL_PUBLIC_IP" ]; then
+  DROPL_IP="$DROPL_PUBLIC_IP"
+  DASHBOARD_HOST="$DROPL_PUBLIC_IP"
+else
+  DROPL_IP="$DROPL_PRIVATE_IP"
+  DASHBOARD_HOST="$DROPL_PRIVATE_IP"
+fi
+
+remove_first_login_hook() {
+  if [ -f /root/.bashrc ]; then
+    sed -i '/chmod +x \/etc\/setup_wizard\.sh/d' /root/.bashrc
+    sed -i '/\/etc\/setup_wizard\.sh/d' /root/.bashrc
+  fi
+}
+
+PS3="Select a provider (1-6): "
+options=(
+  "GradientAI"
+  "OpenAI (API key — usage billing)"
+  "OpenAI Codex (ChatGPT / subscription OAuth)"
+  "Anthropic"
+  "OpenRouter"
+  "OpenClaw Model Setup"
+)
+
+echo ""
+echo "========================================================================"
+echo "  OpenClaw — authoritative documentation"
+echo "========================================================================"
+echo "  Project docs:     ${DOCS_MAIN}"
+echo "  OpenAI & Codex:   ${DOCS_OPENAI}"
+echo "  Source / issues:  ${DOCS_REPO}"
+echo "========================================================================"
+echo ""
+echo "OpenAI has two different setups: an API key (platform billing) vs"
+echo "ChatGPT/Codex subscription (OAuth). They are not interchangeable — see the"
+echo "OpenAI provider doc above before changing config."
+echo ""
+echo "--- AI Provider Selector ---"
 
 selected_provider="n/a"
 target_config="n/a"
-echo "--- AI Provider Selector ---"
 
 select opt in "${options[@]}"
 do
@@ -21,11 +70,20 @@ do
         echo "Configured models include Llama 3.3 70B, DeepSeek R1 Distill Llama 70B, GPT OSS 120B, Claude 4.5 Sonnet, MiniMax M2.5, Kimi K2.5, and GLM 5 (full list: /etc/config/gradientai.json)."
         break
         ;;
-    "OpenAI")
+    "OpenAI (API key — usage billing)")
         selected_provider="OpenAI"
         target_config="/etc/config/openai.json"
         env_key_name="OPENAI_API_KEY"
-        echo "You selected OpenAI."
+        echo "You selected OpenAI via API key (OPENAI_API_KEY)."
+        echo "For ChatGPT / Codex subscription (OAuth), cancel (Ctrl+C) and choose"
+        echo "'OpenAI Codex' instead, or see: ${DOCS_OPENAI}"
+        break
+        ;;
+    "OpenAI Codex (ChatGPT / subscription OAuth)")
+        selected_provider="OpenAI Codex"
+        target_config=""
+        echo "You selected OpenAI Codex (subscription OAuth via OpenClaw onboard)."
+        echo "Follow the prompts. Official details: ${DOCS_OPENAI}"
         break
         ;;
     "Anthropic")
@@ -55,45 +113,83 @@ do
   esac
 done
 
+echo ""
 echo "${selected_provider} Configuration Setup"
 echo "=============================="
 echo ""
+
+mkdir -p /home/openclaw/.openclaw
 
 if [[ "$selected_provider" == "OpenClaw Model Setup" ]]; then
   /opt/openclaw-cli.sh configure --section model
   jq -s '.[0] * .[1]' /home/openclaw/.openclaw/openclaw.json ${target_config} > /home/openclaw/.openclaw/openclaw.json.bak
   cp /home/openclaw/.openclaw/openclaw.json.bak /home/openclaw/.openclaw/openclaw.json
+elif [[ "$selected_provider" == "OpenAI Codex" ]]; then
+  echo "Starting OpenClaw onboarding for Codex (interactive; browser / device flow may be required)..."
+  echo "Reference: ${DOCS_OPENAI}"
+  if /opt/openclaw-cli.sh onboard --auth-choice openai-codex; then
+    :
+  else
+    echo ""
+    echo "Note: 'onboard --auth-choice openai-codex' failed or is unavailable in this CLI version."
+    echo "Running generic interactive onboard; choose OpenAI / Codex when prompted."
+    echo "Docs: ${DOCS_MAIN}"
+    /opt/openclaw-cli.sh onboard || true
+  fi
+  if [ ! -f /home/openclaw/.openclaw/openclaw.json ]; then
+    echo "Seeding minimal gateway config (onboard did not create openclaw.json)."
+    cp /etc/config/openclaw.json /home/openclaw/.openclaw/openclaw.json
+    chown openclaw:openclaw /home/openclaw/.openclaw/openclaw.json
+  fi
 else
-  while [ -z "$model_access_key" ]
+  while [ -z "${model_access_key:-}" ]
     do
       read -p "Enter ${selected_provider} model access key: " model_access_key
     done
+
+  if [[ "$selected_provider" == "GradientAI" ]]; then
+      jq --arg key "$model_access_key" '.models.providers.gradient.apiKey = $key' "$target_config" > /home/openclaw/.openclaw/openclaw.json
+  elif [[ "$selected_provider" == "OpenRouter" ]]; then
+      jq --arg key "$model_access_key" '.models.providers.openrouter.apiKey = $key' "$target_config" > /home/openclaw/.openclaw/openclaw.json
+  else
+      cp ${target_config} /home/openclaw/.openclaw/openclaw.json
+      echo -e "\n${env_key_name}=${model_access_key}" >> /opt/openclaw.env
+  fi
 fi
 
-mkdir -p /home/openclaw/.openclaw
-
-if [[ "$selected_provider" == "GradientAI" ]]; then
-    jq --arg key "$model_access_key" '.models.providers.gradient.apiKey = $key' "$target_config" > /home/openclaw/.openclaw/openclaw.json
-elif [[ "$selected_provider" == "OpenRouter" ]]; then
-    jq --arg key "$model_access_key" '.models.providers.openrouter.apiKey = $key' "$target_config" > /home/openclaw/.openclaw/openclaw.json
-elif [[ "$selected_provider" != "OpenClaw Model Setup" ]]; then
-    cp ${target_config} /home/openclaw/.openclaw/openclaw.json
-    echo -e "\n${env_key_name}=${model_access_key}" >> /opt/openclaw.env
-fi
-
-GATEWAY_TOKEN=$(grep "^OPENCLAW_GATEWAY_TOKEN=" /opt/openclaw.env 2>/dev/null | cut -d'=' -f2)
+GATEWAY_TOKEN=$(grep "^OPENCLAW_GATEWAY_TOKEN=" /opt/openclaw.env 2>/dev/null | cut -d'=' -f2-)
 
 jq --arg key "${GATEWAY_TOKEN}" '.gateway.auth.token = $key' /home/openclaw/.openclaw/openclaw.json > /home/openclaw/.openclaw/openclaw.json.tmp
 mv /home/openclaw/.openclaw/openclaw.json.tmp /home/openclaw/.openclaw/openclaw.json
 
-jq --arg key "https://${DROPL_IP}" '.gateway.controlUi.allowedOrigins = [ $key ]' /home/openclaw/.openclaw/openclaw.json > /home/openclaw/.openclaw/openclaw.json.tmp
+# Control UI Origin must match the URL users type in the browser (usually public IP).
+jq \
+  --arg pub "${DROPL_PUBLIC_IP}" \
+  --arg prv "${DROPL_PRIVATE_IP}" \
+  '.gateway.controlUi.allowedOrigins = (
+      if ($pub != "" and $pub != $prv) then
+        ["https://" + $pub, "http://" + $pub, "https://" + $prv, "http://" + $prv]
+      elif ($pub != "") then
+        ["https://" + $pub, "http://" + $pub]
+      else
+        ["https://" + $prv, "http://" + $prv]
+      end
+    )' /home/openclaw/.openclaw/openclaw.json > /home/openclaw/.openclaw/openclaw.json.tmp
 mv /home/openclaw/.openclaw/openclaw.json.tmp /home/openclaw/.openclaw/openclaw.json
+
+echo "gateway.controlUi.allowedOrigins -> $(jq -c '.gateway.controlUi.allowedOrigins' /home/openclaw/.openclaw/openclaw.json)"
+echo "(Open the Control UI at https://${DASHBOARD_HOST}/ so the browser Origin matches.)"
 
 chown openclaw:openclaw /home/openclaw/.openclaw/openclaw.json
 chmod 0600 /home/openclaw/.openclaw/openclaw.json
 
 echo ""
-echo "${selected_provider} key configured successfully."
+if [[ "$selected_provider" == "OpenAI Codex" ]]; then
+  echo "OpenClaw Codex onboarding step finished. Run /opt/openclaw-cli.sh doctor if your CLI version supports it."
+else
+  echo "${selected_provider} key configured successfully."
+fi
+echo "Authoritative docs: ${DOCS_MAIN} | OpenAI/Codex: ${DOCS_OPENAI}"
 echo "Restarting OpenClaw service..."
 systemctl restart openclaw
 
@@ -130,6 +226,9 @@ fi
 
 printf "\nSince version 1.26 OpenClaw requires pairing the Control UI (dashboard) before it can be used.\n"
 printf "The next steps open the dashboard in your browser and approve the pending request.\n"
+printf "If you still see \"pairing required\" after connecting, run (as root):\n"
+printf "  sudo /opt/openclaw-approve-ui-pairing.sh\n"
+printf "Documentation: %s\n" "${DOCS_MAIN}"
 
 while true; do
     read -p "Do you want to run pairing automation now? (yes/no): " yn
@@ -140,6 +239,7 @@ while true; do
             ;;
         no|n )
             echo "OpenClaw setup complete! Happy clawing!"
+            echo "Docs: ${DOCS_MAIN} | ${DOCS_OPENAI}"
 
             cp /etc/skel/.bashrc /root
             exit 0
@@ -150,7 +250,7 @@ while true; do
     esac
 done
 
-DASHBOARD_URL="https://${DROPL_IP}"
+DASHBOARD_URL="https://${DASHBOARD_HOST}"
 
 printf '\n======================================\n'
 printf '  Browser Pairing Setup\n'
@@ -175,6 +275,8 @@ while true; do
             ;;
         exit|e )
             echo "OpenClaw setup complete! Happy clawing!"
+            echo "Docs: ${DOCS_MAIN} | ${DOCS_OPENAI}"
+            remove_first_login_hook
             exit 0
             ;;
         * )
@@ -189,15 +291,23 @@ for attempt in $(seq 1 10); do
     /opt/openclaw-cli.sh devices list --token="${GATEWAY_TOKEN}" > "$BROWSER_TMPFILE" 2>&1 || true
 
     OUTPUT=$(sed -n '/Pending/,/Paired/p' "$BROWSER_TMPFILE")
-    REQUEST_IDS=($(echo "$OUTPUT" | grep -oP '[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}'))
+    REQUEST_IDS=($(echo "$OUTPUT" | grep -oE '[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}' || true))
     COUNT=${#REQUEST_IDS[@]}
 
     if [ "$COUNT" -ge 1 ]; then
         printf "Pairing request(s) found (%d)...\n" "$COUNT"
+        APPROVE_FAILED=false
         for rid in "${REQUEST_IDS[@]}"; do
-            /opt/openclaw-cli.sh devices approve "$rid" --token="${GATEWAY_TOKEN}" > /dev/null 2>&1 || true
+            if ! /opt/openclaw-cli.sh devices approve "$rid" --token="${GATEWAY_TOKEN}" > /dev/null 2>&1; then
+                APPROVE_FAILED=true
+            fi
         done
-        BROWSER_PAIR_SUCCESS=true
+        if [ "$APPROVE_FAILED" = true ]; then
+            printf "Approval command failed; gateway may still be starting.\n"
+            BROWSER_PAIR_SUCCESS=false
+        else
+            BROWSER_PAIR_SUCCESS=true
+        fi
         break
     fi
 
@@ -209,9 +319,20 @@ rm -f "$BROWSER_TMPFILE"
 if [ "$BROWSER_PAIR_SUCCESS" = true ]; then
     printf "Pairing request approved! Refresh the page to open dashboard.\n\nSetup complete. You should now be able to refresh dashboard UI and start using your OpenClaw 1-Click!\n"
     printf "🔧 You can launch OpenClaw TUI using:\n\t$ /opt/openclaw-tui.sh\n"
+    printf "\nDocumentation:\n  %s\n  %s\n" "${DOCS_MAIN}" "${DOCS_OPENAI}"
     cp /etc/skel/.bashrc /root
     exit 0
 else
-    echo "Error: No pending requests found after 10 attempts. Please proceed with manual pairing." >&2
-    exit 1
+    echo "Error: No pending requests found after 10 attempts." >&2
+    echo "" >&2
+    echo "Manual Control UI pairing:" >&2
+    echo "  1. Keep the dashboard open at ${DASHBOARD_URL}" >&2
+    echo "  2. Ensure the gateway token is pasted and you clicked Connect." >&2
+    echo "  3. As root, run:  sudo /opt/openclaw-approve-ui-pairing.sh" >&2
+    echo "     (Or: /opt/openclaw-cli.sh devices list --token=\"...\" then devices approve <id>)" >&2
+    echo "  4. Refresh the browser." >&2
+    echo "" >&2
+    echo "Docs: ${DOCS_MAIN}" >&2
+    remove_first_login_hook
+    exit 0
 fi

--- a/openclaw-24-04/files/etc/update-motd.d/99-one-click
+++ b/openclaw-24-04/files/etc/update-motd.d/99-one-click
@@ -2,8 +2,10 @@
 #
 # Configured as part of the DigitalOcean 1-Click Image build process
 
-myip=$(hostname -I | awk '{print$1}')
-gateway_token=$(grep "^OPENCLAW_GATEWAY_TOKEN=" /opt/openclaw.env 2>/dev/null | cut -d'=' -f2)
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print$1}')}"
+gateway_token=$(grep "^OPENCLAW_GATEWAY_TOKEN=" /opt/openclaw.env 2>/dev/null | cut -d'=' -f2-)
 
 cat <<EOF
 ********************************************************************************
@@ -15,8 +17,12 @@ on the channels you already use (WhatsApp, Telegram, Slack, Discord, and more).
 
 🌐 Control UI & Gateway Access:
   Dashboard URL: https://$myip
+  (Use this URL in the browser — it must match gateway.controlUi.allowedOrigins.)
   (Paste token in dashboard settings if prompted)
   Gateway Token: $gateway_token
+
+  Stuck on "pairing required"? After you connect in the browser, run as root:
+    sudo /opt/openclaw-approve-ui-pairing.sh
 
 📝 Configuration:
   Edit settings: /opt/openclaw.env
@@ -32,6 +38,7 @@ on the channels you already use (WhatsApp, Telegram, Slack, Discord, and more).
   - /opt/status-openclaw.sh    (show status and token)
   - /opt/update-openclaw.sh    (update to latest version)
   - /opt/openclaw-cli.sh       (run CLI commands)
+  - /opt/openclaw-approve-ui-pairing.sh  (approve Control UI after "pairing required")
 
 🔒 Enable HTTPS (TLS):
   Point your domain to this droplet, then run:
@@ -46,6 +53,7 @@ on the channels you already use (WhatsApp, Telegram, Slack, Discord, and more).
 
 📚 Documentation: https://docs.clawd.bot/
 🔗 GitHub: https://github.com/openclaw/openclaw
+📘 OpenAI vs Codex (API key vs subscription): https://github.com/openclaw/openclaw/blob/main/docs/providers/openai.md
 
 🔧 You can launch OpenClaw TUI using:
   $ /opt/openclaw-tui.sh

--- a/openclaw-24-04/files/opt/openclaw-approve-ui-pairing.sh
+++ b/openclaw-24-04/files/opt/openclaw-approve-ui-pairing.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Approve pending Control UI (browser) pairing after you open the dashboard,
+# paste the gateway token, and see "pairing required".
+#
+# Run as root:  sudo /opt/openclaw-approve-ui-pairing.sh
+# Docs: https://docs.clawd.bot/
+
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Run as root: sudo $0" >&2
+  exit 1
+fi
+
+if [ ! -r /opt/openclaw.env ]; then
+  echo "Missing /opt/openclaw.env" >&2
+  exit 1
+fi
+
+GATEWAY_TOKEN=$(grep '^OPENCLAW_GATEWAY_TOKEN=' /opt/openclaw.env | cut -d= -f2-)
+if [ -z "$GATEWAY_TOKEN" ]; then
+  echo "OPENCLAW_GATEWAY_TOKEN is not set in /opt/openclaw.env" >&2
+  exit 1
+fi
+
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
+if ! systemctl is-active --quiet openclaw; then
+  echo "openclaw service is not active. Try:" >&2
+  echo "  sudo systemctl restart openclaw" >&2
+  echo "  sudo journalctl -u openclaw -n 100 --no-pager" >&2
+  exit 1
+fi
+
+echo "Waiting for local gateway (127.0.0.1:18789) to respond..."
+for _ in $(seq 1 15); do
+  code=$(curl -so /dev/null -w '%{http_code}' --max-time 2 http://127.0.0.1:18789/ 2>/dev/null || true)
+  if [ "$code" != "000" ] && [ -n "$code" ]; then
+    break
+  fi
+  sleep 2
+done
+
+# Read pending requests with retries because gateway startup can lag.
+for attempt in $(seq 1 10); do
+  /opt/openclaw-cli.sh devices list --token="${GATEWAY_TOKEN}" >"$TMPFILE" 2>&1 || true
+
+  OUTPUT=$(sed -n '/Pending/,/Paired/p' "$TMPFILE" 2>/dev/null || true)
+  # UUID v4 pattern (same as setup wizard)
+  REQUEST_IDS=($(echo "$OUTPUT" | grep -oE '[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}' || true))
+  if [ "${#REQUEST_IDS[@]}" -gt 0 ]; then
+    break
+  fi
+
+  if grep -qi 'gateway timeout' "$TMPFILE"; then
+    echo "Gateway timeout while listing devices (attempt $attempt/10), retrying..."
+  elif [ "$attempt" -lt 10 ]; then
+    echo "No pending requests yet (attempt $attempt/10), retrying..."
+  fi
+  sleep 2
+done
+
+if [ "${#REQUEST_IDS[@]}" -eq 0 ]; then
+  echo "No pending Control UI pairing requests were found."
+  echo ""
+  echo "1. Open the dashboard in your browser (use your droplet public https URL)."
+  echo "2. Paste the gateway token from: grep OPENCLAW_GATEWAY_TOKEN /opt/openclaw.env"
+  echo "3. Click Connect — you should see \"pairing required\"."
+  echo "4. Run this script again within ~60 seconds."
+  echo ""
+  echo "CLI output from devices list:"
+  cat "$TMPFILE"
+  exit 1
+fi
+
+approve_failed=0
+for rid in "${REQUEST_IDS[@]}"; do
+  echo "Approving pairing request: $rid"
+  ok=false
+  for _ in $(seq 1 3); do
+    if /opt/openclaw-cli.sh devices approve "$rid" --token="${GATEWAY_TOKEN}" >/dev/null 2>&1; then
+      ok=true
+      break
+    fi
+    sleep 1
+  done
+  if [ "$ok" = false ]; then
+    echo "Failed to approve request: $rid" >&2
+    approve_failed=1
+  fi
+done
+
+echo ""
+if [ "$approve_failed" -ne 0 ]; then
+  echo "Some approvals failed. Check gateway health/logs:" >&2
+  echo "  sudo systemctl status openclaw --no-pager" >&2
+  echo "  sudo journalctl -u openclaw -n 120 --no-pager" >&2
+  exit 1
+fi
+
+# Verify no pending requests remain.
+/opt/openclaw-cli.sh devices list --token="${GATEWAY_TOKEN}" >"$TMPFILE" 2>&1 || true
+REMAINING=$(sed -n '/Pending/,/Paired/p' "$TMPFILE" | grep -oE '[a-f0-9]{8}-([a-f0-9]{4}-){3}[a-f0-9]{12}' | wc -l | tr -d ' ')
+if [ "${REMAINING:-0}" -gt 0 ]; then
+  echo "Pairing requests are still pending ($REMAINING). Keep dashboard open and run again." >&2
+  exit 1
+fi
+
+echo "Done. Refresh the Control UI tab in your browser."

--- a/openclaw-24-04/files/opt/openclaw-cli.sh
+++ b/openclaw-24-04/files/opt/openclaw-cli.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
-# Helper script to run Openclaw CLI commands as the openclaw user
-su - openclaw -c "openclaw $*"
+# Run OpenClaw CLI as the openclaw user (arguments preserved and shell-safe).
+if [ "$#" -eq 0 ]; then
+  exec su - openclaw -c "openclaw"
+fi
+cmd="openclaw"
+for a in "$@"; do
+  cmd+=" $(printf '%q' "$a")"
+done
+exec su - openclaw -c "$cmd"

--- a/openclaw-24-04/files/opt/status-openclaw.sh
+++ b/openclaw-24-04/files/opt/status-openclaw.sh
@@ -5,12 +5,16 @@ systemctl status openclaw --no-pager
 echo ""
 echo "=== Gateway Token ==="
 if [ -f "/opt/openclaw.env" ]; then
-    grep "^OPENCLAW_GATEWAY_TOKEN=" /opt/openclaw.env | cut -d'=' -f2
+    grep "^OPENCLAW_GATEWAY_TOKEN=" /opt/openclaw.env | cut -d'=' -f2-
 else
     echo "Token not yet generated. Run the onboot script."
 fi
 
 echo ""
-echo "=== Gateway URL ==="
-myip=$(hostname -I | awk '{print$1}')
-echo "http://$myip:18789"
+echo "=== Control UI (browser) ==="
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+priv=$(hostname -I | awk '{print $1}')
+host="${pub:-$priv}"
+echo "  https://${host}/   (Caddy -> gateway on port 18789)"
+echo "  Direct loopback URL (SSH tunnel only): http://127.0.0.1:18789"

--- a/openclaw-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/openclaw-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -15,7 +15,9 @@ fi
 
 # Replace PLACEHOLDER_DOMAIN in Caddyfile with actual IP address
 meta() { curl -fsS --retry 10 --retry-connrefused --max-time 2 "$1"; }
-DROPLET_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+DROPLET_PUBLIC_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+DROPLET_PRIVATE_IP="$(hostname -I | awk '{print $1}')"
+DROPLET_IP="${DROPLET_PUBLIC_IP:-$DROPLET_PRIVATE_IP}"
 
 mv /etc/caddy/Caddyfile.tmp /etc/caddy/Caddyfile
 
@@ -24,6 +26,35 @@ if grep -q "PLACEHOLDER_DOMAIN" /etc/caddy/Caddyfile 2>/dev/null; then
     sed -i "s/PLACEHOLDER_DOMAIN/$DROPLET_IP/" /etc/caddy/Caddyfile
     systemctl enable caddy
 fi
+
+# Seed user config early so Control UI origin checks pass even before wizard completes.
+mkdir -p /home/openclaw/.openclaw
+if [ ! -f /home/openclaw/.openclaw/openclaw.json ]; then
+    cp /etc/config/openclaw.json /home/openclaw/.openclaw/openclaw.json
+fi
+
+GATEWAY_TOKEN="$(grep '^OPENCLAW_GATEWAY_TOKEN=' /opt/openclaw.env 2>/dev/null | cut -d'=' -f2-)"
+if [ -n "$GATEWAY_TOKEN" ] && [ -f /home/openclaw/.openclaw/openclaw.json ]; then
+    jq --arg key "$GATEWAY_TOKEN" '.gateway.auth.token = $key' /home/openclaw/.openclaw/openclaw.json > /home/openclaw/.openclaw/openclaw.json.tmp
+    mv /home/openclaw/.openclaw/openclaw.json.tmp /home/openclaw/.openclaw/openclaw.json
+
+    jq \
+      --arg pub "$DROPLET_PUBLIC_IP" \
+      --arg prv "$DROPLET_PRIVATE_IP" \
+      '.gateway.controlUi.allowedOrigins = (
+          if ($pub != "" and $pub != $prv) then
+            ["https://" + $pub, "http://" + $pub, "https://" + $prv, "http://" + $prv]
+          elif ($pub != "") then
+            ["https://" + $pub, "http://" + $pub]
+          else
+            ["https://" + $prv, "http://" + $prv]
+          end
+        )' /home/openclaw/.openclaw/openclaw.json > /home/openclaw/.openclaw/openclaw.json.tmp
+    mv /home/openclaw/.openclaw/openclaw.json.tmp /home/openclaw/.openclaw/openclaw.json
+fi
+chown -R openclaw:openclaw /home/openclaw/.openclaw
+chmod 700 /home/openclaw/.openclaw
+chmod 600 /home/openclaw/.openclaw/openclaw.json 2>/dev/null || true
 
 # Remove the ssh force logout command
 sed -e '/Match User root/d' -e '/.*ForceCommand.*droplet.*/d' -i /etc/ssh/sshd_config

--- a/openclaw-24-04/scripts/openclaw.sh
+++ b/openclaw-24-04/scripts/openclaw.sh
@@ -54,6 +54,7 @@ chmod +x /opt/openclaw-cli.sh
 chmod +x /opt/setup-openclaw-domain.sh
 chmod +x /etc/setup_wizard.sh
 chmod +x /opt/openclaw-tui.sh
+chmod +x /opt/openclaw-approve-ui-pairing.sh
 
 # Enable but don't start the service yet (will start after onboot configuration)
 systemctl enable openclaw

--- a/openclaw-24-04/template.json
+++ b/openclaw-24-04/template.json
@@ -4,7 +4,7 @@
     "image_name": "openclaw-snap-{{timestamp}}",
     "apt_packages": "procps file apt-transport-https ca-certificates curl software-properties-common git build-essential libsystemd-dev jq unzip docker.io gnupg fail2ban",
     "application_name": "OpenClaw",
-    "application_version": "v2026.4.9"
+    "application_version": "v2026.5.6"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [

--- a/openclaw-24-04/util/README.md
+++ b/openclaw-24-04/util/README.md
@@ -89,6 +89,39 @@ wget -O - https://raw.githubusercontent.com/digitalocean/droplet-1-clicks/main/o
    - `/opt/openclaw-cli.sh` - run CLI commands
    - `/opt/openclaw-tui.sh` - launch TUI interface
 
+## Testing the OpenClaw 1-Click Control UI (origin + pairing)
+
+Use these checks on a **fresh** or **re-provisioned** Droplet after the first-login wizard (or after editing config manually).
+
+1. **Public IP matches browser URL** (avoids `origin not allowed`):
+
+   ```bash
+   curl -fsS http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address
+   jq -r '.gateway.controlUi.allowedOrigins[]?' /home/openclaw/.openclaw/openclaw.json
+   ```
+
+   You should see `https://<that-public-ip>` in `allowedOrigins`. Open the Control UI at exactly that URL.
+
+2. **Caddy proxies to the gateway:**
+
+   ```bash
+   systemctl is-active caddy openclaw
+   curl -skI "https://$(curl -fsS http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address)/" | head -5
+   ```
+
+3. **Pairing after "pairing required":** In the browser, paste the gateway token and click Connect. Then on the Droplet:
+
+   ```bash
+   sudo /opt/openclaw-approve-ui-pairing.sh
+   ```
+
+   Refresh the browser. For debugging:
+
+   ```bash
+   TOKEN=$(grep '^OPENCLAW_GATEWAY_TOKEN=' /opt/openclaw.env | cut -d= -f2-)
+   sudo /opt/openclaw-cli.sh devices list --token="$TOKEN"
+   ```
+
 ## Troubleshooting
 
 ### Service won't start


### PR DESCRIPTION
Implemented a focused reliability and UX fix-set for OpenClaw 1-Click.

* Clarified OpenAI setup paths in the first-login wizard: added explicit choices for OpenAI API key vs OpenAI Codex OAuth/subscription, with links to authoritative docs so users don’t get misled by ambiguous prompts.
* Added authoritative documentation links throughout: wizard + MOTD now point to OpenClaw docs, GitHub, and the OpenAI/Codex provider guide.
* Fixed Control UI “origin not allowed”: switched to DigitalOcean metadata public IP detection and now writes gateway.controlUi.allowedOrigins for public/private addresses (including both https:// and http:// variants), so browser origin matches out of the box.
* Made the fix apply earlier in lifecycle: on-boot now seeds /home/openclaw/.openclaw/openclaw.json and sets gateway token + allowed origins even before wizard completion, reducing first-run mismatch risk.
Improved pairing flow for “pairing required”: added /opt/openclaw-approve-ui-pairing.sh helper and integrated guidance in wizard/MOTD for manual recovery.
* Hardened pairing helper against startup races: added gateway readiness checks, retries, stricter success/failure handling, and pending-request verification so it doesn’t print false success.
* Improved CLI wrapper robustness: /opt/openclaw-cli.sh now preserves multi-argument commands safely (important for onboarding flags like Codex auth choice).
* Improved operational visibility: updated status/MOTD output to show correct Control UI URL and actionable troubleshooting commands.

Net result: users can now distinguish API key vs Codex setup, connect to Control UI without origin mismatch edits, and complete/repair pairing with a documented and reliable path.