### PR TITLE
Add Gradient auto-config to OpenCode 1-click

### DIFF
--- a/opencode-24-04/README.md
+++ b/opencode-24-04/README.md
@@ -20,6 +20,8 @@ opencode-24-04/
     │   └── update-motd.d/
     │       └── 99-one-click         # Message of the Day
     ├── opt/
+    │   ├── apply-gradient-from-env.sh # Auto-config from GRADIENT_KEY / GRADIENT_MODEL
+    │   ├── opencode.env              # Optional Gradient env vars (see 001_onboot)
     │   ├── setup-opencode.sh       # First-login setup wizard (Gradient key)
     │   ├── update-opencode.sh      # Update to latest version
     │   └── opencode-version.sh     # Display installed version
@@ -79,15 +81,27 @@ Field testing shows **cache-related usage fields are often zero** on `https://in
 
 1. Removes SSH force-logout (allows normal login)
 2. Creates `/root/opencode_info.txt` with getting-started instructions
-3. Hooks the Gradient setup wizard (`/opt/setup-opencode.sh`) into `.bashrc` for first login
+3. If `GRADIENT_KEY` is set in droplet environment (`/etc/environment`) or `/opt/opencode.env`, applies Gradient config automatically and skips the setup wizard
+4. Otherwise hooks the Gradient setup wizard (`/opt/setup-opencode.sh`) into `.bashrc` for first login
 
 ## First Login Experience
 
-On first SSH login, the setup wizard runs and:
+If `GRADIENT_KEY` was not passed at droplet creation, on first SSH login the setup wizard runs and:
 1. Prompts the user for their DigitalOcean Gradient model access key
 2. Writes the key to `/root/.local/share/opencode/auth.json` under **`digitalocean`**
 3. Tests the connection to `https://inference.do-ai.run/v1/models`
 4. Self-removes from `.bashrc` (one-time only)
+
+### Auto-configuration from droplet environment
+
+Pass these environment variables when creating the droplet (or set them in `/opt/opencode.env` before first boot):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GRADIENT_KEY` | Yes | Gradient model access key from the control panel |
+| `GRADIENT_MODEL` | No | Model id, e.g. `minimax-m2.5`, `kimi-k2.5` (default: `minimax-m2.5`) |
+
+On first boot, `/opt/apply-gradient-from-env.sh` writes `/root/.local/share/opencode/auth.json`, sets the default model in `opencode.json`, and skips the interactive wizard.
 
 Pre-configured models (no separate provider key needed, all via Gradient):
 - **`digitalocean/`** (OpenAI-compatible): GPT-5.2, GPT-5, GPT-5.1 Codex Max, GPT-4.1, o3, DeepSeek R1 70B, Qwen3 32B, Llama 3.3 70B, **Kimi K2.5 (default)**, glm-5, MiniMax M2.5, Claude Opus 4.6, Opus 4.5, Sonnet 4.5, Sonnet 4

--- a/opencode-24-04/files/etc/update-motd.d/99-one-click
+++ b/opencode-24-04/files/etc/update-motd.d/99-one-click
@@ -19,8 +19,9 @@ PRE-CONFIGURED MODELS (via DigitalOcean Gradient):
 
 GETTING STARTED:
 
-  1. On first login, the setup wizard will prompt for your Gradient
-     model access key. Create one at:
+  1. If GRADIENT_KEY was passed as a droplet environment variable, Gradient
+     is configured automatically. Otherwise, on first login the setup wizard
+     will prompt for your Gradient model access key. Create one at:
      https://cloud.digitalocean.com/gen-ai
      (API Keys > Model Access Keys)
 

--- a/opencode-24-04/files/opt/apply-gradient-from-env.sh
+++ b/opencode-24-04/files/opt/apply-gradient-from-env.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Apply DigitalOcean Gradient from droplet env or /opt/opencode.env (GRADIENT_KEY, GRADIENT_MODEL).
+# Returns 0 when a key was applied; 1 when skipped (empty or unset placeholder).
+set -euo pipefail
+
+ENV_FILE=/opt/opencode.env
+CONFIG_FILE=/root/.config/opencode/opencode.json
+AUTH_FILE=/root/.local/share/opencode/auth.json
+SETUP_MARKER=/root/.opencode_setup_complete
+
+remove_setup_bashrc_hook() {
+    [ -f /root/.bashrc ] || return 0
+    sed -i '/\/opt\/setup-opencode\.sh/d' /root/.bashrc
+}
+
+read_file_kv() {
+    local key="$1"
+    local line val
+    line=$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -n 1) || return 1
+    val="${line#${key}=}"
+    printf '%s' "$val"
+}
+
+read_config_value() {
+    local key="$1"
+    local env_val="${!key-}"
+    if env_value_usable "$env_val"; then
+        printf '%s' "$env_val"
+        return 0
+    fi
+    read_file_kv "$key"
+}
+
+write_env_file_kv() {
+    local key="$1" val="$2" tmp="${ENV_FILE}.tmp"
+    touch "$ENV_FILE"
+    grep -v "^${key}=" "$ENV_FILE" >"$tmp" 2>/dev/null || : >"$tmp"
+    printf '%s=%q\n' "$key" "$val" >>"$tmp"
+    mv "$tmp" "$ENV_FILE"
+    chmod 600 "$ENV_FILE"
+}
+
+normalize_opencode_model() {
+    local m="$1"
+    case "$m" in
+        digitalocean/*) printf '%s' "$m" ;;
+        gradient/*) printf 'digitalocean/%s' "${m#gradient/}" ;;
+        "") printf '%s' "digitalocean/minimax-m2.5" ;;
+        *) printf 'digitalocean/%s' "$m" ;;
+    esac
+}
+
+env_value_usable() {
+    local v="$1"
+    [ -n "$v" ] || return 1
+    case "$v" in
+        *'${'*|PLACEHOLDER*|your_*_here) return 1 ;;
+    esac
+    return 0
+}
+
+GRADIENT_KEY=$(read_config_value GRADIENT_KEY || true)
+GRADIENT_MODEL=$(read_config_value GRADIENT_MODEL || true)
+
+if ! env_value_usable "$GRADIENT_KEY"; then
+    exit 1
+fi
+
+if ! env_value_usable "$GRADIENT_MODEL"; then
+    GRADIENT_MODEL="minimax-m2.5"
+fi
+
+PRIMARY_MODEL=$(normalize_opencode_model "$GRADIENT_MODEL")
+write_env_file_kv GRADIENT_KEY "$GRADIENT_KEY"
+write_env_file_kv GRADIENT_MODEL "${PRIMARY_MODEL#digitalocean/}"
+
+mkdir -p /root/.config/opencode /root/.local/share/opencode
+
+jq -n --arg key "$GRADIENT_KEY" \
+    '{
+      "digitalocean": {"type": "api", "key": $key},
+      "do-anthropic": {"type": "api", "key": $key}
+    }' >"$AUTH_FILE"
+chmod 600 "$AUTH_FILE"
+
+if [ -f "$CONFIG_FILE" ]; then
+    jq --arg model "$PRIMARY_MODEL" '.model = $model' "$CONFIG_FILE" >"${CONFIG_FILE}.tmp"
+    mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
+fi
+
+touch "$SETUP_MARKER"
+remove_setup_bashrc_hook
+
+echo "Gradient configured from droplet environment: model ${PRIMARY_MODEL}"
+exit 0

--- a/opencode-24-04/files/opt/opencode.env
+++ b/opencode-24-04/files/opt/opencode.env
@@ -1,0 +1,15 @@
+# OpenCode Environment Configuration
+#
+# DigitalOcean Gradient (optional):
+#   GRADIENT_KEY    Gradient model access key (Gen AI / Gradient in the control panel)
+#   GRADIENT_MODEL  Inference model id, e.g. minimax-m2.5, kimi-k2.5, glm-5
+#                   (OpenCode uses digitalocean/<id>; default minimax-m2.5)
+# On first boot, 001_onboot reads /etc/environment first, then /opt/opencode.env.
+# If GRADIENT_KEY is set in either place, it configures Gradient and skips the
+# interactive setup wizard on first login.
+#
+# Run the interactive setup script if these are empty:
+#   /opt/setup-opencode.sh
+
+GRADIENT_KEY=
+GRADIENT_MODEL=minimax-m2.5

--- a/opencode-24-04/files/opt/setup-opencode.sh
+++ b/opencode-24-04/files/opt/setup-opencode.sh
@@ -11,6 +11,26 @@ remove_first_login_hook() {
   sed -i '/\/opt\/setup-opencode\.sh/d' /root/.bashrc 2>/dev/null || true
 }
 
+try_apply_gradient_from_env() {
+  set -a
+  # shellcheck source=/dev/null
+  source /etc/environment 2>/dev/null || true
+  set +a
+
+  if [ -x /opt/apply-gradient-from-env.sh ] && /opt/apply-gradient-from-env.sh; then
+    echo "Gradient configured from droplet environment."
+    remove_first_login_hook
+    return 0
+  fi
+
+  return 1
+}
+
+# Startup scripts may land in /etc/environment after 001_onboot; retry before prompting.
+if [ "$1" != "--force" ] && try_apply_gradient_from_env; then
+  exit 0
+fi
+
 gradient_already_configured() {
   local configured_key
 

--- a/opencode-24-04/files/opt/setup-opencode.sh
+++ b/opencode-24-04/files/opt/setup-opencode.sh
@@ -5,16 +5,36 @@
 
 SETUP_MARKER="/root/.opencode_setup_complete"
 CONFIG_FILE="/root/.config/opencode/opencode.json"
+AUTH_FILE="/root/.local/share/opencode/auth.json"
 
-# Allow re-running manually; only auto-skip when called from .bashrc
-if [ -f "$SETUP_MARKER" ] && [ "$1" != "--force" ]; then
-  # Check if we were invoked from .bashrc (non-interactive re-trigger)
-  # If the user ran this script directly, always allow it
-  if grep -q '/opt/setup-opencode.sh' /root/.bashrc 2>/dev/null; then
-    exit 0
+remove_first_login_hook() {
+  sed -i '/\/opt\/setup-opencode\.sh/d' /root/.bashrc 2>/dev/null || true
+}
+
+gradient_already_configured() {
+  local configured_key
+
+  if [ -f "$SETUP_MARKER" ]; then
+    echo "OpenCode setup is already complete"
+    return 0
   fi
-  # Script was run manually -- remove the marker and continue
-  rm -f "$SETUP_MARKER"
+
+  if [ -f "$AUTH_FILE" ]; then
+    configured_key=$(jq -r '.digitalocean.key // empty' "$AUTH_FILE" 2>/dev/null || true)
+    if [ -n "$configured_key" ] && [ "$configured_key" != "null" ]; then
+      echo "DigitalOcean Gradient is already configured"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+configured_reason=$(gradient_already_configured || true)
+if [ -n "$configured_reason" ] && [ "$1" != "--force" ]; then
+  echo "${configured_reason}. Skipping setup wizard."
+  remove_first_login_hook
+  exit 0
 fi
 
 echo ""
@@ -86,8 +106,7 @@ fi
 # Mark setup as complete
 touch "$SETUP_MARKER"
 
-# Remove setup hook from .bashrc
-sed -i '/\/opt\/setup-opencode.sh/d' /root/.bashrc
+remove_first_login_hook
 
 echo ""
 echo "========================================================================"

--- a/opencode-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/opencode-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -2,6 +2,10 @@
 
 set -e
 
+set -a
+source /etc/environment 2>/dev/null || true
+set +a
+
 # Remove the ssh force logout command
 sed -e '/Match User root/d' \
     -e '/.*ForceCommand.*droplet.*/d' \
@@ -13,10 +17,16 @@ systemctl restart ssh
 mkdir -p /root/.config/opencode
 mkdir -p /root/.local/share/opencode
 
-# Hook setup wizard to run on first SSH login
-cat >> /root/.bashrc <<EOM
+chmod +x /opt/apply-gradient-from-env.sh
+
+if /opt/apply-gradient-from-env.sh; then
+    echo "Gradient pre-configured from droplet environment."
+    echo "Skipping setup wizard on first login."
+elif ! grep -q '/opt/setup-opencode.sh' /root/.bashrc 2>/dev/null; then
+    cat >> /root/.bashrc <<EOM
 /opt/setup-opencode.sh
 EOM
+fi
 
 # Create a getting started file for first-time users
 cat > /root/opencode_info.txt << 'EOF'
@@ -29,15 +39,21 @@ use DigitalOcean Gradient AI for inference.
 
 PRE-CONFIGURED MODELS (via DigitalOcean Gradient):
 
-  digitalocean/ (default: Kimi K2.5):
+  digitalocean/ (default: MiniMax M2.5):
     GPT-5.2, GPT-5, GPT-5.1 Codex Max, GPT-4.1, o3, DeepSeek R1 70B, Qwen3 32B,
     Llama 3.3 70B, Kimi K2.5, glm-5, MiniMax M2.5,
     Claude Opus 4.6, Opus 4.5, Sonnet 4.5, Sonnet 4
 
+AUTO-CONFIGURATION (optional):
+
+  If GRADIENT_KEY (and optionally GRADIENT_MODEL) are passed as droplet
+  environment variables, OpenCode configures Gradient automatically on first
+  boot and skips the interactive setup wizard.
+
 NEXT STEPS:
 
-1. The setup wizard will run on first login to configure your
-   Gradient model access key. To create one:
+1. If Gradient was not auto-configured, the setup wizard runs on first login
+   to configure your Gradient model access key. To create one:
      https://cloud.digitalocean.com/gen-ai
      Navigate to API Keys > Model Access Keys
 
@@ -55,6 +71,7 @@ Other providers: use /connect inside OpenCode to add your own API keys
 
 Configuration:  /root/.config/opencode/opencode.json
 Auth:           /root/.local/share/opencode/auth.json
+Gradient env:   /opt/opencode.env
 
 For documentation: https://opencode.ai/docs
 

--- a/opencode-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/opencode-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -26,6 +26,35 @@ elif ! grep -q '/opt/setup-opencode.sh' /root/.bashrc 2>/dev/null; then
     cat >> /root/.bashrc <<EOM
 /opt/setup-opencode.sh
 EOM
+
+    # Startup scripts can write GRADIENT_KEY after this script; retry after cloud-init.
+    cat > /opt/retry-apply-gradient-after-cloud-init.sh <<'EOF'
+#!/bin/bash
+set -a
+source /etc/environment 2>/dev/null || true
+set +a
+if /opt/apply-gradient-from-env.sh; then
+    sed -i '/\/opt\/setup-opencode\.sh/d' /root/.bashrc 2>/dev/null || true
+fi
+EOF
+    chmod +x /opt/retry-apply-gradient-after-cloud-init.sh
+
+    cat > /etc/systemd/system/opencode-apply-gradient.service <<'EOF'
+[Unit]
+Description=Apply OpenCode Gradient config after cloud-init user-data
+After=cloud-init.service
+ConditionPathExists=!/root/.opencode_setup_complete
+
+[Service]
+Type=oneshot
+ExecStart=/opt/retry-apply-gradient-after-cloud-init.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl enable opencode-apply-gradient.service
+    systemctl start opencode-apply-gradient.service || true
 fi
 
 # Create a getting started file for first-time users

--- a/opencode-24-04/listing.md
+++ b/opencode-24-04/listing.md
@@ -55,7 +55,9 @@ ssh root@your-droplet-ip
 
 ### 3. Complete the Setup Wizard
 
-On first login, the setup wizard will prompt for your DigitalOcean Gradient model access key. To create one:
+If you passed `GRADIENT_KEY` as a droplet environment variable, OpenCode is already configured — skip to step 4.
+
+Otherwise, on first login the setup wizard will prompt for your DigitalOcean Gradient model access key. To create one:
 
 1. Go to https://cloud.digitalocean.com/gen-ai/model-access-keys
 2. Click **Create Model Access Key**
@@ -82,11 +84,13 @@ The default model is **Kimi K2.5** (`digitalocean/kimi-k2.5` via DigitalOcean Gr
 | Check version | `/opt/opencode-version.sh` |
 | Update to latest | `/opt/update-opencode.sh` |
 | Re-run setup wizard | `/opt/setup-opencode.sh` |
+| Apply Gradient from env | `/opt/apply-gradient-from-env.sh` |
 
 ### Configuration
 
 - **OpenCode config**: `/root/.config/opencode/opencode.json`
 - **Auth / API key**: `/root/.local/share/opencode/auth.json`
+- **Gradient env vars**: `/opt/opencode.env` (`GRADIENT_KEY`, `GRADIENT_MODEL`)
 - **Getting started guide**: `cat /root/opencode_info.txt`
 
 ### Inference usage (Gradient)

--- a/opencode-24-04/scripts/010-opencode.sh
+++ b/opencode-24-04/scripts/010-opencode.sh
@@ -41,6 +41,8 @@ mkdir -p /root/.local/share/opencode
 chmod +x /opt/update-opencode.sh
 chmod +x /opt/opencode-version.sh
 chmod +x /opt/setup-opencode.sh
+chmod +x /opt/apply-gradient-from-env.sh
+chmod 600 /opt/opencode.env
 chmod +x /etc/update-motd.d/99-one-click
 chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
 


### PR DESCRIPTION
If GRADIENT_KEY (and optional GRADIENT_MODEL) are passed at droplet creation, OpenCode configures Gradient on first boot and skips the setup wizard. Default model is minimax-m2.5 when GRADIENT_MODEL is not set.

Also retries auto-config after cloud-init, since Startup scripts can write the key after 001_onboot.