### PR TITLE
Add Twenty CRM 1-Click for Ubuntu 24.04

### DIFF
--- a/twenty-24-04/files/etc/caddy/Caddyfile.tmp
+++ b/twenty-24-04/files/etc/caddy/Caddyfile.tmp
@@ -1,0 +1,10 @@
+PLACEHOLDER_DOMAIN {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+    reverse_proxy localhost:3000
+    header X-DO-MARKETPLACE "twenty"
+}

--- a/twenty-24-04/files/etc/systemd/system/twenty.service
+++ b/twenty-24-04/files/etc/systemd/system/twenty.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Twenty CRM Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/twenty
+TimeoutStartSec=600
+ExecStart=/usr/bin/docker compose -f /opt/twenty/docker-compose.yml up -d --wait
+ExecStop=/usr/bin/docker compose -f /opt/twenty/docker-compose.yml down
+ExecReload=/usr/bin/docker compose -f /opt/twenty/docker-compose.yml restart
+
+[Install]
+WantedBy=multi-user.target

--- a/twenty-24-04/files/etc/update-motd.d/99-one-click
+++ b/twenty-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(curl -fsS --retry 3 --max-time 2 http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || hostname -I | awk '{print $1}')
+cat <<EOF
+********************************************************************************
+
+Welcome to Twenty CRM - The open-source alternative to Salesforce
+
+Twenty is running behind Caddy with HTTPS enabled. Access your workspace at:
+
+  https://$myip
+
+On first visit, create your workspace and admin account through the setup wizard.
+
+Configuration:
+
+  Environment file:  /opt/twenty/.env
+  Docker Compose:    /opt/twenty/docker-compose.yml
+
+  After editing .env, restart Twenty:
+    systemctl restart twenty
+
+Management Commands:
+
+  Start:             /opt/twenty/start-twenty.sh   (or: systemctl start twenty)
+  Stop:              /opt/twenty/stop-twenty.sh    (or: systemctl stop twenty)
+  Restart:           /opt/twenty/restart-twenty.sh (or: systemctl restart twenty)
+  Update:            /opt/twenty/update-twenty.sh
+  Status:            /opt/twenty/status-twenty.sh
+  Custom domain:     /opt/twenty/setup-twenty-domain.sh
+
+  View logs:         docker compose -f /opt/twenty/docker-compose.yml logs -f
+
+Database Backup:
+
+  docker exec twenty-db-1 pg_dump -U postgres default > backup_\$(date +%Y%m%d).sql
+
+Important Notes:
+
+  • ENCRYPTION_KEY and database password were generated on first boot
+  • Keep /opt/twenty/.env secure — losing ENCRYPTION_KEY loses stored secrets
+  • Data persists in Docker volumes across restarts
+  • Minimum 2GB RAM recommended for production workloads
+
+Documentation:
+
+  Twenty Docs:  https://docs.twenty.com/
+  GitHub:       https://github.com/twentyhq/twenty
+
+********************************************************************************
+To delete this message of the day: rm -rf \$(readlink -f \${0})
+EOF

--- a/twenty-24-04/files/opt/twenty/docker-compose.yml
+++ b/twenty-24-04/files/opt/twenty/docker-compose.yml
@@ -1,0 +1,90 @@
+name: twenty
+
+services:
+  server:
+    image: twentycrm/twenty:${TAG:-latest}
+    volumes:
+      - server-local-data:/app/packages/twenty-server/.local-storage
+    ports:
+      - "127.0.0.1:3000:3000"
+    env_file: /opt/twenty/.env
+    environment:
+      NODE_PORT: 3000
+      PG_DATABASE_URL: postgres://${PG_DATABASE_USER:-postgres}:${PG_DATABASE_PASSWORD:-postgres}@${PG_DATABASE_HOST:-db}:${PG_DATABASE_PORT:-5432}/default
+      SERVER_URL: ${SERVER_URL}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      DISABLE_DB_MIGRATIONS: ${DISABLE_DB_MIGRATIONS:-}
+      DISABLE_CRON_JOBS_REGISTRATION: ${DISABLE_CRON_JOBS_REGISTRATION:-}
+      STORAGE_TYPE: ${STORAGE_TYPE}
+      STORAGE_S3_REGION: ${STORAGE_S3_REGION:-}
+      STORAGE_S3_NAME: ${STORAGE_S3_NAME:-}
+      STORAGE_S3_ENDPOINT: ${STORAGE_S3_ENDPOINT:-}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      FALLBACK_ENCRYPTION_KEY: ${FALLBACK_ENCRYPTION_KEY:-}
+      APP_SECRET: ${APP_SECRET:-}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: curl --fail http://localhost:3000/healthz
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    restart: always
+
+  worker:
+    image: twentycrm/twenty:${TAG:-latest}
+    volumes:
+      - server-local-data:/app/packages/twenty-server/.local-storage
+    command: ["yarn", "worker:prod"]
+    env_file: /opt/twenty/.env
+    environment:
+      PG_DATABASE_URL: postgres://${PG_DATABASE_USER:-postgres}:${PG_DATABASE_PASSWORD:-postgres}@${PG_DATABASE_HOST:-db}:${PG_DATABASE_PORT:-5432}/default
+      SERVER_URL: ${SERVER_URL}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379}
+      DISABLE_DB_MIGRATIONS: "true"
+      DISABLE_CRON_JOBS_REGISTRATION: "true"
+      STORAGE_TYPE: ${STORAGE_TYPE}
+      STORAGE_S3_REGION: ${STORAGE_S3_REGION:-}
+      STORAGE_S3_NAME: ${STORAGE_S3_NAME:-}
+      STORAGE_S3_ENDPOINT: ${STORAGE_S3_ENDPOINT:-}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      FALLBACK_ENCRYPTION_KEY: ${FALLBACK_ENCRYPTION_KEY:-}
+      APP_SECRET: ${APP_SECRET:-}
+    depends_on:
+      db:
+        condition: service_healthy
+      server:
+        condition: service_healthy
+    restart: always
+
+  db:
+    image: postgres:16
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: ${PG_DATABASE_NAME:-default}
+      POSTGRES_PASSWORD: ${PG_DATABASE_PASSWORD:-postgres}
+      POSTGRES_USER: ${PG_DATABASE_USER:-postgres}
+    healthcheck:
+      test: pg_isready -U ${PG_DATABASE_USER:-postgres} -h localhost -d postgres
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: always
+
+  redis:
+    image: redis
+    restart: always
+    command: ["--maxmemory-policy", "noeviction"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  db-data:
+  server-local-data:

--- a/twenty-24-04/files/opt/twenty/restart-twenty.sh
+++ b/twenty-24-04/files/opt/twenty/restart-twenty.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+echo "Restarting Twenty CRM..."
+systemctl restart twenty
+
+if systemctl is-active --quiet twenty; then
+    echo "Twenty CRM restarted successfully."
+else
+    echo "Failed to restart Twenty CRM. Check: systemctl status twenty"
+    exit 1
+fi

--- a/twenty-24-04/files/opt/twenty/setup-twenty-domain.sh
+++ b/twenty-24-04/files/opt/twenty/setup-twenty-domain.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+read -rp "Enter the domain you pointed at this droplet (e.g. crm.example.com): " DOMAIN
+if [ -z "${DOMAIN}" ]; then
+    echo "Domain cannot be empty."
+    exit 1
+fi
+
+read -rp "Enter an email for Let's Encrypt notifications (optional): " EMAIL
+
+SERVER_URL="https://${DOMAIN}"
+
+if grep -q '^SERVER_URL=' /opt/twenty/.env; then
+    sed -i "s|^SERVER_URL=.*|SERVER_URL=${SERVER_URL}|" /opt/twenty/.env
+else
+    echo "SERVER_URL=${SERVER_URL}" >> /opt/twenty/.env
+fi
+
+{
+    cat > /etc/caddy/Caddyfile << CADDYEOC
+${DOMAIN} {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+    reverse_proxy localhost:3000
+    header X-DO-MARKETPLACE "twenty"
+}
+CADDYEOC
+    if [ -n "$EMAIL" ]; then
+        sed -i "1iemail ${EMAIL}" /etc/caddy/Caddyfile
+    fi
+}
+
+systemctl enable caddy
+systemctl restart twenty
+systemctl restart caddy
+
+echo "Twenty CRM is now available at ${SERVER_URL}"
+echo "Update complete. You may need to wait a minute for SSL certificate issuance."

--- a/twenty-24-04/files/opt/twenty/start-twenty.sh
+++ b/twenty-24-04/files/opt/twenty/start-twenty.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+echo "Starting Twenty CRM..."
+systemctl start twenty
+
+if systemctl is-active --quiet twenty; then
+    echo "Twenty CRM started successfully."
+    echo "Access at: https://$(curl -fsS --retry 3 --max-time 2 http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || hostname -I | awk '{print $1}')"
+else
+    echo "Failed to start Twenty CRM. Check: systemctl status twenty"
+    exit 1
+fi

--- a/twenty-24-04/files/opt/twenty/status-twenty.sh
+++ b/twenty-24-04/files/opt/twenty/status-twenty.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "=== Twenty CRM Service Status ==="
+systemctl status twenty --no-pager || true
+
+echo ""
+echo "=== Docker Containers ==="
+docker compose -f /opt/twenty/docker-compose.yml ps 2>/dev/null || true
+
+echo ""
+echo "=== Caddy Status ==="
+systemctl status caddy --no-pager 2>/dev/null || true

--- a/twenty-24-04/files/opt/twenty/stop-twenty.sh
+++ b/twenty-24-04/files/opt/twenty/stop-twenty.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+echo "Stopping Twenty CRM..."
+systemctl stop twenty
+echo "Twenty CRM stopped."

--- a/twenty-24-04/files/opt/twenty/twenty.env
+++ b/twenty-24-04/files/opt/twenty/twenty.env
@@ -1,0 +1,19 @@
+# Twenty CRM Environment Configuration
+#
+# After making changes to this file, restart Twenty with:
+#   systemctl restart twenty
+
+TAG=latest
+
+PG_DATABASE_USER=postgres
+PG_DATABASE_PASSWORD=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+PG_DATABASE_HOST=db
+PG_DATABASE_PORT=5432
+PG_DATABASE_NAME=default
+REDIS_URL=redis://redis:6379
+
+SERVER_URL=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+
+ENCRYPTION_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+
+STORAGE_TYPE=local

--- a/twenty-24-04/files/opt/twenty/update-twenty.sh
+++ b/twenty-24-04/files/opt/twenty/update-twenty.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+echo "Updating Twenty CRM to latest Docker images..."
+
+if [ ! -f /opt/twenty/docker-compose.yml ]; then
+    echo "Error: Twenty installation not found at /opt/twenty"
+    exit 1
+fi
+
+cd /opt/twenty
+
+echo "Stopping Twenty CRM..."
+systemctl stop twenty
+
+echo "Pulling latest images..."
+docker compose pull
+
+echo "Starting Twenty CRM with updated images..."
+systemctl start twenty
+
+if systemctl is-active --quiet twenty; then
+    echo "Twenty CRM updated and restarted successfully."
+else
+    echo "Error: Failed to restart Twenty CRM after update"
+    exit 1
+fi

--- a/twenty-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/twenty-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+echo "Configuring Twenty CRM on first boot..."
+
+if [ ! -f /opt/twenty/.env ]; then
+    echo "Creating environment configuration..."
+    cp /opt/twenty/twenty.env /opt/twenty/.env
+fi
+
+if grep -q "PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT" /opt/twenty/.env 2>/dev/null; then
+    echo "Generating unique secrets for this droplet..."
+
+    ENCRYPTION_KEY=$(openssl rand -base64 32)
+    PG_DATABASE_PASSWORD=$(openssl rand -hex 32)
+
+    sed -i "s|ENCRYPTION_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|ENCRYPTION_KEY=${ENCRYPTION_KEY}|" /opt/twenty/.env
+    sed -i "s|PG_DATABASE_PASSWORD=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|PG_DATABASE_PASSWORD=${PG_DATABASE_PASSWORD}|" /opt/twenty/.env
+
+    echo "Secrets generated successfully."
+fi
+
+meta() { curl -fsS --retry 10 --retry-connrefused --max-time 2 "$1"; }
+DROPLET_PUBLIC_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+DROPLET_PRIVATE_IP="$(hostname -I | awk '{print $1}')"
+DROPLET_IP="${DROPLET_PUBLIC_IP:-$DROPLET_PRIVATE_IP}"
+
+if grep -q "PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT" /opt/twenty/.env 2>/dev/null; then
+    sed -i "s|SERVER_URL=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|SERVER_URL=https://${DROPLET_IP}|" /opt/twenty/.env
+elif grep -q '^SERVER_URL=' /opt/twenty/.env; then
+    sed -i "s|^SERVER_URL=.*|SERVER_URL=https://${DROPLET_IP}|" /opt/twenty/.env
+fi
+
+chmod 600 /opt/twenty/.env
+
+mv /etc/caddy/Caddyfile.tmp /etc/caddy/Caddyfile
+
+if grep -q "PLACEHOLDER_DOMAIN" /etc/caddy/Caddyfile 2>/dev/null; then
+    echo "Configuring Caddy with droplet IP address..."
+    sed -i "s/PLACEHOLDER_DOMAIN/${DROPLET_IP}/" /etc/caddy/Caddyfile
+    systemctl enable caddy
+fi
+
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh
+
+# Reload Caddy before Twenty starts so HTTPS is available even if compose is slow.
+systemctl restart caddy
+
+echo "Starting Twenty CRM (database initialization may take a few minutes)..."
+systemctl enable twenty
+
+TWENTY_STARTED=0
+for attempt in 1 2 3; do
+    if systemctl start twenty; then
+        TWENTY_STARTED=1
+        break
+    fi
+    echo "Twenty start attempt ${attempt} failed; retrying in 30 seconds..."
+    sleep 30
+done
+
+if [ "$TWENTY_STARTED" -eq 0 ]; then
+    echo "WARNING: twenty.service did not start cleanly. Trying docker compose directly..."
+    cd /opt/twenty && docker compose up -d --wait || true
+fi
+
+systemctl restart caddy
+
+echo "Waiting for Twenty CRM to become healthy..."
+for i in $(seq 1 60); do
+    if curl -fsS http://127.0.0.1:3000/healthz >/dev/null 2>&1; then
+        echo "Twenty CRM is ready at https://${DROPLET_IP}"
+        exit 0
+    fi
+    sleep 5
+done
+
+echo "Twenty CRM may still be initializing. Check status with: /opt/twenty/status-twenty.sh"
+echo "View logs with: docker compose -f /opt/twenty/docker-compose.yml logs -f"

--- a/twenty-24-04/listing.md
+++ b/twenty-24-04/listing.md
@@ -1,0 +1,199 @@
+# Twenty CRM 1-Click Application
+
+Deploy [Twenty](https://twenty.com), the open-source CRM designed for technical teams, on DigitalOcean with this 1-Click application. Twenty gives you objects, views, workflows, and AI agents with the flexibility to extend everything as code.
+
+## What is Twenty?
+
+Twenty is the open alternative to Salesforce — a modern CRM you can build, ship, and version like the rest of your stack. Built with TypeScript, NestJS, React, PostgreSQL, and Redis, Twenty offers:
+
+- **Custom objects and fields** — Model your business data without rigid schemas
+- **Views and pipelines** — Kanban, table, and filter views for every workflow
+- **Workflows and automation** — Automate repetitive CRM tasks
+- **AI agents** — Built-in AI capabilities for modern sales teams
+- **Self-hosted** — Full control over your data and infrastructure
+- **Open source** — MIT-licensed with an active community
+
+## Key Features
+
+- Modern, intuitive CRM interface
+- Flexible data model with custom objects
+- REST and GraphQL APIs
+- Workflow automation
+- Email and calendar integrations (configurable)
+- Role-based access control
+- Docker-based deployment for reliable operations
+- HTTPS via Caddy with Let's Encrypt short-lived IP certificates
+
+## System Components
+
+This 1-Click includes:
+
+- **Twenty CRM v2.8.3** — Latest stable release (`twentycrm/twenty` Docker image)
+- **PostgreSQL 16** — Primary database
+- **Redis** — Job queue and caching
+- **Caddy** — Reverse proxy with automatic HTTPS
+- **Docker & Docker Compose** — Container orchestration
+- **Ubuntu 24.04 LTS** — Long-term support base system
+- **UFW Firewall** — Pre-configured for security
+
+## System Requirements
+
+Twenty requires at least **2GB RAM**. Use these Droplet sizes as a guide:
+
+| Use Case | RAM | CPU | Recommended Droplet |
+|----------|-----|-----|---------------------|
+| Evaluation | 2GB | 2 CPU | s-2vcpu-2gb |
+| Small team | 4GB | 2 CPU | s-2vcpu-4gb |
+| Production | 8GB | 4 CPU | s-4vcpu-8gb |
+
+## Getting Started
+
+### Initial Setup
+
+1. **Deploy the Droplet** — Select this 1-Click App from the DigitalOcean Marketplace
+2. **Wait for initialization** — First boot takes 3–5 minutes while the database initializes
+3. **Access Twenty** — Open your Droplet's IP in a browser:
+   ```
+   https://your-droplet-ip
+   ```
+
+### Create Your Workspace
+
+On first visit, Twenty walks you through workspace setup:
+
+1. Navigate to `https://your-droplet-ip`
+2. Create your workspace name
+3. Sign up with your email and password
+4. Invite team members from Settings
+
+### Custom Domain (Optional)
+
+To use your own domain with HTTPS:
+
+1. Point an A record at your Droplet's IP address
+2. SSH into the Droplet and run:
+   ```bash
+   /opt/twenty/setup-twenty-domain.sh
+   ```
+3. Enter your domain when prompted
+4. Twenty restarts with the updated `SERVER_URL`
+
+## Configuration
+
+### Environment Variables
+
+Edit the configuration file:
+
+```bash
+nano /opt/twenty/.env
+```
+
+Key variables:
+
+- `SERVER_URL` — Public URL users access in their browser (must match how they connect)
+- `ENCRYPTION_KEY` — Protects stored secrets; do not change after setup without following the key rotation guide
+- `PG_DATABASE_PASSWORD` — PostgreSQL password
+- `TAG` — Docker image version (e.g. `v2.8.3`)
+
+After changes, restart:
+
+```bash
+systemctl restart twenty
+```
+
+## Management Commands
+
+### Service Control
+
+```bash
+# Start
+systemctl start twenty
+/opt/twenty/start-twenty.sh
+
+# Stop
+systemctl stop twenty
+/opt/twenty/stop-twenty.sh
+
+# Restart
+systemctl restart twenty
+/opt/twenty/restart-twenty.sh
+
+# Status
+/opt/twenty/status-twenty.sh
+systemctl status twenty
+```
+
+### Viewing Logs
+
+```bash
+docker compose -f /opt/twenty/docker-compose.yml logs -f
+docker compose -f /opt/twenty/docker-compose.yml logs -f server
+```
+
+### Updating Twenty
+
+```bash
+/opt/twenty/update-twenty.sh
+```
+
+This pulls the latest Docker images for the configured `TAG` and restarts services. To pin a specific version, set `TAG` in `/opt/twenty/.env` before updating.
+
+## Backup and Restore
+
+### Database Backup
+
+```bash
+docker exec twenty-db-1 pg_dump -U postgres default > backup_$(date +%Y%m%d).sql
+```
+
+### Restore
+
+```bash
+docker compose -f /opt/twenty/docker-compose.yml stop server worker
+docker exec -i twenty-db-1 psql -U postgres default < backup_20240115.sql
+docker compose -f /opt/twenty/docker-compose.yml up -d
+```
+
+## Security Best Practices
+
+1. **Protect `/opt/twenty/.env`** — Contains encryption keys and database credentials
+2. **Use a custom domain** — Run `/opt/twenty/setup-twenty-domain.sh` for production
+3. **Regular backups** — Back up the PostgreSQL database and Docker volumes
+4. **Keep updated** — Run `/opt/twenty/update-twenty.sh` periodically
+5. **Strong passwords** — Use strong credentials for workspace admin accounts
+
+## Troubleshooting
+
+### Twenty won't start
+
+```bash
+/opt/twenty/status-twenty.sh
+docker compose -f /opt/twenty/docker-compose.yml logs -f
+```
+
+### Cannot access the web interface
+
+1. Verify services: `systemctl status twenty caddy`
+2. Check firewall: `ufw status`
+3. Wait 3–5 minutes after first boot for database migrations
+
+### Out of memory
+
+Twenty needs at least 2GB RAM. Resize your Droplet if containers crash or restart frequently.
+
+## Resources
+
+- **Documentation**: https://docs.twenty.com/
+- **GitHub**: https://github.com/twentyhq/twenty
+- **Docker Compose guide**: https://docs.twenty.com/developers/self-host/capabilities/docker-compose
+- **Discord**: https://discord.gg/twenty
+
+## Support
+
+For issues with this 1-Click application, contact DigitalOcean support.
+
+For Twenty-specific questions, see the [Twenty documentation](https://docs.twenty.com/) and [GitHub issues](https://github.com/twentyhq/twenty/issues).
+
+## License
+
+Twenty is open-source software. See the [Twenty repository](https://github.com/twentyhq/twenty) for license details.

--- a/twenty-24-04/readme.md
+++ b/twenty-24-04/readme.md
@@ -1,0 +1,120 @@
+# Twenty CRM 1-Click Application for DigitalOcean
+
+This directory contains the Packer configuration and supporting files to build a DigitalOcean Marketplace 1-Click image for [Twenty CRM](https://github.com/twentyhq/twenty).
+
+## Overview
+
+Twenty is an open-source CRM built with TypeScript, NestJS, React, PostgreSQL, and Redis. This 1-Click deploys Twenty v2.8.3 using the official Docker Compose stack behind Caddy with HTTPS via Let's Encrypt short-lived IP certificates.
+
+## What's Included
+
+- **Twenty CRM v2.8.3** — Official `twentycrm/twenty` Docker image
+- **PostgreSQL 16** — Database backend
+- **Redis** — Background job queue
+- **Caddy** — Reverse proxy with automatic TLS
+- **Docker & Docker Compose v2** — Container orchestration
+- **Ubuntu 24.04 LTS** — Base operating system
+- **UFW Firewall** — Pre-configured security
+- **Systemd service** — Service lifecycle management
+- **Helper scripts** — Start, stop, restart, update, status, and domain setup
+
+## Architecture
+
+Docker Compose runs four containers:
+
+1. **server** — Twenty API and web UI (localhost:3000, proxied by Caddy)
+2. **worker** — Background job processor
+3. **db** — PostgreSQL 16 with persistent volume
+4. **redis** — Redis with `noeviction` policy
+
+Caddy terminates HTTPS on ports 80/443 and reverse-proxies to the Twenty server on localhost.
+
+## Directory Structure
+
+```
+twenty-24-04/
+├── template.json
+├── scripts/
+│   └── twenty.sh
+├── files/
+│   ├── etc/
+│   │   ├── caddy/Caddyfile.tmp
+│   │   ├── systemd/system/twenty.service
+│   │   └── update-motd.d/99-one-click
+│   ├── opt/twenty/
+│   │   ├── docker-compose.yml
+│   │   ├── twenty.env
+│   │   ├── start-twenty.sh
+│   │   ├── stop-twenty.sh
+│   │   ├── restart-twenty.sh
+│   │   ├── update-twenty.sh
+│   │   ├── status-twenty.sh
+│   │   └── setup-twenty-domain.sh
+│   └── var/lib/cloud/scripts/per-instance/001_onboot
+├── listing.md
+└── readme.md
+```
+
+## Building the Image
+
+### Prerequisites
+
+1. DigitalOcean API token with write access
+2. Packer 1.8+ with the DigitalOcean plugin
+3. `DIGITALOCEAN_API_TOKEN` environment variable set
+
+### Build Steps
+
+```bash
+cd droplet-1-clicks
+export DIGITALOCEAN_API_TOKEN="your_token_here"
+packer init config/plugins.pkr.hcl   # once per checkout
+packer build twenty-24-04/template.json
+```
+
+The build creates a temporary Droplet, installs Docker and Caddy, pre-pulls Twenty images, and snapshots the result.
+
+### Build Time
+
+Approximately 10–15 minutes depending on network speed for Docker image pulls.
+
+## First Boot Process
+
+When a Droplet is created from this snapshot:
+
+1. Cloud-init runs `001_onboot`
+2. Unique `ENCRYPTION_KEY` and `PG_DATABASE_PASSWORD` are generated
+3. `SERVER_URL` is set to `https://<droplet-ip>`
+4. Caddy is configured with a short-lived ACME IP certificate
+5. Twenty Docker Compose stack starts
+6. Database migrations run (may take several minutes)
+
+## Security
+
+- Secrets are generated per-droplet on first boot using OpenSSL
+- Twenty listens on `127.0.0.1:3000` only; external access is via Caddy
+- UFW allows SSH (rate-limited), HTTP, and HTTPS
+- `/opt/twenty/.env` is chmod 600 after secret generation
+
+## Version Information
+
+- **Twenty**: v2.8.3 (set via `application_version` in `template.json`)
+- **PostgreSQL**: 16
+- **Ubuntu**: 24.04 LTS
+
+To bump the Twenty version, update `application_version` in `template.json` and rebuild.
+
+## Testing
+
+After building:
+
+1. Create a Droplet from the snapshot (minimum s-2vcpu-2gb)
+2. Wait 3–5 minutes for first boot
+3. SSH in and run `/opt/twenty/status-twenty.sh`
+4. Open `https://<droplet-ip>` and complete workspace setup
+
+## Resources
+
+- [Twenty Documentation](https://docs.twenty.com/)
+- [Docker Compose Self-Hosting Guide](https://docs.twenty.com/developers/self-host/capabilities/docker-compose)
+- [Twenty GitHub](https://github.com/twentyhq/twenty)

--- a/twenty-24-04/scripts/twenty.sh
+++ b/twenty-24-04/scripts/twenty.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+
+APP_VERSION="${application_version:-v2.8.3}"
+
+# Open required ports for HTTPS reverse proxy
+ufw allow 80
+ufw allow 443
+ufw limit ssh/tcp
+ufw --force enable
+
+# Install Caddy (reverse proxy with automatic TLS)
+curl -1sLf "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" > /etc/apt/sources.list.d/caddy-stable.list
+apt-get update -y
+apt-get install -y caddy
+mkdir -p /var/log/caddy
+chown -R caddy:caddy /var/log/caddy
+
+systemctl enable docker
+systemctl start docker
+
+# Pin image tag from packer variable
+sed -i "s|TAG=latest|TAG=${APP_VERSION}|g" /opt/twenty/twenty.env
+
+chmod +x /opt/twenty/start-twenty.sh
+chmod +x /opt/twenty/stop-twenty.sh
+chmod +x /opt/twenty/restart-twenty.sh
+chmod +x /opt/twenty/update-twenty.sh
+chmod +x /opt/twenty/status-twenty.sh
+chmod +x /opt/twenty/setup-twenty-domain.sh
+chmod +x /etc/update-motd.d/99-one-click
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+
+# Temporary env for pre-pulling images during build
+cp /opt/twenty/twenty.env /opt/twenty/.env
+sed -i 's|PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|buildtime-placeholder|g' /opt/twenty/.env
+
+cd /opt/twenty
+docker compose pull
+rm -f /opt/twenty/.env
+
+systemctl enable twenty
+
+echo "Twenty CRM installation completed. Services start on first boot."

--- a/twenty-24-04/template.json
+++ b/twenty-24-04/template.json
@@ -1,0 +1,81 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "twenty-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "apt-transport-https ca-certificates curl software-properties-common git build-essential libsystemd-dev jq unzip docker.io docker-compose-v2 gnupg",
+    "application_name": "Twenty CRM",
+    "application_version": "v2.8.3"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-2vcpu-2gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "twenty-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "twenty-24-04/files/opt/",
+      "destination": "/opt/"
+    },
+    {
+      "type": "file",
+      "source": "twenty-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "twenty-24-04/scripts/twenty.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a new `twenty-24-04/` Packer builder for [Twenty CRM](https://github.com/twentyhq/twenty) on Ubuntu 24.04
- Deploys the official Docker Compose stack (server, worker, PostgreSQL 16, Redis) with Caddy HTTPS via Let's Encrypt short-lived IP certificates
- Generates per-droplet secrets on first boot and includes resilient startup handling for slow database initialization (`TimeoutStartSec=600`, Caddy reload before compose start, retry logic)

## Test plan
- [x] `packer build twenty-24-04/template.json` completed successfully (snapshot `twenty-24-04-snapshot-1780075112`)
- [x] Deployed droplet from snapshot and verified HTTPS access at droplet IP
- [x] Verified all four containers start after first-boot fixes (db, redis, server, worker)
- [ ] Marketplace QA: complete Twenty workspace setup wizard on a fresh droplet
- [ ] Verify avatar/file upload on a 2GB+ droplet under normal load