### PR TITLE
MP-7020 Add Plex Media Server 1-Click for Ubuntu 24.04

### DIFF
--- a/plex-24-04/README.md
+++ b/plex-24-04/README.md
@@ -1,0 +1,38 @@
+# Plex Media Server 1-Click
+
+Packer build template for the DigitalOcean Marketplace Plex Media Server 1-Click on Ubuntu 24.04 LTS.
+
+## Build
+
+```sh
+export DIGITALOCEAN_API_TOKEN=dop_your-token
+make validate-plex-24-04
+make build-plex-24-04
+```
+
+Override the pinned Plex version at build time:
+
+```sh
+packer build \
+  -var 'plex_version=1.5.7.4016-25d94bad9' \
+  -var 'application_version=1.5.7.4016-25d94bad9' \
+  plex-24-04/template.json
+```
+
+## Components
+
+- Ubuntu 24.04 LTS
+- Plex Media Server (`plexinc/pms-docker`, version pinned in `template.json`)
+- Docker and Docker Compose
+- NGINX reverse proxy (HTTP on port 80)
+- UFW (SSH, HTTP/HTTPS, Plex port 32400)
+
+## Suggested Droplet size
+
+4 GB RAM minimum (`s-2vcpu-4gb`), per the Akamai Plex deployment guide.
+
+## Updating Plex on a Droplet
+
+```sh
+/opt/update-plex.sh
+```

--- a/plex-24-04/files/etc/nginx/sites-available/plex
+++ b/plex-24-04/files/etc/nginx/sites-available/plex
@@ -1,0 +1,22 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1000;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/xml application/xml text/javascript application/x-javascript image/svg+xml;
+
+    location / {
+        proxy_pass http://127.0.0.1:32400;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Plex-Client-Identifier $http_x_plex_client_identifier;
+        proxy_set_header X-Plex-Token $http_x_plex_token;
+        proxy_buffering off;
+    }
+}

--- a/plex-24-04/files/etc/systemd/system/plex.service
+++ b/plex-24-04/files/etc/systemd/system/plex.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Plex Media Server
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/plex
+ExecStart=/usr/bin/docker compose up -d
+ExecStop=/usr/bin/docker compose down
+ExecReload=/usr/bin/docker compose restart
+
+[Install]
+WantedBy=multi-user.target

--- a/plex-24-04/files/etc/update-motd.d/99-one-click
+++ b/plex-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+cat <<EOF
+********************************************************************************
+
+Welcome to Plex Media Server
+
+Stream your personal media library to nearly any device.
+
+Access Plex:
+
+  Web (via NGINX):  http://$myip
+  Direct:           http://$myip:32400/web
+
+Media directory:
+
+  /opt/plex/media
+
+Management:
+
+  Start:    /opt/start-plex.sh    (or: systemctl start plex)
+  Stop:     /opt/stop-plex.sh     (or: systemctl stop plex)
+  Restart:  /opt/restart-plex.sh  (or: systemctl restart plex)
+  Update:   /opt/update-plex.sh
+  Logs:     docker compose -f /opt/plex/docker-compose.yml logs -f
+  Status:   systemctl status plex
+
+After deployment, sign in at the Plex web UI to claim this server and
+configure remote access on port 32400.
+
+Documentation: https://www.akamai.com/cloud/marketplace-docs/guides/plex/
+
+********************************************************************************
+To delete this message of the day: rm -rf \$(readlink -f \${0})
+EOF

--- a/plex-24-04/files/opt/plex/docker-compose.yml
+++ b/plex-24-04/files/opt/plex/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  plex:
+    image: plexinc/pms-docker:PLEX_VERSION_PLACEHOLDER
+    container_name: plex
+    restart: unless-stopped
+    ports:
+      - "32400:32400/tcp"
+    environment:
+      - TZ=UTC
+      - VERSION=docker
+    volumes:
+      - /opt/plex/config:/config
+      - /opt/plex/transcode:/transcode
+      - /opt/plex/media:/data

--- a/plex-24-04/files/opt/restart-plex.sh
+++ b/plex-24-04/files/opt/restart-plex.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Restarting Plex Media Server..."
+systemctl restart plex
+echo "Plex Media Server restarted."

--- a/plex-24-04/files/opt/start-plex.sh
+++ b/plex-24-04/files/opt/start-plex.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Starting Plex Media Server..."
+systemctl start plex
+
+if systemctl is-active --quiet plex; then
+    echo "Plex Media Server started successfully."
+    echo ""
+    echo "Web interface: http://$(hostname -I | awk '{print $1}')"
+    echo "Direct access:  http://$(hostname -I | awk '{print $1}'):32400/web"
+else
+    echo "Error: Failed to start Plex Media Server"
+    exit 1
+fi

--- a/plex-24-04/files/opt/stop-plex.sh
+++ b/plex-24-04/files/opt/stop-plex.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Stopping Plex Media Server..."
+systemctl stop plex
+echo "Plex Media Server stopped."

--- a/plex-24-04/files/opt/update-plex.sh
+++ b/plex-24-04/files/opt/update-plex.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "Updating Plex Media Server to the latest image..."
+
+if [ ! -d "/opt/plex" ]; then
+    echo "Error: Plex installation directory not found at /opt/plex"
+    exit 1
+fi
+
+cd /opt/plex
+
+systemctl stop plex
+
+docker compose pull
+
+if [ $? -eq 0 ]; then
+    systemctl start plex
+    echo "Plex Media Server updated and restarted successfully."
+else
+    echo "Error: Failed to pull updated Plex image"
+    exit 1
+fi

--- a/plex-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/plex-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "Configuring Plex Media Server on first boot..."
+
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh
+
+systemctl start plex
+
+sleep 5
+
+if systemctl is-active --quiet plex; then
+    echo "Plex Media Server started successfully."
+    echo ""
+    echo "Web interface: http://$(hostname -I | awk '{print $1}')"
+    echo "Direct access:  http://$(hostname -I | awk '{print $1}'):32400/web"
+else
+    echo "Plex may need more time to start. Check: systemctl status plex"
+fi
+
+echo "First boot configuration completed."

--- a/plex-24-04/scripts/010-plex.sh
+++ b/plex-24-04/scripts/010-plex.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+echo "Starting Plex Media Server installation..."
+
+systemctl enable docker
+systemctl start docker
+
+ufw allow 32400/tcp
+
+mkdir -p /opt/plex/{config,transcode,media}
+
+sed -i "s|PLEX_VERSION_PLACEHOLDER|${plex_version}|g" /opt/plex/docker-compose.yml
+
+chmod +x /opt/start-plex.sh
+chmod +x /opt/stop-plex.sh
+chmod +x /opt/restart-plex.sh
+chmod +x /opt/update-plex.sh
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+chmod +x /etc/update-motd.d/99-one-click
+
+ln -sf /etc/nginx/sites-available/plex /etc/nginx/sites-enabled/plex
+rm -f /etc/nginx/sites-enabled/default
+
+nginx -t
+systemctl enable nginx
+systemctl restart nginx
+
+cd /opt/plex
+docker compose pull
+
+systemctl enable plex
+
+echo "Plex Media Server installation completed."

--- a/plex-24-04/template.json
+++ b/plex-24-04/template.json
@@ -1,0 +1,97 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "plex-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "apt-transport-https ca-certificates curl software-properties-common jq nginx certbot python3-certbot-nginx docker.io docker-compose-v2",
+    "application_name": "Plex Media Server",
+    "application_version": "1.5.7.4016-25d94bad9",
+    "plex_version": "1.5.7.4016-25d94bad9"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-2vcpu-4gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "plex-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "plex-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "plex-24-04/files/opt/",
+      "destination": "/opt/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "plex_version={{user `plex_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "plex-24-04/scripts/010-plex.sh",
+        "common/scripts/014-ufw-nginx.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "common/scripts/900-cleanup.sh"
+      ],
+      "expect_disconnect": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a new Plex Media Server Droplet 1-Click on Ubuntu 24.04 LTS (`plex-24-04`), installing Plex via Docker (`plexinc/pms-docker`) with NGINX reverse proxy, UFW, systemd service, first-boot setup, MOTD, and helper scripts. Aligned with the [Akamai Plex Marketplace guide](https://www.akamai.com/cloud/marketplace-docs/guides/plex/).

## Changes

- Add new `plex-24-04/` Packer 1-Click directory
- Packer builder: `ubuntu-24-04-x64`, droplet size `s-2vcpu-4gb` (4 GB RAM minimum)
- Install Docker, Plex (`plexinc/pms-docker`), NGINX, certbot, and UFW via `template.json`
- Add `scripts/010-plex.sh` for Plex install, NGINX config, and image pull
- Add `files/opt/plex/docker-compose.yml` with pinned `plex_version`
- Add NGINX site config proxying port 80 → Plex on 32400
- Add `plex.service` systemd unit and first-boot `001_onboot` script
- Add MOTD and helper scripts: `start-plex.sh`, `stop-plex.sh`, `restart-plex.sh`, `update-plex.sh`
- Split `900-cleanup.sh` into a separate provisioner with `expect_disconnect: true` to fix Packer SSH disconnect during build
- Branch: `mp-7020-create-plex-media-server` on `digitalocean/droplet-1-clicks`

## Test plan

- [x] `packer validate plex-24-04/template.json`
- [x] `packer build plex-24-04/template.json`
- [x] Create Droplet from snapshot (4 GB+); verify SSH and MOTD
- [x] Open `http://<ip>` and `http://<ip>:32400/web` — Plex UI loads
- [x] Confirm `docker ps` shows `plex` running; `systemctl status nginx` and `plex` are healthy
- [x] Verify `/opt/start-plex.sh` and `/opt/stop-plex.sh` work

## Links
:clipboard: [Jira ticket](https://do-internal.atlassian.net/browse/MP-7020)