### PR TITLE
Update Codex Universal image handling

### DIFF
--- a/codex-universal-24-04/files/opt/codex-universal/codex-universal-version.sh
+++ b/codex-universal-24-04/files/opt/codex-universal/codex-universal-version.sh
@@ -5,16 +5,13 @@ TEMPLATE="/opt/codex-universal/codex-universal.env"
 
 if [ -f "$ENV_FILE" ]; then
     IMAGE="$(grep -E '^IMAGE=' "$ENV_FILE" | cut -d= -f2- || echo unknown)"
-    IMAGE_DIGEST="$(grep -E '^IMAGE_DIGEST=' "$ENV_FILE" | cut -d= -f2- || echo unknown)"
     TAG="$(grep -E '^TAG=' "$ENV_FILE" | cut -d= -f2- || echo unknown)"
 else
     IMAGE="$(grep -E '^IMAGE=' "$TEMPLATE" | cut -d= -f2- || echo unknown)"
-    IMAGE_DIGEST="$(grep -E '^IMAGE_DIGEST=' "$TEMPLATE" | cut -d= -f2- || echo unknown)"
     TAG="$(grep -E '^TAG=' "$TEMPLATE" | cut -d= -f2- || echo unknown)"
 fi
 
 echo "Codex Universal image: ${IMAGE}"
-echo "Image digest: ${IMAGE_DIGEST}"
 echo "Tag label: ${TAG}"
 
 if docker ps -a --format '{{.Names}}' | grep -qx codex-universal; then

--- a/codex-universal-24-04/files/opt/codex-universal/codex-universal.env
+++ b/codex-universal-24-04/files/opt/codex-universal/codex-universal.env
@@ -6,9 +6,8 @@
 # See supported versions:
 #   https://github.com/openai/codex-universal#configuring-language-runtimes
 
-# Pinned image (updated via template.json image_digest at build time)
-IMAGE=ghcr.io/openai/codex-universal@sha256:905e512f36460e1be4cfedb30928a8a28299edb0fcd5de7998ceaa72d27fe304
-IMAGE_DIGEST=sha256:905e512f36460e1be4cfedb30928a8a28299edb0fcd5de7998ceaa72d27fe304
+# Upstream image tag pulled during build and first boot
+IMAGE=ghcr.io/openai/codex-universal:latest
 TAG=latest
 
 CODEX_ENV_PYTHON_VERSION=3.12

--- a/codex-universal-24-04/files/opt/codex-universal/update-codex-universal.sh
+++ b/codex-universal-24-04/files/opt/codex-universal/update-codex-universal.sh
@@ -9,7 +9,6 @@ if [ ! -f "$ENV_FILE" ]; then
 fi
 
 IMAGE_REF="$(grep -E '^IMAGE=' "$ENV_FILE" | cut -d= -f2- || true)"
-IMAGE_DIGEST="$(grep -E '^IMAGE_DIGEST=' "$ENV_FILE" | cut -d= -f2- || true)"
 
 if [ -z "$IMAGE_REF" ]; then
     echo "ERROR: IMAGE is not set in $ENV_FILE." >&2
@@ -27,5 +26,4 @@ systemctl restart codex-universal
 
 echo "Codex Universal updated successfully."
 echo ""
-echo "To pin a new digest, update IMAGE and IMAGE_DIGEST in $ENV_FILE"
-echo "and in template.json (image_digest), then rebuild the 1-click snapshot."
+echo "To change the image tag, update IMAGE in $ENV_FILE, then rerun this script."

--- a/codex-universal-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/codex-universal-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -30,6 +30,13 @@ systemctl restart ssh
 
 systemctl enable codex-universal
 
+echo "Updating Codex Universal before first start..."
+if /opt/codex-universal/update-codex-universal.sh; then
+    echo "Codex Universal update complete."
+else
+    echo "WARNING: Codex Universal update failed. Continuing with the installed image."
+fi
+
 echo "Starting Codex Universal dev container (language setup may take a few minutes on first boot)..."
 if systemctl start codex-universal; then
     echo "Codex Universal is ready."

--- a/codex-universal-24-04/listing.md
+++ b/codex-universal-24-04/listing.md
@@ -127,19 +127,19 @@ journalctl -u codex-universal -f
 
 ## Updating
 
-Pull the pinned image and restart:
+Pull the latest configured image and restart:
 
 ```bash
 /opt/codex-universal/update-codex-universal.sh
 ```
 
-The image is pinned by digest (`IMAGE` and `IMAGE_DIGEST` in `/opt/codex-universal/.env`) for reproducible builds. To adopt a newer upstream release, update the digest in the env file and rebuild the 1-click snapshot, or edit `IMAGE` / `IMAGE_DIGEST` manually after verifying the new digest.
+The image defaults to `ghcr.io/openai/codex-universal:latest`. To use a different tag, edit `IMAGE` in `/opt/codex-universal/.env`, then rerun the update helper.
 
 ## Security Notes
 
 - Only SSH (port 22) is exposed by default; UFW rate-limits SSH connections
 - No web interface or HTTP ports are opened
-- Docker image is pinned by digest at build time (see `IMAGE_DIGEST` in `.env`)
+- Docker image is pulled from the upstream latest tag at build time and first boot
 - `CODEX_ENV_*` droplet environment variables are validated against upstream supported versions on first boot
 - Store secrets and API keys outside the image; configure them at runtime
 - The dev container runs as root — suitable for development, not for production

--- a/codex-universal-24-04/readme.md
+++ b/codex-universal-24-04/readme.md
@@ -4,7 +4,7 @@ This directory contains the Packer builder configuration for creating a Codex Un
 
 ## Overview
 
-[Codex Universal](https://github.com/openai/codex-universal) is OpenAI's reference Docker image for the multi-language development environment used in Codex. This builder pre-installs Docker, pulls the official image (pinned by digest), and configures a persistent dev container with a mounted workspace at `/root/workspace`.
+[Codex Universal](https://github.com/openai/codex-universal) is OpenAI's reference Docker image for the multi-language development environment used in Codex. This builder pre-installs Docker, pulls the official latest image, and configures a persistent dev container with a mounted workspace at `/root/workspace`.
 
 ## Directory Structure
 
@@ -70,29 +70,27 @@ The build uses an `s-2vcpu-4gb` Droplet because the codex-universal image is lar
 |----------|---------|-------------|
 | `application_name` | Codex Universal | Application tag name |
 | `application_version` | latest | Human-readable tag label (`TAG` in env file) |
-| `image_digest` | sha256:905e512f... | Pinned digest for `ghcr.io/openai/codex-universal` |
 
 Default language runtimes are set in `files/opt/codex-universal/codex-universal.env`. Users can override via droplet environment variables on first boot (validated against upstream supported versions).
 
-### Updating the pinned image digest
+### Updating the Codex Universal image
 
 ```bash
-docker pull ghcr.io/openai/codex-universal:latest
-docker inspect ghcr.io/openai/codex-universal:latest --format='{{index .RepoDigests 0}}'
+/opt/codex-universal/update-codex-universal.sh
 ```
 
-Update `image_digest` in `template.json` and `IMAGE` / `IMAGE_DIGEST` in `codex-universal.env`, then rebuild.
+The update helper pulls the configured image tag from `/opt/codex-universal/.env` and restarts the service. To use a different tag, update `IMAGE` in that file, then rerun the helper.
 
 ## Runtime Behavior
 
-1. **Packer build** — Installs Docker, pulls pinned image by digest, enables systemd unit; `.env` is not left in the snapshot
+1. **Packer build** — Installs Docker, pulls `ghcr.io/openai/codex-universal:latest`, enables systemd unit; `.env` is not left in the snapshot
 2. **First boot** — `001_onboot` creates `.env` from template, validates droplet env overrides, starts `codex-universal.service`
 3. **Usage** — User runs `/opt/codex-universal/shell-codex-universal.sh` to `docker exec` into the running container
 
 ## Security
 
 - SSH-only UFW firewall
-- Image pinned by digest
+- Codex Universal image pulled from the upstream latest tag
 - `CODEX_ENV_*` allowlist validation on boot
 - `security_opt: no-new-privileges:true` on the container
 - `/opt/codex-universal/test-codex-universal.sh` includes runtime security checks

--- a/codex-universal-24-04/scripts/010-codex-universal.sh
+++ b/codex-universal-24-04/scripts/010-codex-universal.sh
@@ -3,7 +3,6 @@
 set -e
 
 APP_VERSION="${application_version:-latest}"
-IMAGE_DIGEST="${image_digest:?image_digest is required}"
 
 # SSH only — codex-universal is a terminal dev environment, not a web app
 ufw allow 22/tcp
@@ -27,9 +26,6 @@ systemctl start docker
 
 mkdir -p /root/workspace
 
-# Pin image digest from packer variable
-sed -i "s|IMAGE_DIGEST=sha256:.*|IMAGE_DIGEST=${IMAGE_DIGEST}|g" /opt/codex-universal/codex-universal.env
-sed -i "s|IMAGE=ghcr.io/openai/codex-universal@sha256:.*|IMAGE=ghcr.io/openai/codex-universal@${IMAGE_DIGEST}|g" /opt/codex-universal/codex-universal.env
 sed -i "s|TAG=.*|TAG=${APP_VERSION}|g" /opt/codex-universal/codex-universal.env
 
 chmod 600 /opt/codex-universal/codex-universal.env
@@ -49,7 +45,7 @@ chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
 cp /opt/codex-universal/codex-universal.env /opt/codex-universal/.env
 chmod 600 /opt/codex-universal/.env
 
-echo "Pre-pulling ghcr.io/openai/codex-universal@${IMAGE_DIGEST} (this may take several minutes)..."
+echo "Pre-pulling ghcr.io/openai/codex-universal:latest (this may take several minutes)..."
 cd /opt/codex-universal
 docker compose pull
 

--- a/codex-universal-24-04/template.json
+++ b/codex-universal-24-04/template.json
@@ -4,8 +4,7 @@
     "image_name": "codex-universal-24-04-snapshot-{{timestamp}}",
     "apt_packages": "apt-transport-https ca-certificates curl software-properties-common git jq unzip ufw",
     "application_name": "Codex Universal",
-    "application_version": "latest",
-    "image_digest": "sha256:905e512f36460e1be4cfedb30928a8a28299edb0fcd5de7998ceaa72d27fe304"
+    "application_version": "latest"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -40,7 +39,6 @@
       "environment_vars": [
         "application_name={{user `application_name`}}",
         "application_version={{user `application_version`}}",
-        "image_digest={{user `image_digest`}}",
         "DEBIAN_FRONTEND=noninteractive",
         "LC_ALL=C",
         "LANG=en_US.UTF-8",


### PR DESCRIPTION
## Summary
- Update Codex Universal first boot to pull the configured image before starting the service.
- Switch Codex Universal image configuration from a pinned digest to `ghcr.io/openai/codex-universal:latest`.
- Refresh helper output and docs to describe tag-based updates instead of digest pinning.


Made with [Cursor](https://cursor.com)