### PR TITLE
add: created folder to add craft cms

### DIFF
--- a/craftcms-24-04/README.md
+++ b/craftcms-24-04/README.md
@@ -1,0 +1,49 @@
+# Craft CMS 1-Click
+
+Deploy [Craft CMS](https://craftcms.com/) on DigitalOcean with Nginx, PHP 8.3, and MySQL on Ubuntu 24.04.
+
+## Included software
+
+- Ubuntu 24.04 LTS
+- Craft CMS 5.10.11
+- Nginx
+- PHP 8.3 FPM
+- MySQL
+- Composer
+- Certbot (`python3-certbot-nginx`)
+- UFW firewall (ports 22, 80, 443)
+
+## Getting started
+
+1. Create a Droplet from this 1-Click (2 GB RAM recommended).
+2. Wait about 1–2 minutes for first-boot database setup.
+3. SSH in as `root` to run the setup wizard, **or** open `http://your-droplet-ip` and finish the Craft web installer.
+
+Credentials are saved in `/root/.digitalocean_password`.
+
+- Site: `http://your-droplet-ip`
+- Control Panel: `http://your-droplet-ip/admin`
+- Project path: `/var/www/craft`
+- Web root: `/var/www/craft/web`
+
+### Enable HTTPS
+
+```bash
+certbot --nginx -d your.domain
+```
+
+## Build
+
+```bash
+export DIGITALOCEAN_API_TOKEN=...
+make build-craftcms-24-04
+```
+
+Override the Craft version:
+
+```bash
+packer build \
+  -var 'application_version=5.10.11' \
+  -var 'craft_version=5.10.11' \
+  craftcms-24-04/template.json
+```

--- a/craftcms-24-04/files/etc/nginx/sites-available/craftcms
+++ b/craftcms-24-04/files/etc/nginx/sites-available/craftcms
@@ -1,0 +1,45 @@
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+	server_name _;
+
+	root /var/www/craft/web;
+	index index.php;
+
+	charset utf-8;
+	client_max_body_size 64M;
+
+	# Security headers
+	add_header X-Frame-Options "SAMEORIGIN" always;
+	add_header X-Content-Type-Options "nosniff" always;
+
+	location / {
+		try_files $uri $uri/ /index.php?$query_string;
+	}
+
+	location ~ [^/]\.php(/|$) {
+		fastcgi_split_path_info ^(.+\.php)(/.*)$;
+		try_files $fastcgi_script_name =404;
+
+		include fastcgi_params;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param PATH_INFO $fastcgi_path_info;
+		fastcgi_param HTTP_PROXY "";
+
+		fastcgi_pass unix:/run/php/php8.3-fpm.sock;
+		fastcgi_index index.php;
+		fastcgi_read_timeout 300;
+		fastcgi_buffers 16 16k;
+		fastcgi_buffer_size 32k;
+	}
+
+	location ~* \.(?:css|js|jpg|jpeg|gif|png|svg|ico|webp|woff2?)$ {
+		expires 7d;
+		access_log off;
+		try_files $uri /index.php?$query_string;
+	}
+
+	location ~ /\. {
+		deny all;
+	}
+}

--- a/craftcms-24-04/files/etc/update-motd.d/99-one-click
+++ b/craftcms-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's 1-Click Craft CMS Droplet.
+To keep this Droplet secure, the UFW firewall is enabled.
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
+
+In a web browser, you can view:
+  * Your Craft CMS website: http://$myip
+  * The Craft Control Panel: http://$myip/admin
+
+On the server:
+  * The Craft project root is located at /var/www/craft
+  * The web root is located at /var/www/craft/web
+  * The MySQL root and craft passwords are saved in /root/.digitalocean_password
+  * Certbot is preinstalled. Run it to configure HTTPS. See
+    https://craftcms.com/docs/5.x/ for more detail.
+
+For help and more information, visit https://craftcms.com/docs/5.x/
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/craftcms-24-04/files/root/craft_setup.sh
+++ b/craftcms-24-04/files/root/craft_setup.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Craft CMS setup script (WordPress wp_setup.sh pattern).
+# Runs on first SSH login. Users can also finish setup in the browser.
+
+set -e
+
+MARKER=/root/.craft_setup_complete
+
+# Already completed
+if [ -f "${MARKER}" ]; then
+  sed -i '/craft_setup.sh/d' /root/.bashrc 2>/dev/null || true
+  exit 0
+fi
+
+# Skip if Craft is already installed
+if php /var/www/craft/craft install/check >/dev/null 2>&1; then
+  touch "${MARKER}"
+  sed -i '/craft_setup.sh/d' /root/.bashrc 2>/dev/null || true
+  exit 0
+fi
+
+myip=$(hostname -I | awk '{print$1}')
+
+echo "================================================================"
+echo "Craft CMS Setup"
+echo "================================================================"
+echo ""
+echo "Craft CMS files and database are ready."
+echo "You can finish setup in the browser at: http://${myip}"
+echo "Or continue here to create the admin account via CLI."
+echo ""
+
+read -p "Continue with CLI setup now? [Y/n] " proceed
+proceed=${proceed:-Y}
+if [[ ! "${proceed}" =~ ^[Yy]$ ]]; then
+  echo "Skipping CLI setup. Visit http://${myip} to finish installation."
+  exit 0
+fi
+
+email=""
+username=""
+pass=""
+title=""
+
+craft_admin_account() {
+  while [ -z "$email" ]; do
+    read -p "Admin Email Address: " email
+  done
+  while [ -z "$username" ]; do
+    read -p "Admin Username: " username
+  done
+  while [ -z "$pass" ]; do
+    read -s -p "Admin Password: " pass
+    echo ""
+  done
+  while [ -z "$title" ]; do
+    read -p "Site Name: " title
+  done
+}
+
+craft_admin_account
+
+echo ""
+while true; do
+  read -p "Is the information correct? [Y/n] " confirmation
+  confirmation=${confirmation:-y}
+  confirmation=$(echo "$confirmation" | tr '[:upper:]' '[:lower:]')
+  if [[ "${confirmation}" =~ ^(yes|y)$ ]]; then
+    break
+  else
+    email=""
+    username=""
+    pass=""
+    title=""
+    echo ""
+    craft_admin_account
+    echo ""
+  fi
+done
+
+site_url="http://${myip}"
+
+echo ""
+echo "Installing Craft CMS..."
+cd /var/www/craft
+sudo -u www-data php craft install \
+  --interactive=0 \
+  --email="${email}" \
+  --username="${username}" \
+  --password="${pass}" \
+  --site-name="${title}" \
+  --site-url="${site_url}" \
+  --language=en-US
+
+chown -R www-data:www-data /var/www/craft
+touch "${MARKER}"
+sed -i '/craft_setup.sh/d' /root/.bashrc 2>/dev/null || true
+
+echo ""
+echo "Craft CMS is ready!"
+echo "  Front-end:      ${site_url}"
+echo "  Control Panel:  ${site_url}/admin"
+echo ""
+echo "To enable HTTPS with a domain:"
+echo "  certbot --nginx -d your.domain"
+echo ""

--- a/craftcms-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/craftcms-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# Generate MySQL passwords (WordPress / LEMP pattern)
+root_mysql_pass=$(openssl rand -hex 24)
+craft_mysql_pass=$(openssl rand -hex 24)
+debian_sys_maint_mysql_pass=$(openssl rand -hex 24)
+myip=$(hostname -I | awk '{print$1}')
+
+# Don't finish Craft install until first login (optional CLI wizard)
+cat >> /root/.bashrc <<EOM
+chmod +x /root/craft_setup.sh
+/root/craft_setup.sh
+EOM
+
+# Save the passwords
+cat > /root/.digitalocean_password <<EOM
+root_mysql_pass="${root_mysql_pass}"
+craft_mysql_pass="${craft_mysql_pass}"
+EOM
+chmod 600 /root/.digitalocean_password
+
+# Soften MySQL on tiny droplets (same approach as WordPress)
+dropletMemory=$(LANG=C free | awk '/^Mem:/{print $2}')
+if [ "$dropletMemory" -lt 2000000 ]; then
+  echo "[mysqld]
+performance_schema=off" > /etc/mysql/mysql.conf.d/performance.cnf
+  systemctl restart mysql
+fi
+
+# Set up Postfix defaults
+hostname=$(hostname)
+sed -i "s/myhostname \= .*/myhostname = $hostname/g" /etc/postfix/main.cf || true
+sed -i "s/inet_interfaces = all/inet_interfaces = loopback-only/g" /etc/postfix/main.cf || true
+systemctl restart postfix &
+
+mysqladmin -u root -h localhost create craftcms
+mysqladmin -u root -h localhost password ${root_mysql_pass}
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "CREATE USER 'craft'@'localhost' IDENTIFIED BY '${craft_mysql_pass}'"
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "GRANT ALL PRIVILEGES ON craftcms.* TO craft@localhost"
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "ALTER USER 'debian-sys-maint'@'localhost' IDENTIFIED BY '${debian_sys_maint_mysql_pass}'"
+
+MYSQL_ROOT_PASSWORD=${root_mysql_pass}
+
+SECURE_MYSQL=$(expect -c "
+set timeout 10
+spawn mysql_secure_installation
+expect \"Enter current password for root (enter for none):\"
+send \"$MYSQL_ROOT_PASSWORD\r\"
+expect \"Change the root password?\"
+send \"n\r\"
+expect \"Remove anonymous users?\"
+send \"y\r\"
+expect \"Disallow root login remotely?\"
+send \"y\r\"
+expect \"Remove test database and access to it?\"
+send \"y\r\"
+expect \"Reload privilege tables now?\"
+send \"y\r\"
+expect eof
+")
+
+cat > /etc/mysql/debian.cnf <<EOM
+# Automatically generated for Debian scripts. DO NOT TOUCH!
+[client]
+host     = localhost
+user     = debian-sys-maint
+password = ${debian_sys_maint_mysql_pass}
+socket   = /var/run/mysqld/mysqld.sock
+[mysql_upgrade]
+host     = localhost
+user     = debian-sys-maint
+password = ${debian_sys_maint_mysql_pass}
+socket   = /var/run/mysqld/mysqld.sock
+EOM
+chmod 600 /etc/mysql/debian.cnf
+
+# Populate Craft .env for this droplet
+ENV_FILE=/var/www/craft/.env
+cat > "${ENV_FILE}" <<EOF
+# DigitalOcean Craft CMS 1-Click
+# https://craftcms.com/docs/5.x/configure.html
+
+CRAFT_APP_ID=
+CRAFT_ENVIRONMENT=production
+
+CRAFT_DB_DRIVER=mysql
+CRAFT_DB_SERVER=127.0.0.1
+CRAFT_DB_PORT=3306
+CRAFT_DB_DATABASE=craftcms
+CRAFT_DB_USER=craft
+CRAFT_DB_PASSWORD=${craft_mysql_pass}
+CRAFT_DB_SCHEMA=
+CRAFT_DB_TABLE_PREFIX=
+
+CRAFT_SECURITY_KEY=
+CRAFT_DEV_MODE=false
+CRAFT_ALLOW_ADMIN_CHANGES=true
+CRAFT_DISALLOW_ROBOTS=false
+EOF
+
+cd /var/www/craft
+php craft setup/app-id --interactive=0
+php craft setup/security-key --interactive=0
+
+chown -R www-data:www-data /var/www/craft
+chmod 640 /var/www/craft/.env
+chmod +x /var/www/craft/craft
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh
+systemctl restart nginx php8.3-fpm mysql

--- a/craftcms-24-04/scripts/011-craftcms.sh
+++ b/craftcms-24-04/scripts/011-craftcms.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configure PHP for FPM / CLI — sized for Craft CMS
+sed -e "s|memory_limit.*|memory_limit = 512M|g" \
+    -e "s|upload_max_filesize.*|upload_max_filesize = 64M|g" \
+    -e "s|post_max_size.*|post_max_size = 64M|g" \
+    -e "s|max_execution_time.*|max_execution_time = 300|g" \
+    -e "s|max_input_vars.*|max_input_vars = 5000|g" \
+    -i /etc/php/8.3/fpm/php.ini
+
+sed -e "s|memory_limit.*|memory_limit = 512M|g" \
+    -e "s|upload_max_filesize.*|upload_max_filesize = 64M|g" \
+    -e "s|post_max_size.*|post_max_size = 64M|g" \
+    -e "s|max_execution_time.*|max_execution_time = 300|g" \
+    -e "s|max_input_vars.*|max_input_vars = 5000|g" \
+    -i /etc/php/8.3/cli/php.ini
+
+sed -i 's/^listen = .*/listen = \/run\/php\/php8.3-fpm.sock/' /etc/php/8.3/fpm/pool.d/www.conf
+sed -i 's/^;listen.owner = www-data/listen.owner = www-data/' /etc/php/8.3/fpm/pool.d/www.conf
+sed -i 's/^;listen.group = www-data/listen.group = www-data/' /etc/php/8.3/fpm/pool.d/www.conf
+sed -i 's/^;listen.mode = 0660/listen.mode = 0660/' /etc/php/8.3/fpm/pool.d/www.conf
+
+# Enable Nginx site
+rm -rf /etc/nginx/sites-enabled/default
+ln -sf /etc/nginx/sites-available/craftcms /etc/nginx/sites-enabled/craftcms
+nginx -t
+
+# Install Craft CMS into /var/www/craft
+# --no-install/--no-scripts: skip post-create hooks that need a database.
+mkdir -p /var/www
+rm -rf /var/www/craft
+export COMPOSER_ALLOW_SUPERUSER=1
+export COMPOSER_HOME=/root/.composer
+
+composer create-project craftcms/craft /var/www/craft \
+  --no-interaction \
+  --prefer-dist \
+  --no-install \
+  --no-scripts
+
+cd /var/www/craft
+
+if [ -f composer.json.default ]; then
+  rm -f composer.json
+  mv composer.json.default composer.json
+fi
+
+composer install --no-interaction --prefer-dist --optimize-autoloader
+
+if [ -n "${CRAFT_VERSION:-}" ]; then
+  composer require "craftcms/cms:${CRAFT_VERSION}" \
+    --no-interaction \
+    --update-with-dependencies \
+    --prefer-dist
+fi
+
+cat > /var/www/craft/.env <<'EOF'
+# DigitalOcean Craft CMS 1-Click
+# https://craftcms.com/docs/5.x/configure.html
+
+CRAFT_APP_ID=
+CRAFT_ENVIRONMENT=production
+
+CRAFT_DB_DRIVER=mysql
+CRAFT_DB_SERVER=127.0.0.1
+CRAFT_DB_PORT=3306
+CRAFT_DB_DATABASE=craftcms
+CRAFT_DB_USER=craft
+CRAFT_DB_PASSWORD=
+CRAFT_DB_SCHEMA=
+CRAFT_DB_TABLE_PREFIX=
+
+CRAFT_SECURITY_KEY=
+CRAFT_DEV_MODE=false
+CRAFT_ALLOW_ADMIN_CHANGES=true
+CRAFT_DISALLOW_ROBOTS=false
+EOF
+
+chown -R www-data:www-data /var/www/craft
+chmod -R u+rwX,g+rwX /var/www/craft/storage /var/www/craft/web/cpresources 2>/dev/null || true
+chmod +x /var/www/craft/craft
+chmod +x /root/craft_setup.sh
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+chmod +x /etc/update-motd.d/99-one-click
+
+systemctl enable nginx php8.3-fpm mysql
+systemctl restart php8.3-fpm nginx

--- a/craftcms-24-04/template.json
+++ b/craftcms-24-04/template.json
@@ -1,0 +1,88 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "craftcms-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "fail2ban mysql-server nginx composer unzip curl git jq expect postfix python3-certbot-nginx software-properties-common php8.3-fpm php8.3 php8.3-cli php8.3-common php8.3-mysql php8.3-mbstring php8.3-xml php8.3-curl php8.3-zip php8.3-bcmath php8.3-intl php8.3-gd php8.3-imagick php8.3-opcache",
+    "application_name": "Craft CMS",
+    "application_version": "5.10.11",
+    "craft_version": "5.10.11"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-2gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "craftcms-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "craftcms-24-04/files/root/",
+      "destination": "/root/"
+    },
+    {
+      "type": "file",
+      "source": "craftcms-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install software-properties-common",
+        "add-apt-repository -y ppa:ondrej/php",
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "CRAFT_VERSION={{user `craft_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8",
+        "COMPOSER_ALLOW_SUPERUSER=1"
+      ],
+      "scripts": [
+        "craftcms-24-04/scripts/011-craftcms.sh",
+        "common/scripts/014-ufw-nginx.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a new `craftcms-24-04` Packer 1-Click for [Craft CMS](https://craftcms.com/) on Ubuntu 24.04 LTS.
- Installs Craft CMS **5.10.11** with Nginx, PHP 8.3 FPM, MySQL, Composer, Certbot, and UFW (ports 22/80/443).
- Follows the WordPress/LEMP layout: single install script (`011-craftcms.sh`), first-boot MySQL + `.env` setup (`001_onboot`), MOTD, and optional first-login CLI wizard (`/root/craft_setup.sh`).
- Users can finish setup via CLI on first SSH login or through the Craft web installer at `http://<droplet-ip>`.
## Test plan
- [x] Deploy a test Droplet from the snapshot (2 GB RAM recommended)
- [x] After first boot (~1–2 min), SSH as root and confirm MOTD shows Craft CMS info
- [x] Confirm services are active: `systemctl is-active nginx php8.3-fpm mysql`
- [x] Confirm Craft version: `cd /var/www/craft && sudo -u www-data php craft` shows **5.10.11**
- [x] Confirm install health: `cd /var/www/craft && sudo -u www-data php craft install/check`
- [x] Confirm credentials exist in `/root/.digitalocean_password`
- [x] Confirm UFW allows only 22/80/443: `ufw status`
- [x] Open `http://<droplet-ip>` and complete Craft setup (CLI wizard **or** browser installer)
- [x] Log in to Control Panel at `/admin`
- [x] Reboot the Droplet and verify site + `/admin` still work
