### PR TITLE
Fix GNOME packer template

### DIFF
--- a/ubuntu-desktop-24-04/template.json
+++ b/ubuntu-desktop-24-04/template.json
@@ -32,11 +32,6 @@
     },
     {
       "type": "file",
-      "source": "ubuntu-desktop-24-04/files/var/",
-      "destination": "/var/"
-    },
-    {
-      "type": "file",
       "source": "ubuntu-desktop-24-04/files/etc/",
       "destination": "/etc/"
     },


### PR DESCRIPTION
There is no `ubuntu-desktop-24-04/files/var/` directory so packer fails every run, it causes autoupdate errors