### PR TITLE
ZeroClaw 1-Click: preset Gradient from GRADIENT_KEY env on boot.

### DIFF
--- a/zeroclaw-24-04/Catalog-README.md
+++ b/zeroclaw-24-04/Catalog-README.md
@@ -28,14 +28,22 @@ With a memory footprint under 5MB and cold start times under 10ms, ZeroClaw is d
 ## Getting Started
 
 1. **Create a Droplet** using this 1-Click image
-2. **SSH into your Droplet** — the setup wizard will run automatically on first login
-3. **Select an AI provider** (DigitalOcean Gradient, OpenAI, Anthropic, or OpenRouter). For Gradient, choose an inference model (default: Kimi K2.5).
-4. **Enter your API key** when prompted
-5. **Access the gateway** at `https://your-droplet-ip`
+2. **Configure inference** using one of:
+   - Set `GRADIENT_KEY` (and optional `GRADIENT_MODEL`) as droplet environment variables at create time — Gradient is applied on first boot with no wizard
+   - Edit `/opt/zeroclaw.env`, then reboot or run `sudo /opt/apply-gradient-from-env.sh`
+   - SSH in and complete the interactive setup wizard on first login
+3. **Access the gateway** at `https://your-droplet-ip`
 
 ### DigitalOcean Gradient
 
-Gradient uses a single model access key for serverless inference at `https://inference.do-ai.run/v1`. The default model is **Kimi K2.5** (`kimi-k2.5`). During first-login setup you can choose **Kimi K2.5**, **MiniMax M2.5** (`minimax-m2.5`), **GLM 5** (`glm-5`), or **Claude Sonnet 4.5** (`anthropic-claude-4.5-sonnet`). Re-run `sudo /etc/setup_wizard.sh` to switch models, or edit `default_model` in `/home/zeroclaw/.zeroclaw/config.toml`.
+Gradient uses a single model access key for serverless inference at `https://inference.do-ai.run/v1`. The default model is **Kimi K2.5** (`kimi-k2.5`).
+
+| Variable | Purpose |
+|----------|---------|
+| `GRADIENT_KEY` | Gradient model access key (required for auto-config) |
+| `GRADIENT_MODEL` | Optional model id (default: `kimi-k2.5`) |
+
+Supported model IDs include **kimi-k2.5**, **minimax-m2.5**, **glm-5**, and **anthropic-claude-4.5-sonnet**. During interactive setup you can pick a model from the menu. Re-run `sudo /etc/setup_wizard.sh` to switch providers, or edit `default_model` in `/home/zeroclaw/.zeroclaw/config.toml`.
 
 ## Managing ZeroClaw
 

--- a/zeroclaw-24-04/README.md
+++ b/zeroclaw-24-04/README.md
@@ -12,13 +12,26 @@ This Packer template builds a DigitalOcean Marketplace 1-Click image for [ZeroCl
 
 ## How It Works
 
-ZeroClaw is installed as a pre-built binary at `/usr/local/bin/zeroclaw`. It runs as a systemd service under a dedicated `zeroclaw` user. On first SSH login, an interactive setup wizard prompts you to select an AI provider (DigitalOcean Gradient, OpenAI, Anthropic, or OpenRouter), choose a Gradient inference model when applicable, and enter your API key.
+ZeroClaw is installed as a pre-built binary at `/usr/local/bin/zeroclaw`. It runs as a systemd service under a dedicated `zeroclaw` user.
+
+On first boot, `001_onboot` sources `/etc/environment` and runs `/opt/apply-gradient-from-env.sh`. If `GRADIENT_KEY` is set (droplet environment variables or `/opt/zeroclaw.env`), Gradient is configured automatically and the interactive wizard is skipped. Otherwise, on first SSH login, an interactive setup wizard prompts you to select an AI provider (DigitalOcean Gradient, OpenAI, Anthropic, or OpenRouter), choose a Gradient inference model when applicable, and enter your API key.
 
 Caddy provides HTTPS via IP-based TLS certificates from Let's Encrypt, reverse-proxying to ZeroClaw's gateway on port 42617.
 
 ### DigitalOcean Gradient
 
-When you choose **DigitalOcean Gradient** in the setup wizard, inference uses `https://inference.do-ai.run/v1` with a Gradient model access key. The default model is **Kimi K2.5** (`kimi-k2.5`). You can pick another model during setup or change `default_model` in `/home/zeroclaw/.zeroclaw/config.toml` later.
+When you choose **DigitalOcean Gradient** in the setup wizard (or pre-configure via env), inference uses `https://inference.do-ai.run/v1` with a Gradient model access key. The default model is **Kimi K2.5** (`kimi-k2.5`). You can pick another model during setup or change `default_model` in `/home/zeroclaw/.zeroclaw/config.toml` later.
+
+| Variable | Purpose |
+|----------|---------|
+| `GRADIENT_KEY` | DigitalOcean Gradient model access key |
+| `GRADIENT_MODEL` | Optional model id (default: `kimi-k2.5`) |
+
+Set these as droplet environment variables at create time, or edit `/opt/zeroclaw.env`, then reboot or run:
+
+```bash
+sudo /opt/apply-gradient-from-env.sh
+```
 
 | Model | Model ID |
 |-------|----------|
@@ -50,6 +63,7 @@ ZeroClaw is extremely lightweight (<5MB RAM, ~8.8MB binary). The minimum `s-1vcp
 | `files/etc/systemd/system/zeroclaw.service` | Systemd unit file |
 | `files/etc/caddy/Caddyfile.tmp` | Caddy config template |
 | `files/etc/update-motd.d/99-one-click` | MOTD with usage instructions |
-| `files/opt/zeroclaw.env` | Environment configuration |
+| `files/opt/zeroclaw.env` | Environment configuration (`GRADIENT_KEY`, `GRADIENT_MODEL`) |
+| `files/opt/apply-gradient-from-env.sh` | Apply Gradient key from env on boot |
 | `files/opt/*.sh` | Helper scripts (restart, status, update, domain, cli) |
 | `files/var/lib/cloud/scripts/per-instance/001_onboot` | First-boot initialization |

--- a/zeroclaw-24-04/files/etc/setup_wizard.sh
+++ b/zeroclaw-24-04/files/etc/setup_wizard.sh
@@ -3,9 +3,40 @@
 # ZeroClaw Provider Setup Script
 # Run this script to configure ZeroClaw with an AI API key
 
-DROPL_IP=$(hostname -I | awk '{print$1}')
+SETUP_MARKER=/home/zeroclaw/.zeroclaw/gradient-configured
 CONFIG_DIR="/home/zeroclaw/.zeroclaw"
 CONFIG_FILE="${CONFIG_DIR}/config.toml"
+
+remove_first_login_hook() {
+  if [ -f /root/.bashrc ]; then
+    sed -i '/chmod +x \/etc\/setup_wizard\.sh/d' /root/.bashrc
+    sed -i '/\/etc\/setup_wizard\.sh/d' /root/.bashrc
+  fi
+}
+
+gradient_already_configured() {
+  local api_key
+  [ -f "$CONFIG_FILE" ] || return 1
+  api_key=$(grep -E '^api_key\s*=' "$CONFIG_FILE" 2>/dev/null | tail -n 1 | sed 's/^api_key\s*=\s*"\?\([^"]*\)"\?.*/\1/') || return 1
+  case "$api_key" in
+    ''|PLACEHOLDER|*'${'*) return 1 ;;
+  esac
+  return 0
+}
+
+DROPL_IP=$(hostname -I | awk '{print$1}')
+
+if [ "$1" != "--force" ]; then
+  if [ -f "$SETUP_MARKER" ] || gradient_already_configured; then
+    echo "ZeroClaw provider is already configured. Skipping setup."
+    remove_first_login_hook
+    exit 0
+  fi
+  if [ -x /opt/apply-gradient-from-env.sh ] && /opt/apply-gradient-from-env.sh; then
+    remove_first_login_hook
+    exit 0
+  fi
+fi
 
 PS3="Select a provider (1-4): "
 options=("DigitalOcean Gradient" "OpenAI" "Anthropic" "OpenRouter")
@@ -104,6 +135,13 @@ sed -i 's/^port = .*/port = 42617/' "${CONFIG_FILE}"
 
 chown zeroclaw:zeroclaw "${CONFIG_FILE}"
 chmod 0600 "${CONFIG_FILE}"
+
+if [[ "$onboard_provider" == "custom:https://inference.do-ai.run/v1" ]]; then
+  touch "$SETUP_MARKER"
+  chown zeroclaw:zeroclaw "$SETUP_MARKER" 2>/dev/null || true
+fi
+
+remove_first_login_hook
 
 echo ""
 echo "${selected_provider} key configured successfully."

--- a/zeroclaw-24-04/files/etc/setup_wizard.sh
+++ b/zeroclaw-24-04/files/etc/setup_wizard.sh
@@ -3,7 +3,8 @@
 # ZeroClaw Provider Setup Script
 # Run this script to configure ZeroClaw with an AI API key
 
-SETUP_MARKER=/home/zeroclaw/.zeroclaw/gradient-configured
+ENV_FILE=/opt/zeroclaw.env
+SETUP_MARKER=/root/.zeroclaw_setup_complete
 CONFIG_DIR="/home/zeroclaw/.zeroclaw"
 CONFIG_FILE="${CONFIG_DIR}/config.toml"
 
@@ -22,6 +23,17 @@ gradient_already_configured() {
     ''|PLACEHOLDER|*'${'*) return 1 ;;
   esac
   return 0
+}
+
+write_gradient_env_key() {
+  local key="$1" model="$2"
+  umask 077
+  touch "$ENV_FILE"
+  grep -Ev '^(GRADIENT_KEY|GRADIENT_MODEL)=' "$ENV_FILE" >"${ENV_FILE}.tmp" 2>/dev/null || : >"${ENV_FILE}.tmp"
+  printf 'GRADIENT_KEY=%q\n' "$key" >>"${ENV_FILE}.tmp"
+  printf 'GRADIENT_MODEL=%q\n' "$model" >>"${ENV_FILE}.tmp"
+  mv "${ENV_FILE}.tmp" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
 }
 
 DROPL_IP=$(hostname -I | awk '{print$1}')
@@ -123,22 +135,24 @@ echo "${selected_provider} Configuration Setup"
 echo "=============================="
 echo ""
 
-while [ -z "$model_access_key" ]
-do
-  read -p "Enter ${selected_provider} API key: " model_access_key
+old_histfile="${HISTFILE-}"
+unset HISTFILE
+while [ -z "${model_access_key:-}" ]; do
+  read -rsp "Enter ${selected_provider} API key: " model_access_key
+  echo ""
 done
-
-su - zeroclaw -c "/usr/local/bin/zeroclaw onboard --force --api-key '${model_access_key}' --provider '${onboard_provider}' --model '${onboard_model}'" > /dev/null 2>&1
-
-# Override gateway port to match systemd service expectation
-sed -i 's/^port = .*/port = 42617/' "${CONFIG_FILE}"
-
-chown zeroclaw:zeroclaw "${CONFIG_FILE}"
-chmod 0600 "${CONFIG_FILE}"
+[ -n "${old_histfile:-}" ] && export HISTFILE="$old_histfile"
 
 if [[ "$onboard_provider" == "custom:https://inference.do-ai.run/v1" ]]; then
+  write_gradient_env_key "$model_access_key" "$onboard_model"
+  /opt/apply-gradient-from-env.sh
+else
+  /opt/zeroclaw-run-onboard.sh "$model_access_key" "$onboard_provider" "$onboard_model"
+  umask 077
   touch "$SETUP_MARKER"
-  chown zeroclaw:zeroclaw "$SETUP_MARKER" 2>/dev/null || true
+  chmod 600 "$SETUP_MARKER"
+  systemctl enable zeroclaw
+  systemctl restart zeroclaw
 fi
 
 remove_first_login_hook
@@ -146,8 +160,6 @@ remove_first_login_hook
 echo ""
 echo "${selected_provider} key configured successfully."
 echo "Starting ZeroClaw service..."
-systemctl enable zeroclaw
-systemctl restart zeroclaw
 
 sleep 3
 

--- a/zeroclaw-24-04/files/etc/update-motd.d/99-one-click
+++ b/zeroclaw-24-04/files/etc/update-motd.d/99-one-click
@@ -18,8 +18,10 @@ anywhere. Uses <5MB RAM and starts in <10ms.
 
   Configuration:
     Config file:    /home/zeroclaw/.zeroclaw/config.toml
-    Environment:    /opt/zeroclaw.env
-    Gradient default model: Kimi K2.5 — change via: sudo /etc/setup_wizard.sh
+    Environment:    /opt/zeroclaw.env (GRADIENT_KEY, GRADIENT_MODEL)
+    Gradient:       set GRADIENT_KEY at create time or in /opt/zeroclaw.env
+                    then: sudo /opt/apply-gradient-from-env.sh
+    Default model:  Kimi K2.5 (kimi-k2.5) — or: sudo /etc/setup_wizard.sh
 
   Management Commands:
     Restart service:  systemctl restart zeroclaw

--- a/zeroclaw-24-04/files/opt/apply-gradient-from-env.sh
+++ b/zeroclaw-24-04/files/opt/apply-gradient-from-env.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Apply DigitalOcean Gradient from droplet env or /opt/zeroclaw.env (GRADIENT_KEY, GRADIENT_MODEL).
+# Returns 0 when a key was applied; 1 when skipped (empty or unset placeholder).
+set -euo pipefail
+
+ENV_FILE=/opt/zeroclaw.env
+CONFIG_FILE=/home/zeroclaw/.zeroclaw/config.toml
+SETUP_MARKER=/home/zeroclaw/.zeroclaw/gradient-configured
+DEFAULT_MODEL=kimi-k2.5
+GRADIENT_PROVIDER=custom:https://inference.do-ai.run/v1
+
+remove_setup_wizard_bashrc_hook() {
+    [ -f /root/.bashrc ] || return 0
+    sed -i \
+        -e '/chmod +x \/etc\/setup_wizard\.sh/d' \
+        -e '/\/etc\/setup_wizard\.sh/d' \
+        /root/.bashrc
+}
+
+read_file_kv() {
+    local key="$1"
+    local line val
+    line=$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -n 1) || return 1
+    val="${line#${key}=}"
+    val="${val#\"}"; val="${val%\"}"
+    val="${val#\'}"; val="${val%\'}"
+    printf '%s' "$val"
+}
+
+read_config_value() {
+    local key="$1"
+    local env_val="${!key-}"
+    if env_value_usable "$env_val"; then
+        printf '%s' "$env_val"
+        return 0
+    fi
+    read_file_kv "$key"
+}
+
+write_env_file_kv() {
+    local key="$1" val="$2" tmp="${ENV_FILE}.tmp"
+    touch "$ENV_FILE"
+    grep -v "^${key}=" "$ENV_FILE" >"$tmp" 2>/dev/null || : >"$tmp"
+    printf '%s=%q\n' "$key" "$val" >>"$tmp"
+    mv "$tmp" "$ENV_FILE"
+    chmod 600 "$ENV_FILE"
+}
+
+env_value_usable() {
+    local v="$1"
+    [ -n "$v" ] || return 1
+    case "$v" in
+        *'${'*|PLACEHOLDER*|your_*_here) return 1 ;;
+    esac
+    return 0
+}
+
+normalize_gradient_model() {
+    local m="$1"
+    m="${m#gradient/}"
+    case "$m" in
+        '') printf '%s' "$DEFAULT_MODEL" ;;
+        *) printf '%s' "$m" ;;
+    esac
+}
+
+redact_gradient_secrets_from_system_environment() {
+    local env_file=/etc/environment
+    [ -f "$env_file" ] || return 0
+    grep -Ev '^(GRADIENT_KEY|GRADIENT_MODEL)=' "$env_file" >"${env_file}.tmp" 2>/dev/null || : >"${env_file}.tmp"
+    mv "${env_file}.tmp" "$env_file"
+    chmod 644 "$env_file"
+}
+
+GRADIENT_KEY=$(read_config_value GRADIENT_KEY || true)
+GRADIENT_MODEL=$(read_config_value GRADIENT_MODEL || true)
+
+if ! env_value_usable "$GRADIENT_KEY"; then
+    exit 1
+fi
+
+if ! env_value_usable "$GRADIENT_MODEL"; then
+    GRADIENT_MODEL="$DEFAULT_MODEL"
+fi
+
+PRIMARY_MODEL=$(normalize_gradient_model "$GRADIENT_MODEL")
+write_env_file_kv GRADIENT_KEY "$GRADIENT_KEY"
+write_env_file_kv GRADIENT_MODEL "$PRIMARY_MODEL"
+
+mkdir -p /home/zeroclaw/.zeroclaw
+chown zeroclaw:zeroclaw /home/zeroclaw/.zeroclaw
+
+su - zeroclaw -c "/usr/local/bin/zeroclaw onboard --force \
+  --api-key '${GRADIENT_KEY}' \
+  --provider '${GRADIENT_PROVIDER}' \
+  --model '${PRIMARY_MODEL}'" > /dev/null 2>&1
+
+if [ -f "$CONFIG_FILE" ]; then
+    sed -i 's/^port = .*/port = 42617/' "$CONFIG_FILE"
+    chown zeroclaw:zeroclaw "$CONFIG_FILE"
+    chmod 600 "$CONFIG_FILE"
+fi
+
+systemctl enable zeroclaw
+systemctl restart zeroclaw
+
+remove_setup_wizard_bashrc_hook
+redact_gradient_secrets_from_system_environment
+touch "$SETUP_MARKER"
+chown zeroclaw:zeroclaw "$SETUP_MARKER" 2>/dev/null || true
+
+echo "Testing connection to DigitalOcean Gradient..."
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${GRADIENT_KEY}" \
+    -H "Content-Type: application/json" \
+    https://inference.do-ai.run/v1/models 2>/dev/null || true)
+
+if [ "$HTTP_STATUS" = "200" ]; then
+    echo "Gradient configured from ${ENV_FILE}: model ${PRIMARY_MODEL}"
+else
+    echo "Gradient configured from ${ENV_FILE}: model ${PRIMARY_MODEL}"
+    echo "Warning: Received HTTP ${HTTP_STATUS:-000} from the Gradient API." >&2
+fi
+
+exit 0

--- a/zeroclaw-24-04/files/opt/apply-gradient-from-env.sh
+++ b/zeroclaw-24-04/files/opt/apply-gradient-from-env.sh
@@ -4,10 +4,10 @@
 set -euo pipefail
 
 ENV_FILE=/opt/zeroclaw.env
-CONFIG_FILE=/home/zeroclaw/.zeroclaw/config.toml
-SETUP_MARKER=/home/zeroclaw/.zeroclaw/gradient-configured
+SETUP_MARKER=/root/.zeroclaw_setup_complete
 DEFAULT_MODEL=kimi-k2.5
 GRADIENT_PROVIDER=custom:https://inference.do-ai.run/v1
+ALLOWED_MODELS="kimi-k2.5 minimax-m2.5 glm-5 anthropic-claude-4.5-sonnet"
 
 remove_setup_wizard_bashrc_hook() {
     [ -f /root/.bashrc ] || return 0
@@ -39,6 +39,7 @@ read_config_value() {
 
 write_env_file_kv() {
     local key="$1" val="$2" tmp="${ENV_FILE}.tmp"
+    umask 077
     touch "$ENV_FILE"
     grep -v "^${key}=" "$ENV_FILE" >"$tmp" 2>/dev/null || : >"$tmp"
     printf '%s=%q\n' "$key" "$val" >>"$tmp"
@@ -55,13 +56,25 @@ env_value_usable() {
     return 0
 }
 
+gradient_model_allowed() {
+    local m="$1" allowed
+    for allowed in $ALLOWED_MODELS; do
+        [ "$m" = "$allowed" ] && return 0
+    done
+    return 1
+}
+
 normalize_gradient_model() {
     local m="$1"
     m="${m#gradient/}"
     case "$m" in
-        '') printf '%s' "$DEFAULT_MODEL" ;;
-        *) printf '%s' "$m" ;;
+        '') m="$DEFAULT_MODEL" ;;
     esac
+    if ! gradient_model_allowed "$m"; then
+        echo "Warning: Unknown GRADIENT_MODEL '${m}'; using ${DEFAULT_MODEL}." >&2
+        m="$DEFAULT_MODEL"
+    fi
+    printf '%s' "$m"
 }
 
 redact_gradient_secrets_from_system_environment() {
@@ -87,27 +100,16 @@ PRIMARY_MODEL=$(normalize_gradient_model "$GRADIENT_MODEL")
 write_env_file_kv GRADIENT_KEY "$GRADIENT_KEY"
 write_env_file_kv GRADIENT_MODEL "$PRIMARY_MODEL"
 
-mkdir -p /home/zeroclaw/.zeroclaw
-chown zeroclaw:zeroclaw /home/zeroclaw/.zeroclaw
-
-su - zeroclaw -c "/usr/local/bin/zeroclaw onboard --force \
-  --api-key '${GRADIENT_KEY}' \
-  --provider '${GRADIENT_PROVIDER}' \
-  --model '${PRIMARY_MODEL}'" > /dev/null 2>&1
-
-if [ -f "$CONFIG_FILE" ]; then
-    sed -i 's/^port = .*/port = 42617/' "$CONFIG_FILE"
-    chown zeroclaw:zeroclaw "$CONFIG_FILE"
-    chmod 600 "$CONFIG_FILE"
-fi
+/opt/zeroclaw-run-onboard.sh "$GRADIENT_KEY" "$GRADIENT_PROVIDER" "$PRIMARY_MODEL"
 
 systemctl enable zeroclaw
 systemctl restart zeroclaw
 
 remove_setup_wizard_bashrc_hook
 redact_gradient_secrets_from_system_environment
+umask 077
 touch "$SETUP_MARKER"
-chown zeroclaw:zeroclaw "$SETUP_MARKER" 2>/dev/null || true
+chmod 600 "$SETUP_MARKER"
 
 echo "Testing connection to DigitalOcean Gradient..."
 HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \

--- a/zeroclaw-24-04/files/opt/zeroclaw-run-onboard.sh
+++ b/zeroclaw-24-04/files/opt/zeroclaw-run-onboard.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Run zeroclaw onboard without placing API keys on the su(1) command line.
+# Usage: zeroclaw-run-onboard.sh <api_key> <provider> <model>
+set -euo pipefail
+
+API_KEY="${1:?api_key required}"
+PROVIDER="${2:?provider required}"
+MODEL="${3:?model required}"
+
+CONFIG_DIR=/home/zeroclaw/.zeroclaw
+CONFIG_FILE="${CONFIG_DIR}/config.toml"
+CRED_FILE="${CONFIG_DIR}/.onboard-credentials"
+
+umask 077
+mkdir -p "$CONFIG_DIR"
+printf 'ZEROCLAW_API_KEY=%q\n' "$API_KEY" >"$CRED_FILE"
+chmod 600 "$CRED_FILE"
+chown zeroclaw:zeroclaw "$CRED_FILE" "$CONFIG_DIR"
+
+onboard_cmd=$(
+    printf 'set -a; . %q; set +a; exec /usr/local/bin/zeroclaw onboard --force --provider %q --model %q' \
+        "$CRED_FILE" "$PROVIDER" "$MODEL"
+)
+su - zeroclaw -c "$onboard_cmd" >/dev/null 2>&1
+
+rm -f "$CRED_FILE"
+
+if [ -f "$CONFIG_FILE" ]; then
+    sed -i 's/^port = .*/port = 42617/' "$CONFIG_FILE"
+    chmod 600 "$CONFIG_FILE"
+    chown zeroclaw:zeroclaw "$CONFIG_FILE"
+fi

--- a/zeroclaw-24-04/files/opt/zeroclaw.env
+++ b/zeroclaw-24-04/files/opt/zeroclaw.env
@@ -13,13 +13,20 @@ ZEROCLAW_GATEWAY_PORT=42617
 # Use 'zeroclaw status' or 'journalctl -u zeroclaw' to find the pairing code
 
 # Model Configuration
-# Run the interactive setup script to configure a provider:
+# DigitalOcean Gradient (optional):
+#   GRADIENT_KEY    Gradient model access key (Gen AI / Gradient in the control panel)
+#   GRADIENT_MODEL  Inference model id, e.g. kimi-k2.5, minimax-m2.5, glm-5
+#
+# On first boot, 001_onboot reads /etc/environment first, then /opt/zeroclaw.env.
+# If GRADIENT_KEY is set in either place, Gradient is configured and the interactive
+# provider wizard is skipped.
+#
+# Run the interactive setup script if these are empty:
 #   sudo /etc/setup_wizard.sh
 # This lets you choose between DigitalOcean Gradient, OpenAI, Anthropic, or OpenRouter.
 #
-# DigitalOcean Gradient (inference.do-ai.run) defaults to Kimi K2.5. Model IDs include:
-#   kimi-k2.5 (default), minimax-m2.5, glm-5, anthropic-claude-4.5-sonnet
-# Set default_model in ~/.zeroclaw/config.toml to switch after onboarding.
-#
-# Or set your API key directly in ~/.zeroclaw/config.toml:
-# api_key = "your_api_key_here"
+# Re-apply Gradient from env without reboot:
+#   sudo /opt/apply-gradient-from-env.sh
+
+GRADIENT_KEY=
+GRADIENT_MODEL=kimi-k2.5

--- a/zeroclaw-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/zeroclaw-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+
+set -a
+source /etc/environment 2>/dev/null || true
+set +a
 
 DROPL_IP=$(hostname -I | awk '{print$1}')
 sed "s/PLACEHOLDER_IP/${DROPL_IP}/" /etc/caddy/Caddyfile.tmp > /etc/caddy/Caddyfile
@@ -6,10 +10,18 @@ sed "s/PLACEHOLDER_IP/${DROPL_IP}/" /etc/caddy/Caddyfile.tmp > /etc/caddy/Caddyf
 # Remove the ssh force logout command
 sed -e '/Match User root/d' -e '/.*ForceCommand.*droplet.*/d' -i /etc/ssh/sshd_config
 
-cat >> /root/.bashrc <<EOM
+chmod +x /opt/apply-gradient-from-env.sh
+
+GRADIENT_APPLIED=0
+if /opt/apply-gradient-from-env.sh; then
+    GRADIENT_APPLIED=1
+    echo "Gradient pre-configured from droplet environment."
+elif ! grep -q 'setup_wizard.sh' /root/.bashrc 2>/dev/null; then
+    cat >> /root/.bashrc <<EOM
 chmod +x /etc/setup_wizard.sh
 /etc/setup_wizard.sh
 EOM
+fi
 
 systemctl restart ssh
 systemctl enable caddy

--- a/zeroclaw-24-04/scripts/010-zeroclaw.sh
+++ b/zeroclaw-24-04/scripts/010-zeroclaw.sh
@@ -60,6 +60,8 @@ chmod +x /opt/status-zeroclaw.sh
 chmod +x /opt/update-zeroclaw.sh
 chmod +x /opt/zeroclaw-cli.sh
 chmod +x /opt/setup-zeroclaw-domain.sh
+chmod +x /opt/apply-gradient-from-env.sh
+chmod 600 /opt/zeroclaw.env
 chmod +x /etc/setup_wizard.sh
 chmod +x /etc/update-motd.d/99-one-click
 chmod +x /var/lib/cloud/scripts/per-instance/001_onboot

--- a/zeroclaw-24-04/scripts/010-zeroclaw.sh
+++ b/zeroclaw-24-04/scripts/010-zeroclaw.sh
@@ -61,6 +61,7 @@ chmod +x /opt/update-zeroclaw.sh
 chmod +x /opt/zeroclaw-cli.sh
 chmod +x /opt/setup-zeroclaw-domain.sh
 chmod +x /opt/apply-gradient-from-env.sh
+chmod +x /opt/zeroclaw-run-onboard.sh
 chmod 600 /opt/zeroclaw.env
 chmod +x /etc/setup_wizard.sh
 chmod +x /etc/update-motd.d/99-one-click


### PR DESCRIPTION
- Add /opt/apply-gradient-from-env.sh to configure DigitalOcean Gradient from GRADIENT_KEY and optional GRADIENT_MODEL (same contract as codex-cli-24-04 and openclaw-24-04).
- On first boot, 001_onboot sources /etc/environment, applies Gradient when a key is present, and skips the interactive setup wizard.
- Update setup wizard, env template, MOTD, and docs for droplet env var pre-configuration.