### PR TITLE
Add KiloCode 24.04 1-Click builder

### DIFF
--- a/kilocode-24-04/files/etc/update-motd.d/99-one-click
+++ b/kilocode-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's One-Click Kilo Code CLI Droplet.
+
+Kilo Code is an open-source AI coding agent CLI. Use natural language to plan,
+write, debug, and refactor code directly from your terminal.
+
+GETTING STARTED:
+
+  Optional DigitalOcean model access key setup:
+
+     The first-login setup helper will ask for DIGITALOCEAN_ACCESS_TOKEN.
+     If you do not have one, press Enter to skip setup; Kilo will start
+     automatically.
+
+     To configure it later, export your model access key as
+     DIGITALOCEAN_ACCESS_TOKEN and apply it:
+
+       export DIGITALOCEAN_ACCESS_TOKEN=your_token_here
+       /opt/apply-digitalocean-token.sh
+
+     Create or manage keys at:
+     https://cloud.digitalocean.com/model-studio/manage-keys
+
+  Kilo Code starts automatically after the first-login setup prompt.
+  To run it again later:
+     kilo
+
+Helper Commands:
+  Update Kilo Code:   /opt/update-kilocode.sh
+  Re-run setup:       /opt/setup-kilocode.sh --force
+
+Documentation:  https://kilo.ai/docs/code-with-ai/platforms/cli
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/kilocode-24-04/files/opt/apply-digitalocean-token.sh
+++ b/kilocode-24-04/files/opt/apply-digitalocean-token.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Apply a DigitalOcean model access key from DIGITALOCEAN_ACCESS_TOKEN.
+# Returns 0 when a usable token was applied; 1 when skipped.
+set -euo pipefail
+
+PROFILED=/etc/profile.d/kilocode-digitalocean.sh
+SETUP_MARKER=/root/.kilocode_setup_complete
+BASHRC_BEGIN='# kilocode-24-04-digitalocean-env BEGIN'
+BASHRC_END='# kilocode-24-04-digitalocean-env END'
+BASHRC_RANGE_BEGIN='kilocode-24-04-digitalocean-env BEGIN'
+BASHRC_RANGE_END='kilocode-24-04-digitalocean-env END'
+
+env_value_usable() {
+  local value="$1"
+  [ -n "$value" ] || return 1
+  case "$value" in
+    *'${'*|PLACEHOLDER*|your_*_here) return 1 ;;
+  esac
+  return 0
+}
+
+remove_setup_wizard_bashrc_hook() {
+  [ -f /root/.bashrc ] || return 0
+  sed -i '/\/opt\/setup-kilocode\.sh/d' /root/.bashrc
+}
+
+ensure_token_sourced() {
+  touch /root/.bashrc
+  if ! grep -qF "$BASHRC_RANGE_BEGIN" /root/.bashrc 2>/dev/null; then
+    {
+      echo ""
+      echo "$BASHRC_BEGIN"
+      echo "[ -f $PROFILED ] && . $PROFILED"
+      echo "$BASHRC_END"
+    } >> /root/.bashrc
+  fi
+}
+
+write_profiled() {
+  local token="$1"
+  umask 077
+  mkdir -p /etc/profile.d
+  {
+    printf 'export DIGITALOCEAN_ACCESS_TOKEN=%q\n' "$token"
+    printf 'export KILO_PROVIDER_TYPE=digitalocean\n'
+  } > "$PROFILED"
+  chmod 600 "$PROFILED"
+}
+
+redact_token_from_system_environment() {
+  local env_file=/etc/environment
+  [ -f "$env_file" ] || return 0
+  grep -Ev '^DIGITALOCEAN_ACCESS_TOKEN=' "$env_file" >"${env_file}.tmp" 2>/dev/null || : >"${env_file}.tmp"
+  mv "${env_file}.tmp" "$env_file"
+  chmod 644 "$env_file"
+}
+
+DIGITALOCEAN_TOKEN="${DIGITALOCEAN_ACCESS_TOKEN-}"
+
+if ! env_value_usable "$DIGITALOCEAN_TOKEN"; then
+  exit 1
+fi
+
+write_profiled "$DIGITALOCEAN_TOKEN"
+ensure_token_sourced
+remove_setup_wizard_bashrc_hook
+redact_token_from_system_environment
+touch "$SETUP_MARKER"
+
+echo "Testing DigitalOcean model access key..."
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer ${DIGITALOCEAN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  https://inference.do-ai.run/v1/models 2>/dev/null || true)
+
+if [ "$HTTP_STATUS" = "200" ]; then
+  echo "DigitalOcean model access key saved for Kilo Code sessions."
+else
+  echo "DigitalOcean model access key saved for Kilo Code."
+  echo "Warning: Received HTTP ${HTTP_STATUS:-000} from the inference API." >&2
+fi
+
+exit 0

--- a/kilocode-24-04/files/opt/setup-kilocode.sh
+++ b/kilocode-24-04/files/opt/setup-kilocode.sh
@@ -35,8 +35,7 @@ echo ""
 
 old_histfile="${HISTFILE-}"
 unset HISTFILE
-read -rsp "Enter DIGITALOCEAN_ACCESS_TOKEN (or press Enter to skip): " MODEL_KEY
-echo ""
+read -rp "Enter DIGITALOCEAN_ACCESS_TOKEN (or press Enter to skip): " MODEL_KEY
 [ -n "${old_histfile:-}" ] && export HISTFILE="$old_histfile"
 
 if [ -z "$MODEL_KEY" ]; then

--- a/kilocode-24-04/files/opt/setup-kilocode.sh
+++ b/kilocode-24-04/files/opt/setup-kilocode.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Kilo Code first-login setup helper.
+# Prompts for a DigitalOcean model access key, then gets out of the way.
+
+SETUP_MARKER="/root/.kilocode_setup_complete"
+
+if [ -f "$SETUP_MARKER" ] && [ "$1" != "--force" ]; then
+  if ! grep -q '/opt/setup-kilocode.sh' /root/.bashrc 2>/dev/null; then
+    exit 0
+  fi
+  rm -f "$SETUP_MARKER"
+fi
+
+if [ "$1" != "--force" ] && [ -x /opt/apply-digitalocean-token.sh ]; then
+  if /opt/apply-digitalocean-token.sh; then
+    exit 0
+  fi
+fi
+
+echo ""
+echo "========================================================================"
+echo "  Kilo Code CLI Setup"
+echo "========================================================================"
+echo ""
+echo "This droplet can save a DigitalOcean model access key for Kilo Code"
+echo "sessions using DIGITALOCEAN_ACCESS_TOKEN."
+echo ""
+echo "If you do not have a token yet, press Enter to skip setup."
+echo "Kilo will start automatically afterward."
+echo ""
+echo "Create or manage DigitalOcean model access keys at:"
+echo "  https://cloud.digitalocean.com/model-studio/manage-keys"
+echo ""
+
+old_histfile="${HISTFILE-}"
+unset HISTFILE
+read -rsp "Enter DIGITALOCEAN_ACCESS_TOKEN (or press Enter to skip): " MODEL_KEY
+echo ""
+[ -n "${old_histfile:-}" ] && export HISTFILE="$old_histfile"
+
+if [ -z "$MODEL_KEY" ]; then
+  echo ""
+  echo "No token entered. Skipping DigitalOcean model access key setup."
+  echo "You can still run Kilo now:"
+  echo "  cd /path/to/your/project && kilo"
+  echo ""
+  echo "To configure a DigitalOcean model access key later:"
+  echo "  export DIGITALOCEAN_ACCESS_TOKEN=your_token"
+  echo "  /opt/apply-digitalocean-token.sh"
+  touch "$SETUP_MARKER"
+  sed -i '/\/opt\/setup-kilocode.sh/d' /root/.bashrc
+  exit 0
+fi
+
+DIGITALOCEAN_ACCESS_TOKEN="$MODEL_KEY" /opt/apply-digitalocean-token.sh
+
+echo ""
+echo "========================================================================"
+echo "  Setup complete! Kilo Code CLI is ready to use."
+echo ""
+echo "  To start:  cd /path/to/your/project && kilo"
+echo "  Token env: DIGITALOCEAN_ACCESS_TOKEN"
+echo "  Provider:  KILO_PROVIDER_TYPE=digitalocean"
+echo "========================================================================"
+echo ""

--- a/kilocode-24-04/files/opt/update-kilocode.sh
+++ b/kilocode-24-04/files/opt/update-kilocode.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo "Updating Kilo Code CLI to the latest version..."
+npm update --global @kilocode/cli
+
+echo "Kilo Code CLI updated successfully."
+echo "Current version: $(kilo --version 2>/dev/null || echo 'unknown')"

--- a/kilocode-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/kilocode-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -e
+
+set -a
+source /etc/environment 2>/dev/null || true
+set +a
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh
+
+chmod +x /opt/apply-digitalocean-token.sh
+
+DIGITALOCEAN_APPLIED=0
+if /opt/apply-digitalocean-token.sh; then
+    DIGITALOCEAN_APPLIED=1
+    echo "DIGITALOCEAN_ACCESS_TOKEN saved for Kilo Code sessions."
+fi
+
+# On first SSH login, ask for the optional model access key, then start Kilo.
+if ! grep -q 'kilocode-24-04-first-login BEGIN' /root/.bashrc 2>/dev/null; then
+    cat >> /root/.bashrc <<'EOM'
+
+# kilocode-24-04-first-login BEGIN
+if [ ! -f /root/.kilocode_first_login_complete ]; then
+  [ -f /etc/profile.d/kilocode-digitalocean.sh ] && . /etc/profile.d/kilocode-digitalocean.sh
+  /opt/setup-kilocode.sh
+  [ -f /etc/profile.d/kilocode-digitalocean.sh ] && . /etc/profile.d/kilocode-digitalocean.sh
+  touch /root/.kilocode_first_login_complete
+  kilo
+fi
+# kilocode-24-04-first-login END
+EOM
+fi
+
+if [ "$DIGITALOCEAN_APPLIED" -eq 1 ]; then
+    cat > /root/kilocode_info.txt << 'EOF'
+================================================================================
+Kilo Code CLI 1-Click Droplet - Getting Started
+================================================================================
+
+Kilo Code is an open-source AI coding agent CLI. It is installed as `kilo`
+and can run from any project directory.
+
+DIGITALOCEAN_ACCESS_TOKEN was configured automatically from a DigitalOcean
+model access key.
+
+FIRST LOGIN:
+
+Kilo Code will start automatically after the first-login setup check.
+
+Helper commands:
+   Update Kilo Code:   /opt/update-kilocode.sh
+   Re-run setup:       /opt/setup-kilocode.sh --force
+
+Token env:      DIGITALOCEAN_ACCESS_TOKEN
+Provider env:   KILO_PROVIDER_TYPE=digitalocean
+Documentation:  https://kilo.ai/docs/code-with-ai/platforms/cli
+
+================================================================================
+EOF
+else
+    cat > /root/kilocode_info.txt << 'EOF'
+================================================================================
+Kilo Code CLI 1-Click Droplet - Getting Started
+================================================================================
+
+Kilo Code is an open-source AI coding agent CLI. It is installed as `kilo`
+and can run from any project directory.
+
+OPTIONAL DIGITALOCEAN MODEL ACCESS KEY SETUP:
+
+The first-login setup helper will ask for DIGITALOCEAN_ACCESS_TOKEN. If you
+do not have one, press Enter to skip setup; Kilo will start automatically.
+
+To configure a DigitalOcean model access key later, export it as
+DIGITALOCEAN_ACCESS_TOKEN and apply it:
+
+   export DIGITALOCEAN_ACCESS_TOKEN=your_token_here
+   /opt/apply-digitalocean-token.sh
+
+Create or manage keys at:
+   https://cloud.digitalocean.com/model-studio/manage-keys
+
+If you skip token setup, Kilo still starts automatically. Configure providers
+from inside the CLI when needed.
+
+FIRST LOGIN:
+
+Kilo Code will start automatically after the setup prompt.
+
+Helper commands:
+   Update Kilo Code:   /opt/update-kilocode.sh
+   Re-run setup:       /opt/setup-kilocode.sh --force
+
+Documentation:  https://kilo.ai/docs/code-with-ai/platforms/cli
+
+================================================================================
+EOF
+fi
+
+chmod 600 /root/kilocode_info.txt
+
+echo "Kilo Code CLI first-boot initialization complete!"
+echo "Getting started info saved to /root/kilocode_info.txt"

--- a/kilocode-24-04/listing.md
+++ b/kilocode-24-04/listing.md
@@ -1,0 +1,112 @@
+# Kilo Code CLI 1-Click Application
+
+Deploy Kilo Code CLI, an open-source AI coding agent that runs in your terminal. Kilo helps you plan, write, debug, and refactor code from an SSH session, with optional DigitalOcean model access key setup.
+
+## What is Kilo Code?
+
+Kilo Code is an AI coding agent for terminal-first development workflows. It uses the same foundation as the Kilo IDE extension and provides a keyboard-first command-line experience for working on code directly on your Droplet.
+
+## Key Features
+
+- **Terminal-first AI agent** - Run `kilo` from any project directory
+- **DigitalOcean model access key setup** - Optional helper saves `DIGITALOCEAN_ACCESS_TOKEN` for shell sessions
+- **Agent modes** - Plan, debug, ask questions, and orchestrate coding work
+- **Provider flexibility** - Start Kilo and configure providers from the CLI when needed
+- **SSH only** - No public web interface is exposed by default
+
+## System Requirements
+
+Kilo Code is lightweight; most compute happens at the model provider.
+
+| Use Case | RAM | CPU | Storage |
+|----------|-----|-----|---------|
+| Minimum | 1 GB | 1 vCPU | 25 GB |
+| Recommended | 2 GB | 2 vCPU | 50 GB |
+
+## Included System Components
+
+- **Ubuntu 24.04 LTS** - Base operating system
+- **Kilo Code CLI** - Installed from npm as `@kilocode/cli`
+- **Node.js LTS** - Runtime for Kilo Code CLI
+- **Git**, **curl**, **jq**, **unzip** - Common development utilities
+- **UFW Firewall** - SSH only, rate-limited
+
+## Getting Started
+
+### 1. Deploy the Droplet
+
+1. Select this 1-Click App from the DigitalOcean Marketplace
+2. Choose a Droplet size
+3. Add your SSH key for secure access
+4. Create the Droplet
+
+### 2. SSH In
+
+```bash
+ssh root@your-droplet-ip
+```
+
+### 3. Optional DigitalOcean Model Access Key Setup
+
+On first login, the setup helper asks for `DIGITALOCEAN_ACCESS_TOKEN`. If you do not have a token, press Enter to skip setup. Kilo starts automatically after the prompt either way.
+
+Create a DigitalOcean model access key at https://cloud.digitalocean.com/model-studio/manage-keys, export it as `DIGITALOCEAN_ACCESS_TOKEN`, and apply it:
+
+```bash
+export DIGITALOCEAN_ACCESS_TOKEN=your_token_here
+/opt/apply-digitalocean-token.sh
+```
+
+The helper stores the token for future shell sessions. If you do not have a token yet, skip this step and Kilo will still start.
+
+### 4. Run Kilo Code Later
+
+```bash
+cd /path/to/your/project
+kilo
+```
+
+## Managing Kilo Code
+
+| Action | Command |
+|--------|---------|
+| Update Kilo Code | `/opt/update-kilocode.sh` |
+| Re-run setup | `/opt/setup-kilocode.sh --force` |
+
+## Configuration
+
+- **DigitalOcean token env**: `DIGITALOCEAN_ACCESS_TOKEN`
+- **Kilo provider env**: `KILO_PROVIDER_TYPE=digitalocean`
+- **Getting started guide**: `cat /root/kilocode_info.txt`
+
+## Troubleshooting
+
+### Kilo not found in PATH
+
+Open a new login shell or check the npm global binary path:
+
+```bash
+npm bin -g
+```
+
+### DigitalOcean inference is not working
+
+Verify the token is available and re-apply it:
+
+```bash
+export DIGITALOCEAN_ACCESS_TOKEN=your_token_here
+/opt/apply-digitalocean-token.sh
+```
+
+If you do not want to use a DigitalOcean model access key, start Kilo and
+configure providers from inside the CLI when needed.
+
+## Additional Resources
+
+- **Documentation**: https://kilo.ai/docs
+- **CLI Guide**: https://kilo.ai/docs/code-with-ai/platforms/cli
+- **Install Guide**: https://kilo.ai/docs/getting-started/installing
+
+---
+
+**Note**: This 1-Click installs Kilo Code CLI via npm and includes optional DigitalOcean model access key setup. SSH is the only exposed port.

--- a/kilocode-24-04/readme.md
+++ b/kilocode-24-04/readme.md
@@ -1,0 +1,82 @@
+# Kilo Code CLI 1-Click Droplet Builder
+
+This directory contains the Packer builder configuration for creating a Kilo Code CLI 1-Click DigitalOcean Droplet image.
+
+## Overview
+
+Kilo Code CLI is an open-source AI coding agent that runs in the terminal. Users SSH into the Droplet and run `kilo` to work on code with AI assistance. This builder creates an Ubuntu 24.04 LTS Droplet with Node.js LTS, Kilo Code CLI, and optional DigitalOcean model access key setup.
+
+## Directory Structure
+
+```text
+kilocode-24-04/
+├── template.json
+├── readme.md
+├── listing.md
+├── scripts/
+│   └── 010-kilocode.sh
+└── files/
+    ├── etc/
+    │   └── update-motd.d/
+    │       └── 99-one-click
+    ├── opt/
+    │   ├── apply-digitalocean-token.sh
+    │   ├── setup-kilocode.sh
+    │   └── update-kilocode.sh
+    └── var/
+        └── lib/
+            └── cloud/
+                └── scripts/
+                    └── per-instance/
+                        └── 001_onboot
+```
+
+## Build Requirements
+
+1. **Packer**: Install from https://www.packer.io/downloads
+2. **DigitalOcean API Token**: Generate with write access from https://cloud.digitalocean.com/account/api/tokens
+
+```bash
+export DIGITALOCEAN_API_TOKEN="your_api_token_here"
+```
+
+## Building the Image
+
+```bash
+packer validate kilocode-24-04/template.json
+make build-kilocode-24-04
+# or: packer build kilocode-24-04/template.json
+```
+
+## What Gets Installed
+
+- **Kilo Code CLI** from npm package `@kilocode/cli`
+- **Node.js LTS** via the shared `common/scripts/010-nodejs.sh`
+- **DigitalOcean model access key helper** for `DIGITALOCEAN_ACCESS_TOKEN`
+- **Git**, **curl**, **jq**, **unzip**, **UFW** and related system utilities
+
+## First Boot Behavior
+
+1. Removes the SSH force-logout rule
+2. Sources `/etc/environment` and checks for `DIGITALOCEAN_ACCESS_TOKEN`
+3. If present, persists it and `KILO_PROVIDER_TYPE=digitalocean` to root-only files for future shell sessions
+4. Hooks first login to run `/opt/setup-kilocode.sh`, reload the saved token if present, and start `kilo`
+5. Writes `/root/kilocode_info.txt` with token setup and first-login instructions
+
+## First Login Experience
+
+The MOTD and setup helper ask for `DIGITALOCEAN_ACCESS_TOKEN`. If the user does not have one, they can press Enter to skip setup. Kilo starts automatically after the first-login setup prompt in both cases.
+
+To configure a DigitalOcean model access key later, export `DIGITALOCEAN_ACCESS_TOKEN` and run `/opt/apply-digitalocean-token.sh`. Model access keys are managed at https://cloud.digitalocean.com/model-studio/manage-keys.
+
+## Version Pinning
+
+The `application_version` variable in `template.json` pins the npm package version. To bump:
+
+1. Check the latest release: `npm view @kilocode/cli version`
+2. Edit `application_version` in `template.json`
+3. Rebuild the image
+
+## License
+
+This builder configuration follows the same license as the droplet-1-clicks repository. Kilo Code licensing is provided by the upstream Kilo project.

--- a/kilocode-24-04/scripts/010-kilocode.sh
+++ b/kilocode-24-04/scripts/010-kilocode.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+# Configure UFW firewall - SSH only (no web interface)
+ufw limit ssh/tcp
+ufw --force enable
+echo "Firewall configured successfully."
+
+echo "Installing Kilo Code CLI ${application_version} from npm..."
+npm install --global "@kilocode/cli@${application_version}"
+
+# Verify installation
+if command -v kilo >/dev/null 2>&1; then
+  echo "Kilo Code CLI installed successfully: $(kilo --version 2>/dev/null || echo 'version check skipped')"
+else
+  echo "Error: Kilo Code CLI installation failed"
+  exit 1
+fi
+
+# Make helper scripts, MOTD, and onboot script executable (copied by Packer)
+chmod +x /opt/apply-digitalocean-token.sh
+chmod +x /opt/setup-kilocode.sh
+chmod +x /opt/update-kilocode.sh
+chmod +x /etc/update-motd.d/99-one-click
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+
+echo "Kilo Code CLI installation complete."

--- a/kilocode-24-04/template.json
+++ b/kilocode-24-04/template.json
@@ -1,0 +1,63 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "kilocode-24-04-snapshot-{{timestamp}}",
+    "node_version": "lts.x",
+    "apt_packages": "apt-transport-https ca-certificates curl software-properties-common git jq unzip ufw",
+    "application_name": "Kilo Code CLI",
+    "application_version": "7.3.46"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {"type": "shell", "inline": ["cloud-init status --wait"]},
+    {"type": "file", "source": "common/files/var/", "destination": "/var/"},
+    {"type": "file", "source": "kilocode-24-04/files/etc/", "destination": "/etc/"},
+    {"type": "file", "source": "kilocode-24-04/files/opt/", "destination": "/opt/"},
+    {"type": "file", "source": "kilocode-24-04/files/var/", "destination": "/var/"},
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "NODE_VERSION={{user `node_version`}}",
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "common/scripts/010-nodejs.sh",
+        "kilocode-24-04/scripts/010-kilocode.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a new Ubuntu 24.04 Packer builder for Kilo Code CLI.
- Install Node.js LTS and @kilocode/cli with SSH-only firewall defaults.
- Add first-login model access key setup, MOTD/onboot instructions, and Marketplace docs.


Made with [Cursor](https://cursor.com)