### PR TITLE
Permit noninteractive execution of setup script.

### DIFF
--- a/jitsi-24-04/files/var/complete-jitsi-setup.sh
+++ b/jitsi-24-04/files/var/complete-jitsi-setup.sh
@@ -7,7 +7,9 @@ set -euo pipefail
 
 BUILD_HOSTNAME="${JITSI_BUILD_HOSTNAME:-jitsi.localhost}"
 
-read -r -p "Enter the public DNS name for this Jitsi server (for example meet.example.com): " JITSI_HOSTNAME
+if [ -z "${JITSI_HOSTNAME:-}" ]; then
+    read -r -p "Enter the public DNS name for this Jitsi server (for example meet.example.com): " JITSI_HOSTNAME
+fi
 case "$JITSI_HOSTNAME" in
     ""|*"/"*|*" "*|.*|*.)
         echo "ERROR: enter a valid public DNS name, for example meet.example.com" >&2


### PR DESCRIPTION
Providing the JITSI_HOSTNAME environment variable with the desired external hostname prevents the script from prompting for it.  This can already be done with the LETSENCRYPT_EMAIL environment variable.