### PR TITLE
[MP-7132]: Create Jellyfin Droplet 1-Click

### DIFF
--- a/jellyfin-24-04/files/etc/update-motd.d/99-one-click
+++ b/jellyfin-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's 1-Click Jellyfin Droplet.
+To keep this Droplet secure, the UFW firewall is enabled.
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), 443 (HTTPS), and 8096 (Jellyfin).
+
+- Access Jellyfin:
+  * http://$myip:8096
+
+- Jellyfin is running as a systemd service.
+  To view service status run the following command:
+
+  systemctl status jellyfin
+
+- On first visit, complete the Jellyfin setup wizard to create an admin account
+  and add your media libraries.
+
+On the server:
+  * Jellyfin configuration is stored in /etc/jellyfin
+  * Jellyfin data is stored in /var/lib/jellyfin
+
+For more information, please refer to the Getting Started Guide:
+https://marketplace.digitalocean.com/apps/jellyfin
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/jellyfin-24-04/files/etc/update-motd.d/99-one-click
+++ b/jellyfin-24-04/files/etc/update-motd.d/99-one-click
@@ -30,5 +30,5 @@ For more information, please refer to the Getting Started Guide:
 https://marketplace.digitalocean.com/apps/jellyfin
 
 ********************************************************************************
-To delete this message of the day: rm -rf $(readlink -f ${0})
+To delete this message of the day: rm -rf /etc/update-motd.d/99-one-click
 EOF

--- a/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh

--- a/jellyfin-24-04/scripts/01-setup.sh
+++ b/jellyfin-24-04/scripts/01-setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "==> Updating system packages..."
+apt-get update && apt-get upgrade -y
+
+echo "==> Installing prerequisites..."
+apt-get install -y curl gnupg apt-transport-https
+
+echo "==> Downloading and verifying official Jellyfin installer..."
+cd /tmp
+curl -s https://repo.jellyfin.org/install-debuntu.sh -O
+curl -s https://repo.jellyfin.org/install-debuntu.sh.sha256sum -O
+
+# Validate checksum before running
+sha256sum -c install-debuntu.sh.sha256sum
+
+echo "==> Executing Jellyfin installation script..."
+bash install-debuntu.sh
+
+echo "==> Ensuring Jellyfin starts on boot..."
+systemctl daemon-reload
+systemctl enable jellyfin
+systemctl start jellyfin
+
+echo "==> Opening Jellyfin web UI port in UFW..."
+ufw allow 8096/tcp
+
+echo "==> Cleaning up build history..."
+rm -f /tmp/install-debuntu.sh*
+apt-get autoremove -y
+apt-get clean

--- a/jellyfin-24-04/template.json
+++ b/jellyfin-24-04/template.json
@@ -3,8 +3,8 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "jellyfin-24-04-snapshot-{{timestamp}}",
-   "application_name": "Jellyfin",
-    "application_version": "10.9.x",
+    "application_name": "Jellyfin",
+    "application_version": "10.11.x",
     "apt_packages": "curl gnupg apt-transport-https"
   },
   "sensitive-variables": ["do_api_token"],

--- a/jellyfin-24-04/template.json
+++ b/jellyfin-24-04/template.json
@@ -1,0 +1,78 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "jellyfin-24-04-snapshot-{{timestamp}}",
+   "application_name": "Jellyfin",
+    "application_version": "10.9.x",
+    "apt_packages": "curl gnupg apt-transport-https"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "jellyfin-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "jellyfin-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "jellyfin-24-04/scripts/01-setup.sh",
+        "common/scripts/014-ufw-http.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **OS Base Image:** Ubuntu 24.04.
- **Jellyfin:** Installed from the official Jellyfin repository using `install-debuntu.sh` (checksum verified).
- **System Packages:** Prerequisites only (`curl`, `gnupg`, `apt-transport-https`) via apt — Jellyfin is not installed from Ubuntu default repos.
- **Firewall:** Opens Jellyfin web UI port `8096/tcp` (in addition to SSH/HTTP/HTTPS).
- **First boot:** Removes temporary SSH force-logout so users can SSH after droplet creation.
- **MOTD:** Adds Jellyfin welcome message with access URL (`http://<ip>:8096`), service status command, and config/data paths.

## Test plan

- [x] Packer build succeeds from repo root: `packer build jellyfin-24-04/template.json`
- [x] Create droplet from snapshot and SSH as root (MOTD shows Jellyfin welcome)
- [x] `systemctl status jellyfin` is `active (running)`
- [x] `ufw status` shows `8096/tcp` allowed
- [x] Browser opens `http://<ip>:8096` and shows Jellyfin setup wizard
- [x] Confirm install source is official Jellyfin repo (`apt-cache policy jellyfin`)