### PR TITLE
Fix 1-Click scaffold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-.PHONY: build-% update-scripts validate-%
+.PHONY: app build-% update-scripts validate-%
+
+OS_VERSION ?= 24-04
+
+app:
+	@if [ -z "$(NAME)" ]; then \
+		echo "Usage: make app NAME=<app-name> [OS_VERSION=<os-version>]" >&2; \
+		exit 1; \
+	fi
+	./scripts/create-1-click.sh "$(NAME)" "$(OS_VERSION)"
 
 %:
-	./scripts/create-1-click.sh $* $*
+	./scripts/create-1-click.sh $* "$(OS_VERSION)"
 
 build-%:
 	packer build $*/template.json

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build-% update-scripts validate-%
 
 %:
-	./scripts/create-1-click.sh $* $*-20-04
+	./scripts/create-1-click.sh $* $*
 
 build-%:
 	packer build $*/template.json

--- a/README.md
+++ b/README.md
@@ -53,7 +53,19 @@ Running `packer build {{image-name}}/template.json` without any other modificati
 
 ### Creating a new 1-Click
 
-To start adopting this configuration for your image, you can create a scaffold using the command `make {{image-name}}` which will create a directory `{{image-name}}` with a basic Packer build config.
+To start adopting this configuration for your image, create a scaffold with the 1-Click name and optional OS version:
+
+```sh
+make app NAME={{1-click-name}}
+```
+
+This creates a directory named `{{1-click-name}}-24-04` with a basic Packer build config. To use a different OS version suffix, pass `OS_VERSION`:
+
+```sh
+make app NAME={{1-click-name}} OS_VERSION=22-04
+```
+
+This creates a directory named `{{1-click-name}}-22-04`.
 
 The following variables are required.
 

--- a/_template/template.json
+++ b/_template/template.json
@@ -12,7 +12,7 @@
     {
       "type": "digitalocean",
       "api_token": "{{user `do_api_token`}}",
-      "image": "ubuntu-20-04-x64",
+      "image": "ubuntu-24-04-x64",
       "region": "nyc3",
       "size": "s-1vcpu-1gb",
       "ssh_username": "root",

--- a/_template/template.json
+++ b/_template/template.json
@@ -12,7 +12,7 @@
     {
       "type": "digitalocean",
       "api_token": "{{user `do_api_token`}}",
-      "image": "ubuntu-24-04-x64",
+      "image": "ubuntu-{{OS_VERSION}}-x64",
       "region": "nyc3",
       "size": "s-1vcpu-1gb",
       "ssh_username": "root",

--- a/scripts/create-1-click.sh
+++ b/scripts/create-1-click.sh
@@ -17,7 +17,8 @@ create() {
   fi
 
   name=$1
-  image_label=$2
+  label=$2
+  image_label="${name}-${label}"
 
   if [ -d "$image_label" ]
   then

--- a/scripts/create-1-click.sh
+++ b/scripts/create-1-click.sh
@@ -31,7 +31,6 @@ create() {
 
   < "$template_dir/$build_template" \
   sed \
-    -e "s#{{NAME}}#${name}#g;" \
     -e "s#{{IMAGE_LABEL}}#${image_label}#g;" \
   > "$image_label/template.json"
 }

--- a/scripts/create-1-click.sh
+++ b/scripts/create-1-click.sh
@@ -31,6 +31,7 @@ create() {
 
   < "$template_dir/$build_template" \
   sed \
+    -e "s#{{OS_VERSION}}#${label}#g;" \
     -e "s#{{IMAGE_LABEL}}#${image_label}#g;" \
   > "$image_label/template.json"
 }


### PR DESCRIPTION
## Summary
- Add make app NAME=<name> [OS_VERSION=<version>] scaffold creation with a default 24-04 suffix.
- Generate scaffold directories and snapshot names as <name>-<os-version>.
- Make the template base image follow OS_VERSION and document the new scaffold command.