### PR TITLE
Pin WordPress 1-Click to 6.9.5

### DIFF
--- a/wordpress-24-04/scripts/011-wordpress.sh
+++ b/wordpress-24-04/scripts/011-wordpress.sh
@@ -1,16 +1,13 @@
 #!/bin/sh
 
 # Download the WordPress bits and cache them on disk
-wget -q https://wordpress.org/wordpress-latest.tar.gz -O /tmp/wordpress.tar.gz
+wget -q "https://wordpress.org/wordpress-${application_version}.tar.gz" \
+     -O /tmp/wordpress.tar.gz
 
 # Extract the bits and stage up
 mkdir -p /var/www
 tar -C /var/www \
     -xvvf /tmp/wordpress.tar.gz
-
-# Update WordPress core to the latest version
-cd /var/www/wordpress
-wp core update
 
 wget -q https://downloads.wordpress.org/plugin/wp-fail2ban.latest-stable.zip -O /tmp/wp-fail2ban.zip
 unzip -q /tmp/wp-fail2ban.zip -d /tmp/

--- a/wordpress-24-04/template.json
+++ b/wordpress-24-04/template.json
@@ -5,7 +5,7 @@
     "image_name": "wordpress-24-04-snapshot-{{timestamp}}",
     "apt_packages": "fail2ban mysql-server php8.3-fpm php8.3 php8.3-apcu php8.3-bz2 php8.3-curl php8.3-gd php8.3-gmp php8.3-intl php8.3-mbstring php8.3-mysql php8.3-pspell php8.3-soap php8.3-tidy php8.3-xml php8.3-xmlrpc php8.3-xsl php8.3-zip postfix software-properties-common unzip",
     "application_name": "WordPress",
-    "application_version": "",
+    "application_version": "6.9.5",
     "fail2ban_version": ""
   },
   "sensitive-variables": ["do_api_token"],


### PR DESCRIPTION
## Summary
- Pin `application_version` to `6.9.5` in the WordPress 24.04 Packer template so image metadata reflects the shipped version.
- Download `wordpress-6.9.5.tar.gz` during image build instead of `wordpress-latest`, which currently resolves to WordPress 7.0.x.
- Remove the no-op `wp core update` step from the build script (WP-CLI is not installed at build time).

This addresses a recent RCE by shipping the patched 6.9.x release while avoiding a major version jump to WordPress 7.0 before additional testing.

## Test plan
- [ ] Run `packer build wordpress-24-04/template.json`
- [ ] Confirm `/var/www/wordpress/wp-includes/version.php` reports `6.9.5` on the built snapshot
- [ ] Confirm `/var/lib/digitalocean/application.info` contains `application_version="6.9.5"`
- [ ] Deploy a Droplet from the new snapshot and verify first-login setup completes successfully