### PR TITLE
Add Keycloak 1-Click for Ubuntu 24.04

### DIFF
--- a/keycloak-22-04/scripts/01-keycloak.sh
+++ b/keycloak-22-04/scripts/01-keycloak.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-# non-interactive install
 export DEBIAN_FRONTEND=noninteractive
 
-sudo apt -y install postgresql docker.io docker-compose super
 systemctl start docker
 systemctl enable docker
 

--- a/keycloak-24-04/files/etc/nginx/sites-available/keycloak
+++ b/keycloak-24-04/files/etc/nginx/sites-available/keycloak
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name _;
+
+    location ~ /.well-known {
+        allow all;
+    }
+
+    location / {
+        proxy_pass https://localhost:8443;
+        proxy_set_header Host $host:8443;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 9001;
+    server_name _;
+
+    location ~ /.well-known {
+        allow all;
+    }
+
+    location / {
+        proxy_pass https://localhost:9000;
+        proxy_set_header Host $host:9000;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/keycloak-24-04/files/etc/update-motd.d/99-one-click
+++ b/keycloak-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+# Read in the passwords....
+. /root/.digitalocean_passwords
+
+dbaas_text=""
+if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
+    . /root/.digitalocean_dbaas_credentials
+    dbaas_text="Keycloak is configured to use managed database. Use the following credentials to manage the database:
+    Database: keycloak
+    Host:     ${db_host}
+    Port:     ${db_port}
+    User:     keycloak
+    Pass:     ${KEYCLOAK_DATABASE_PASSWORD}"
+else
+    dbaas_text="Keycloak is configured to use local Postgres as its database. Use the following credentials to manage the database:
+    Database: keycloak
+    User:     keycloak
+    Pass:     ${KEYCLOAK_DATABASE_PASSWORD}"
+fi
+
+myip=$(hostname -I | awk '{print$1}')
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's 1-Click Keycloak Droplet.
+To keep this Droplet secure, the UFW firewall is enabled.
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), 443 (HTTPS), 8443 and 9000 (Keycloak ports).
+
+Access the Keycloak dashboard
+    URL: https://${myip}
+    User: admin
+    Pass: ${KEYCLOAK_ADMIN_PASSWORD}
+
+${dbaas_text}
+
+On the server:
+  * The Keycloak application is served as Docker container
+  * To check Keycloak logs use:
+    $ docker logs keycloak
+  * The Keycloak admin and database passwords are saved in /root/.digitalocean_passwords
+  * Certbot is preinstalled. Run it to configure HTTPS.
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/keycloak-24-04/files/var/digitalocean/Dockerfile
+++ b/keycloak-24-04/files/var/digitalocean/Dockerfile
@@ -1,0 +1,26 @@
+FROM quay.io/keycloak/keycloak:25.0 as builder
+
+# Enable health and metrics support
+ENV KC_HEALTH_ENABLED=true
+ENV KC_METRICS_ENABLED=true
+
+# Configure a database vendor
+ENV KC_DB=postgres
+
+ARG STORE_PASS
+
+WORKDIR /opt/keycloak
+
+RUN keytool -genkeypair -storepass $STORE_PASS -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=server" -alias server -ext "SAN:c=DNS:localhost,IP:127.0.0.1" -keystore conf/server.keystore
+
+RUN /opt/keycloak/bin/kc.sh build
+
+
+
+FROM quay.io/keycloak/keycloak:25.0
+
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
+
+ENV KC_DB=postgres
+
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]

--- a/keycloak-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/keycloak-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+DB_USER=keycloak
+DB_TYPE=postgres
+DB_HOST=localhost
+DB_PORT=5432
+
+KEYSTORE_PASSWORD=$(openssl rand -hex 16)
+KEYCLOAK_ADMIN_PASSWD=$(openssl rand -hex 16)
+DB_PASS=$(openssl rand -hex 16)
+
+cat > /root/.digitalocean_passwords <<EOM
+KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWD}
+KEYCLOAK_DATABASE_PASSWORD=${DB_PASS}
+KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD}
+EOM
+
+DROPLET_IP=$(hostname -I | awk '{print$1}')
+
+if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
+  DB_HOST=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  DB_PORT=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  DB_TYPE=$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+
+  DBAAS_DB_USER=$(sed -n "s/^db_username=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  DBAAS_DB_NAME=$(sed -n "s/^db_database=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  DBAAS_DB_PASS=$(sed -n "s/^db_password=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+
+  # Convert postgresql into postgres
+  if [ "${DB_TYPE}" == "postgresql" ]; then
+    DB_TYPE=postgres
+  fi
+
+  # Wait for db to become available
+  while ! pg_isready -h "$DB_HOST" -p "$DB_PORT"; do
+     printf .
+     sleep 2
+  done
+
+  PGPASSWORD=${DBAAS_DB_PASS} psql -h ${DB_HOST} -p ${DB_PORT} -U ${DBAAS_DB_USER} -d ${DBAAS_DB_NAME} -c "CREATE USER keycloak PASSWORD '${DB_PASS}';" --set=sslmode=require
+  PGPASSWORD=${DBAAS_DB_PASS} psql -h ${DB_HOST} -p ${DB_PORT} -U ${DBAAS_DB_USER} -d ${DBAAS_DB_NAME} -c "CREATE DATABASE keycloak WITH ENCODING 'UTF8';" --set=sslmode=require
+  PGPASSWORD=${DBAAS_DB_PASS} psql -h ${DB_HOST} -p ${DB_PORT} -U ${DBAAS_DB_USER} -d ${DBAAS_DB_NAME} -c "GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;" --set=sslmode=require
+  PGPASSWORD=${DBAAS_DB_PASS} psql -h ${DB_HOST} -p ${DB_PORT} -U ${DBAAS_DB_USER} -d keycloak -c "GRANT ALL ON SCHEMA public TO keycloak;" --set=sslmode=require
+
+  systemctl stop postgresql.service
+  systemctl disable postgresql.service
+  rm -rf /etc/postgresql
+
+else
+  setuid postgres psql -U postgres -d postgres -c "CREATE USER keycloak PASSWORD '${DB_PASS}';"
+  setuid postgres createdb keycloak
+  setuid postgres psql -U postgres -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE keycloak TO keycloak;"
+  setuid postgres psql -U postgres -d keycloak -c "GRANT ALL ON SCHEMA public TO keycloak;"
+fi
+
+# Build keycloak image with randomized keystore password
+docker build --build-arg="STORE_PASS=${KEYSTORE_PASSWORD}" /var/digitalocean/. -t local-keycloak >> /var/temp.log
+
+# Run keycloak image with network mode set to host,
+# so Keycloak connects to the Postgres as localhost, not docker internal host
+docker run -d --network=host \
+  --name keycloak \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWD} \
+  -e KC_DB=${DB_TYPE} \
+  -e KC_DB_URL=jdbc:postgresql://${DB_HOST}:${DB_PORT}/keycloak \
+  -e KC_DB_USERNAME=${DB_USER} \
+  -e KC_DB_PASSWORD=${DB_PASS} \
+  -e KC_HOSTNAME=${DROPLET_IP} \
+  local-keycloak \
+  start \
+  --https-key-store-password=${KEYSTORE_PASSWORD} \
+  --optimized >> /var/temp.log
+
+
+# Allow ports used by keycloak for redirecting
+ufw allow 8443
+ufw allow 9000
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh

--- a/keycloak-24-04/scripts/01-keycloak.sh
+++ b/keycloak-24-04/scripts/01-keycloak.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+systemctl start docker
+systemctl enable docker
+
+# Set up nginx
+ln -s /etc/nginx/sites-available/keycloak /etc/nginx/sites-enabled/keycloak
+unlink /etc/nginx/sites-enabled/default
+service nginx restart

--- a/keycloak-24-04/template.json
+++ b/keycloak-24-04/template.json
@@ -1,0 +1,80 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "keycloak-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "postgresql docker.io docker-compose super nginx python3 python3-certbot python3-certbot-nginx",
+    "application_name": "Keycloak",
+    "application_version": "latest"
+  },
+  "sensitive-variables": [
+    "do_api_token"
+  ],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "keycloak-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "keycloak-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "cloud-init status --wait",
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "keycloak-24-04/scripts/01-keycloak.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/014-ufw-nginx.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Fix the Keycloak 22.04 Packer build hang by removing a redundant `apt install postgresql` that triggered an interactive PostgreSQL 16→18 cluster upgrade in a non-TTY SSH session.
- Add a new `keycloak-24-04` 1-click builder on Ubuntu 24.04, using PostgreSQL from Ubuntu repos and the existing Keycloak Docker/nginx setup.

## Test plan
- [x] `packer build keycloak-22-04/template.json` completes without hanging on PostgreSQL configuration
- [x] `packer build keycloak-24-04/template.json` completes provisioning (PostgreSQL install, `01-keycloak.sh`, nginx/ufw scripts)
- [ ] Deploy a Keycloak 24.04 droplet and verify first-boot creates the database, builds the Docker image, and serves the admin console over HTTPS