### PR TITLE
[MP-8463]: Create Exa Droplet 1-Click

### DIFF
--- a/exa-24-04/README.md
+++ b/exa-24-04/README.md
@@ -1,0 +1,61 @@
+# Exa MCP Server 1-Click Droplet Builder
+
+Packer builder for a DigitalOcean Marketplace 1-Click image that installs [exa-mcp-server](https://www.npmjs.com/package/exa-mcp-server) on Ubuntu 24.04 LTS.
+
+Exa MCP uses **stdio** transport. This image does not expose an HTTP UI; UFW allows SSH only. Users set an API key on first SSH login and point MCP clients at `/opt/run-exa-mcp.sh`.
+
+## Directory Structure
+
+```
+exa-24-04/
+├── template.json
+├── README.md
+├── listing.md
+├── scripts/
+│   └── 01-exa.sh
+└── files/
+    ├── etc/update-motd.d/99-one-click
+    ├── opt/
+    │   ├── setup-exa.sh
+    │   ├── status-exa.sh
+    │   ├── update-exa.sh
+    │   └── run-exa-mcp.sh
+    └── var/lib/cloud/scripts/per-instance/001_onboot
+```
+
+## Prerequisites
+
+1. Packer: https://www.packer.io/downloads
+2. DigitalOcean API token with write access
+
+```bash
+export DIGITALOCEAN_API_TOKEN="your_api_token_here"
+```
+
+## Validate and build
+
+```bash
+packer init config/plugins.pkr.hcl
+packer validate exa-24-04/template.json
+make build-exa-24-04
+# or: packer build exa-24-04/template.json
+```
+
+## What gets installed
+
+- Node.js 20 (Nodesource)
+- `exa-mcp-server` at the version in `application_version` (`template.json`)
+- UFW limited to SSH
+- First-boot SSH unlock + first-login API key wizard
+
+## Version bumps
+
+1. Set `application_version` in `template.json` to the desired npm version (for example `3.2.1`).
+2. Rebuild the image.
+3. On existing Droplets, run `/opt/update-exa.sh <version>`.
+
+## First boot / first login
+
+1. `001_onboot` removes SSH `ForceCommand` and hooks `/opt/setup-exa.sh` into root's `.bashrc` when not configured.
+2. First SSH login prompts for `EXA_API_KEY`. Enter skips once (removes the `.bashrc` hook); re-run `/opt/setup-exa.sh` later.
+3. Key is written to `/etc/exa/mcp.env` (mode `600`).

--- a/exa-24-04/files/etc/update-motd.d/99-one-click
+++ b/exa-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's 1-Click Exa MCP Server Droplet.
+To keep this Droplet secure, the UFW firewall is enabled.
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
+
+- On first SSH login as root, you will be prompted for your Exa API key.
+  Get a key at: https://dashboard.exa.ai/
+
+- Exa MCP runs as a systemd service.
+  To view service status:
+
+  systemctl status exa-mcp
+
+On the server:
+  * API key is stored in /etc/exa/mcp.env
+  * Configuration marker: /etc/exa/.configured
+
+For more information, please refer to the Getting Started Guide:
+https://marketplace.digitalocean.com/apps/exa
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/exa-24-04/files/etc/update-motd.d/99-one-click
+++ b/exa-24-04/files/etc/update-motd.d/99-one-click
@@ -2,29 +2,33 @@
 #
 # Configured as part of the DigitalOcean 1-Click Image build process
 
-myip=$(hostname -I | awk '{print$1}')
-
 cat <<EOF
 ********************************************************************************
 
 Welcome to DigitalOcean's 1-Click Exa MCP Server Droplet.
 To keep this Droplet secure, the UFW firewall is enabled.
-All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
+All ports are BLOCKED except 22 (SSH).
+
+Exa MCP uses stdio transport (no public HTTP UI). Your MCP client
+spawns the server locally on this Droplet.
 
 - On first SSH login as root, you will be prompted for your Exa API key.
-  Get a key at: https://dashboard.exa.ai/
+  Get a key at: https://dashboard.exa.ai/api-keys
 
-- Exa MCP runs as a systemd service.
-  To view service status:
+- Configure / check / update:
+  /opt/setup-exa.sh
+  /opt/status-exa.sh
+  /opt/update-exa.sh
 
-  systemctl status exa-mcp
+- MCP client entrypoint:
+  /opt/run-exa-mcp.sh
 
 On the server:
-  * API key is stored in /etc/exa/mcp.env
-  * Configuration marker: /etc/exa/.configured
+  * API key: /etc/exa/mcp.env
+  * Version pin: /etc/exa/version
 
-For more information, please refer to the Getting Started Guide:
-https://marketplace.digitalocean.com/apps/exa
+For more information, see the Exa MCP docs:
+https://docs.exa.ai/reference/exa-mcp
 
 ********************************************************************************
 To delete this message of the day: rm -rf $(readlink -f ${0})

--- a/exa-24-04/files/opt/run-exa-mcp.sh
+++ b/exa-24-04/files/opt/run-exa-mcp.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Stdio entrypoint for MCP clients. Loads EXA_API_KEY and execs the server.
+set -euo pipefail
+
+ENV_FILE="/etc/exa/mcp.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Exa is not configured. Run: /opt/setup-exa.sh" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+if [ -z "${EXA_API_KEY:-}" ]; then
+  echo "EXA_API_KEY is empty in ${ENV_FILE}. Run: /opt/setup-exa.sh --force" >&2
+  exit 1
+fi
+
+exec exa-mcp-server "$@"

--- a/exa-24-04/files/opt/setup-exa.sh
+++ b/exa-24-04/files/opt/setup-exa.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# First-login (or manual) setup: store Exa API key for local stdio MCP.
+
+set -euo pipefail
+
+CONFIGURED_MARKER="/etc/exa/.configured"
+ENV_FILE="/etc/exa/mcp.env"
+
+remove_bashrc_hook() {
+  if [ -f /root/.bashrc ]; then
+    sed -i '\|/opt/setup-exa.sh|d' /root/.bashrc
+  fi
+}
+
+if [ -f "$CONFIGURED_MARKER" ] && [ "${1:-}" != "--force" ]; then
+  remove_bashrc_hook
+  exit 0
+fi
+
+echo ""
+echo "================================================================"
+echo "       Welcome to the Exa MCP Server 1-Click Droplet!"
+echo "================================================================"
+echo ""
+echo "Exa MCP runs over stdio and is started by your MCP client"
+echo "(for example Cursor, Claude Desktop, or Claude Code)."
+echo ""
+echo "To get started, you need an API key from Exa:"
+echo "  https://dashboard.exa.ai/api-keys"
+echo ""
+echo "Press Enter to skip for now (you can re-run: /opt/setup-exa.sh)."
+echo ""
+
+old_histfile="${HISTFILE-}"
+unset HISTFILE
+read -rsp "Please enter your Exa API Key: " EXA_KEY
+echo ""
+[ -n "${old_histfile:-}" ] && export HISTFILE="$old_histfile"
+
+if [ -z "$EXA_KEY" ]; then
+  remove_bashrc_hook
+  echo ""
+  echo "Setup skipped. Configure later with: /opt/setup-exa.sh"
+  echo ""
+  exit 0
+fi
+
+mkdir -p /etc/exa
+chmod 700 /etc/exa
+umask 077
+printf 'EXA_API_KEY=%q\n' "$EXA_KEY" > "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+touch "$CONFIGURED_MARKER"
+chmod 644 "$CONFIGURED_MARKER"
+remove_bashrc_hook
+
+echo ""
+echo "Exa API key saved to ${ENV_FILE}."
+echo ""
+echo "Point your MCP client at: /opt/run-exa-mcp.sh"
+echo "Example (Cursor ~/.cursor/mcp.json):"
+echo '  {"mcpServers":{"exa":{"command":"/opt/run-exa-mcp.sh"}}}'
+echo ""
+echo "Status:  /opt/status-exa.sh"
+echo "Update:  /opt/update-exa.sh"
+echo ""

--- a/exa-24-04/files/opt/status-exa.sh
+++ b/exa-24-04/files/opt/status-exa.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+VERSION_FILE="/etc/exa/version"
+ENV_FILE="/etc/exa/mcp.env"
+CONFIGURED_MARKER="/etc/exa/.configured"
+
+echo "Exa MCP Server status"
+echo "---------------------"
+
+if [ -f "$VERSION_FILE" ]; then
+  echo "Pinned version file: $(cat "$VERSION_FILE")"
+else
+  echo "Pinned version file: (missing)"
+fi
+
+if command -v exa-mcp-server >/dev/null 2>&1; then
+  echo "Binary: $(command -v exa-mcp-server)"
+  npm list -g exa-mcp-server 2>/dev/null | head -n 2 || true
+else
+  echo "Binary: not found on PATH"
+fi
+
+if [ -f "$CONFIGURED_MARKER" ] && [ -f "$ENV_FILE" ]; then
+  echo "API key: configured (${ENV_FILE})"
+else
+  echo "API key: not configured (run /opt/setup-exa.sh)"
+fi
+
+echo "Entrypoint for MCP clients: /opt/run-exa-mcp.sh"
+echo "UFW: SSH only (no HTTP UI; MCP uses stdio)"

--- a/exa-24-04/files/opt/update-exa.sh
+++ b/exa-24-04/files/opt/update-exa.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Update the globally installed exa-mcp-server package.
+# Usage: /opt/update-exa.sh [version]
+# Default version is from /etc/exa/version (build pin). Pass a version to bump.
+set -euo pipefail
+
+VERSION_FILE="/etc/exa/version"
+TARGET_VERSION="${1:-}"
+
+if [ -z "$TARGET_VERSION" ]; then
+  if [ -f "$VERSION_FILE" ]; then
+    TARGET_VERSION="$(cat "$VERSION_FILE")"
+  else
+    echo "No version specified and ${VERSION_FILE} is missing." >&2
+    exit 1
+  fi
+fi
+
+echo "==> Installing exa-mcp-server@${TARGET_VERSION}..."
+npm install -g "exa-mcp-server@${TARGET_VERSION}"
+mkdir -p /etc/exa
+echo "${TARGET_VERSION}" > "$VERSION_FILE"
+chmod 644 "$VERSION_FILE"
+
+echo "Updated to $(npm list -g exa-mcp-server --depth=0 2>/dev/null | tail -n 1 || echo "$TARGET_VERSION")"
+echo "MCP clients should keep using: /opt/run-exa-mcp.sh"

--- a/exa-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/exa-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh

--- a/exa-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/exa-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
 
 # Remove the ssh force logout command
 sed -e '/Match User root/d' \
@@ -6,3 +7,15 @@ sed -e '/Match User root/d' \
     -i /etc/ssh/sshd_config
 
 systemctl restart ssh
+
+mkdir -p /etc/exa
+chmod 700 /etc/exa
+
+# Hook first-login API key setup when not yet configured
+if [ ! -f /etc/exa/.configured ]; then
+  if ! grep -q '/opt/setup-exa.sh' /root/.bashrc 2>/dev/null; then
+    echo '/opt/setup-exa.sh' >> /root/.bashrc
+  fi
+fi
+
+echo "Exa MCP first-boot initialization complete."

--- a/exa-24-04/listing.md
+++ b/exa-24-04/listing.md
@@ -1,0 +1,113 @@
+# Exa MCP Server 1-Click Application
+
+Deploy [Exa](https://exa.ai/) MCP Server on Ubuntu 24.04. Exa gives AI agents web search and content retrieval over the Model Context Protocol (MCP). This Droplet pre-installs the official `exa-mcp-server` npm package for **stdio** use with clients such as Cursor, Claude Desktop, and Claude Code.
+
+## What is Exa MCP?
+
+Exa MCP exposes Exa search tools to MCP-compatible AI clients. The local npm package speaks **stdio** (your client starts the process). There is no public HTTP UI on this Droplet; only SSH is exposed.
+
+## Key Features
+
+- Pinned `exa-mcp-server` install (version from the image build)
+- First-SSH API key setup (key never baked into the snapshot)
+- `/opt/run-exa-mcp.sh` entrypoint for MCP client configs
+- Helper scripts for status and updates
+- UFW: SSH only
+
+## System Requirements
+
+| Use Case | RAM | CPU | Storage |
+|----------|-----|-----|---------|
+| Minimum | 1 GB | 1 vCPU | 25 GB |
+| Recommended | 1 GB | 1 vCPU | 25 GB |
+
+## Included System Components
+
+- **Ubuntu 24.04 LTS** – Base operating system
+- **Node.js 20** – Runtime (Nodesource)
+- **exa-mcp-server** – Exa MCP stdio server (pinned at build time)
+- **UFW Firewall** – SSH only (rate-limited)
+
+## Getting Started
+
+### 1. Deploy the Droplet
+
+1. Select this 1-Click App from the DigitalOcean Marketplace
+2. Choose a Droplet size (1 GB RAM minimum)
+3. Add your SSH key for secure access
+4. Create the Droplet
+
+### 2. SSH In
+
+```bash
+ssh root@your-droplet-ip
+```
+
+On first login you are prompted for an Exa API key. Create one at https://dashboard.exa.ai/api-keys.
+
+Press Enter to skip once (the login hook is removed). Configure later with:
+
+```bash
+/opt/setup-exa.sh
+```
+
+### 3. Point your MCP client at this Droplet
+
+Use the Droplet as the host that runs the stdio server (for example SSH + local client config on the server, or any workflow where the client can execute `/opt/run-exa-mcp.sh`).
+
+Configure the MCP client **on this Droplet** (or any host that can execute the entrypoint) to run:
+
+```text
+/opt/run-exa-mcp.sh
+```
+
+**Cursor** example (`~/.cursor/mcp.json` on the Droplet):
+
+```json
+{
+  "mcpServers": {
+    "exa": {
+      "command": "/opt/run-exa-mcp.sh"
+    }
+  }
+}
+```
+
+**Claude Code** example (on the Droplet):
+
+```bash
+claude mcp add --transport stdio exa -- /opt/run-exa-mcp.sh
+```
+
+Prefer Exa's hosted HTTP MCP instead? Use `https://mcp.exa.ai/mcp` in clients that support remote MCP (no Droplet required).
+
+## Managing Exa MCP
+
+Exa MCP is **not** a long-running systemd daemon. Your MCP client starts and stops the stdio process.
+
+| Action | How |
+|--------|-----|
+| Start | MCP client runs `/opt/run-exa-mcp.sh` (or `exa-mcp-server` with `EXA_API_KEY` set) |
+| Stop | Disconnect / quit the MCP client (ends the stdio process) |
+| Restart | Restart the MCP client or reconnect the Exa server in the client |
+| Status | `/opt/status-exa.sh` |
+| Update | `/opt/update-exa.sh` (reinstalls pin) or `/opt/update-exa.sh 3.2.1` (bump) |
+| Re-run setup | `/opt/setup-exa.sh --force` |
+
+### Paths
+
+- **API key**: `/etc/exa/mcp.env` (`EXA_API_KEY`)
+- **Configured marker**: `/etc/exa/.configured`
+- **Version pin**: `/etc/exa/version`
+- **Client entrypoint**: `/opt/run-exa-mcp.sh`
+
+## Security Notes
+
+- UFW allows **SSH only**. Ports 80/443 are not opened.
+- The API key is collected on first boot/login and is unique per Droplet.
+- Do not commit or share `/etc/exa/mcp.env`.
+
+## Support
+
+- Exa MCP docs: https://docs.exa.ai/reference/exa-mcp
+- Exa dashboard / API keys: https://dashboard.exa.ai/api-keys

--- a/exa-24-04/scripts/01-exa.sh
+++ b/exa-24-04/scripts/01-exa.sh
@@ -3,76 +3,41 @@ set -Eeuo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo "==> Updating package repository..."
-apt-get update && apt-get upgrade -y
+EXA_VERSION="${application_version:?application_version is required}"
 
-echo "==> Installing Node.js and dependencies..."
+echo "==> Configuring UFW (SSH only; Exa MCP uses stdio, no HTTP UI)..."
+ufw limit ssh/tcp
+ufw --force enable
+
+echo "==> Installing Node.js 20 (Nodesource)..."
 curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-apt-get install -y nodejs git unzip curl
+apt-get install -y nodejs
 
-echo "==> Installing the Exa MCP Server globally..."
-npm install -g exa-mcp-server
+echo "==> Installing Exa MCP Server ${EXA_VERSION}..."
+npm install -g "exa-mcp-server@${EXA_VERSION}"
 
 echo "==> Creating Exa config directory..."
-mkdir -p /etc/exa /var/lib/digitalocean
+mkdir -p /etc/exa
 chmod 700 /etc/exa
+echo "${EXA_VERSION}" > /etc/exa/version
+chmod 644 /etc/exa/version
 
-echo "==> Setting up first-boot configuration hook..."
-cat <<'EOF' > /var/lib/digitalocean/one-click-login-check.sh
-#!/bin/bash
-if [ ! -f /etc/exa/.configured ]; then
-    echo "================================================================"
-    echo "       Welcome to the Exa MCP Server 1-Click Droplet!           "
-    echo "================================================================"
-    echo ""
-    echo "To get started, you need an API key from Exa."
-    echo "If you don't have one, grab one here: https://dashboard.exa.ai/"
-    echo ""
-    read -p "Please enter your Exa API Key: " EXA_KEY
-    
-    if [ -z "$EXA_KEY" ]; then
-        echo "Exa API key is required to start the MCP server."
-        exit 1
-    fi
-    
-    mkdir -p /etc/exa
-    chmod 700 /etc/exa
-    umask 077
-    echo "EXA_API_KEY=$EXA_KEY" > /etc/exa/mcp.env
-    chmod 600 /etc/exa/mcp.env
-    touch /etc/exa/.configured
-    
-    echo "==> Restarting Exa MCP service..."
-    systemctl restart exa-mcp
-    echo "Exa MCP Server is successfully configured and running!"
+echo "==> Setting helper script permissions..."
+chmod +x /opt/setup-exa.sh
+chmod +x /opt/status-exa.sh
+chmod +x /opt/update-exa.sh
+chmod +x /opt/run-exa-mcp.sh
+chmod +x /etc/update-motd.d/99-one-click
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+
+# Verify the global binary is on PATH
+if ! command -v exa-mcp-server >/dev/null 2>&1; then
+  echo "Error: exa-mcp-server binary not found after install"
+  exit 1
 fi
-EOF
-
-chmod +x /var/lib/digitalocean/one-click-login-check.sh
-
-# Inject first-boot hook into root's .bashrc
-echo "/var/lib/digitalocean/one-click-login-check.sh" >> /root/.bashrc
-
-echo "==> Creating systemd service for Exa MCP Server..."
-cat <<EOF > /etc/systemd/system/exa-mcp.service
-[Unit]
-Description=Exa Web Search MCP Server
-After=network.target
-
-[Service]
-Type=simple
-EnvironmentFile=-/etc/exa/mcp.env
-ExecStart=/usr/bin/npx -y exa-mcp-server
-Restart=on-failure
-User=root
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-systemctl daemon-reload
-systemctl enable exa-mcp
 
 echo "==> Cleaning up setup environment..."
 apt-get autoremove -y
 apt-get clean
+
+echo "Exa MCP Server ${EXA_VERSION} installation complete."

--- a/exa-24-04/scripts/01-exa.sh
+++ b/exa-24-04/scripts/01-exa.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "==> Updating package repository..."
+apt-get update && apt-get upgrade -y
+
+echo "==> Installing Node.js and dependencies..."
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get install -y nodejs git unzip curl
+
+echo "==> Installing the Exa MCP Server globally..."
+npm install -g exa-mcp-server
+
+echo "==> Creating Exa config directory..."
+mkdir -p /etc/exa /var/lib/digitalocean
+chmod 700 /etc/exa
+
+echo "==> Setting up first-boot configuration hook..."
+cat <<'EOF' > /var/lib/digitalocean/one-click-login-check.sh
+#!/bin/bash
+if [ ! -f /etc/exa/.configured ]; then
+    echo "================================================================"
+    echo "       Welcome to the Exa MCP Server 1-Click Droplet!           "
+    echo "================================================================"
+    echo ""
+    echo "To get started, you need an API key from Exa."
+    echo "If you don't have one, grab one here: https://dashboard.exa.ai/"
+    echo ""
+    read -p "Please enter your Exa API Key: " EXA_KEY
+    
+    if [ -z "$EXA_KEY" ]; then
+        echo "Exa API key is required to start the MCP server."
+        exit 1
+    fi
+    
+    mkdir -p /etc/exa
+    chmod 700 /etc/exa
+    umask 077
+    echo "EXA_API_KEY=$EXA_KEY" > /etc/exa/mcp.env
+    chmod 600 /etc/exa/mcp.env
+    touch /etc/exa/.configured
+    
+    echo "==> Restarting Exa MCP service..."
+    systemctl restart exa-mcp
+    echo "Exa MCP Server is successfully configured and running!"
+fi
+EOF
+
+chmod +x /var/lib/digitalocean/one-click-login-check.sh
+
+# Inject first-boot hook into root's .bashrc
+echo "/var/lib/digitalocean/one-click-login-check.sh" >> /root/.bashrc
+
+echo "==> Creating systemd service for Exa MCP Server..."
+cat <<EOF > /etc/systemd/system/exa-mcp.service
+[Unit]
+Description=Exa Web Search MCP Server
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/exa/mcp.env
+ExecStart=/usr/bin/npx -y exa-mcp-server
+Restart=on-failure
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable exa-mcp
+
+echo "==> Cleaning up setup environment..."
+apt-get autoremove -y
+apt-get clean

--- a/exa-24-04/template.json
+++ b/exa-24-04/template.json
@@ -1,11 +1,10 @@
-
 {
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "exa-24-04-snapshot-{{timestamp}}",
-    "apt_packages": "curl git unzip nodejs npm",
+    "apt_packages": "curl git unzip ca-certificates ufw",
     "application_name": "Exa MCP Server",
-    "application_version": "1.0.0"
+    "application_version": "3.2.1"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -35,6 +34,11 @@
       "type": "file",
       "source": "exa-24-04/files/etc/",
       "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "exa-24-04/files/opt/",
+      "destination": "/opt/"
     },
     {
       "type": "file",
@@ -68,7 +72,6 @@
       ],
       "scripts": [
         "exa-24-04/scripts/01-exa.sh",
-        "common/scripts/014-ufw-http.sh",
         "common/scripts/018-force-ssh-logout.sh",
         "common/scripts/020-application-tag.sh",
         "common/scripts/900-cleanup.sh"

--- a/exa-24-04/template.json
+++ b/exa-24-04/template.json
@@ -1,0 +1,78 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "exa-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "curl git unzip nodejs npm",
+    "application_name": "Exa MCP Server",
+    "application_version": "1.0.0"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "exa-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "exa-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "exa-24-04/scripts/01-exa.sh",
+        "common/scripts/014-ufw-http.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a new **Exa MCP Server** 1-Click image for Ubuntu 24.04 (`exa-24-04`).
- Packer template installs Node.js 20, `exa-mcp-server`, a systemd unit (`exa-mcp`), UFW (SSH/HTTP/HTTPS), MOTD, and first-boot SSH unlock.
- First root login prompts for an Exa API key, stores it in `/etc/exa/mcp.env` with restricted permissions (`700` dir / `600` file), and restarts the service.
- Marketplace metadata is written by `common/scripts/020-application-tag.sh` (shell-sourceable `application.info`).

## Test plan
- [x] Packer build succeeds (`exa-24-04/template.json`)
- [x] First SSH login shows MOTD + API key prompt
- [x] After key entry: `/etc/exa/mcp.env` (`600`), `/etc/exa/.configured`, `systemctl status exa-mcp` is **active**
- [x] `npm list -g exa-mcp-server` and Node 20 are present
- [x] Smoke-test key: `curl` to `https://api.exa.ai/search` with `EXA_API_KEY` from `/etc/exa/mcp.env`
- [x] UFW allows 22/80/443; later logins skip the setup prompt

##Link 
https://do-internal.atlassian.net/browse/MP-8463