### PR TITLE
[MP-8458]: Create Jellyfin Droplet 1-Click

### DIFF
--- a/jellyfin-24-04/README.md
+++ b/jellyfin-24-04/README.md
@@ -44,7 +44,7 @@ packer build jellyfin-24-04/template.json
 | Path | Purpose |
 |------|---------|
 | `template.json` | Packer build template |
-| `scripts/01-setup.sh` | Install Docker app, Caddy, enable services |
+| `scripts/01-setup.sh` | Install Caddy, pull Jellyfin image (start deferred to first boot) |
 | `files/etc/caddy/Caddyfile.tmp` | Caddy TLS reverse-proxy template |
 | `files/etc/systemd/system/jellyfin.service` | systemd unit for the container |
 | `files/etc/update-motd.d/99-one-click` | MOTD with usage instructions |

--- a/jellyfin-24-04/README.md
+++ b/jellyfin-24-04/README.md
@@ -5,7 +5,7 @@ Packer template for a DigitalOcean Marketplace 1-Click image that runs [Jellyfin
 ## What's Included
 
 - **Jellyfin** `10.11.11` (`jellyfin/jellyfin`) bound to `127.0.0.1:8096`
-- **Caddy** reverse proxy with Let's Encrypt short-lived IP/domain certs
+- **Caddy** reverse proxy with Let's Encrypt short-lived IP/domain certs (enabled on first SSH claim)
 - **UFW** allowing SSH (22), HTTP (80), and HTTPS (443) only
 - **Ubuntu 24.04 LTS** base image
 - Helper scripts under `/opt/` and a `jellyfin` systemd unit
@@ -36,8 +36,9 @@ packer build jellyfin-24-04/template.json
 
 1. Packer installs Docker and app dependencies via `apt_packages`.
 2. `scripts/01-setup.sh` enables Docker, installs Caddy (left disabled), pulls the pinned Jellyfin image, and prepares data dirs — it does **not** create the container or enable Caddy.
-3. On first boot, `001_onboot` unlocks SSH, writes the Caddyfile with the droplet public IP, then enables/starts Jellyfin and Caddy.
-4. Users access Jellyfin at `https://<droplet-ip>` and complete the setup wizard.
+3. On first boot, `001_onboot` unlocks SSH, writes the Caddyfile and `JELLYFIN_PublishedServerUrl`, starts Jellyfin on localhost, keeps Caddy disabled, and installs a first-SSH claim hook in `/root/.bashrc`.
+4. First SSH login runs `/opt/claim-jellyfin-access.sh`, which enables Caddy so HTTPS becomes public.
+5. Users complete the Jellyfin setup wizard at `https://<droplet-ip>`.
 
 ## Files
 
@@ -46,8 +47,10 @@ packer build jellyfin-24-04/template.json
 | `template.json` | Packer build template |
 | `scripts/01-setup.sh` | Install Caddy, pull Jellyfin image (start deferred to first boot) |
 | `files/etc/caddy/Caddyfile.tmp` | Caddy TLS reverse-proxy template |
-| `files/etc/systemd/system/jellyfin.service` | systemd unit for the container |
+| `files/etc/systemd/system/jellyfin.service` | systemd unit (`jellyfin-docker.sh`) |
 | `files/etc/update-motd.d/99-one-click` | MOTD with usage instructions |
+| `files/opt/jellyfin-docker.sh` | Container start/stop used by systemd |
+| `files/opt/claim-jellyfin-access.sh` | First-SSH unlock for public HTTPS |
 | `files/opt/*.sh` | start / stop / restart / status / update / domain helpers |
 | `files/var/lib/cloud/scripts/per-instance/001_onboot` | First-boot SSH unlock + Caddy IP config |
 | `listing.md` | Marketplace catalog copy |
@@ -57,8 +60,9 @@ packer build jellyfin-24-04/template.json
 After creating a Droplet from the snapshot:
 
 - [ ] Packer build finished with no interactive/TTY hang
-- [ ] `https://<ip>` reaches the Jellyfin setup wizard
+- [ ] Before first SSH, `https://<ip>` is not serving the Jellyfin wizard (Caddy inactive)
+- [ ] After first SSH, claim script unlocks HTTPS and `https://<ip>` reaches the wizard
 - [ ] Port 8096 is not publicly open (`ufw status` / external probe)
-- [ ] `systemctl status jellyfin` and `systemctl status caddy` are active
-- [ ] MOTD shows HTTPS URL and helper commands
+- [ ] `systemctl status jellyfin` and (after claim) `systemctl status caddy` are active
+- [ ] MOTD shows claim status, HTTPS URL, and helper commands
 - [ ] `sudo /opt/setup-jellyfin-domain.sh` configures TLS for a custom domain

--- a/jellyfin-24-04/README.md
+++ b/jellyfin-24-04/README.md
@@ -1,0 +1,64 @@
+# Jellyfin 1-Click Droplet
+
+Packer template for a DigitalOcean Marketplace 1-Click image that runs [Jellyfin](https://jellyfin.org) in Docker behind Caddy with automatic TLS.
+
+## What's Included
+
+- **Jellyfin** `10.11.11` (`jellyfin/jellyfin`) bound to `127.0.0.1:8096`
+- **Caddy** reverse proxy with Let's Encrypt short-lived IP/domain certs
+- **UFW** allowing SSH (22), HTTP (80), and HTTPS (443) only
+- **Ubuntu 24.04 LTS** base image
+- Helper scripts under `/opt/` and a `jellyfin` systemd unit
+
+## Droplet Size
+
+Build and recommend **`s-1vcpu-2gb`** (minimum 2 GB RAM). Smaller sizes are not sufficient for typical Jellyfin workloads.
+
+## Building
+
+From the `droplet-1-clicks` repository root:
+
+```bash
+export DIGITALOCEAN_API_TOKEN="your-token"
+
+make validate-jellyfin-24-04
+make build-jellyfin-24-04
+```
+
+Or with Packer directly:
+
+```bash
+packer validate jellyfin-24-04/template.json
+packer build jellyfin-24-04/template.json
+```
+
+## How It Works
+
+1. Packer installs Docker and app dependencies via `apt_packages`.
+2. `scripts/01-setup.sh` enables Docker, installs Caddy (left disabled), pulls the pinned Jellyfin image, and prepares data dirs — it does **not** create the container or enable Caddy.
+3. On first boot, `001_onboot` unlocks SSH, writes the Caddyfile with the droplet public IP, then enables/starts Jellyfin and Caddy.
+4. Users access Jellyfin at `https://<droplet-ip>` and complete the setup wizard.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `template.json` | Packer build template |
+| `scripts/01-setup.sh` | Install Docker app, Caddy, enable services |
+| `files/etc/caddy/Caddyfile.tmp` | Caddy TLS reverse-proxy template |
+| `files/etc/systemd/system/jellyfin.service` | systemd unit for the container |
+| `files/etc/update-motd.d/99-one-click` | MOTD with usage instructions |
+| `files/opt/*.sh` | start / stop / restart / status / update / domain helpers |
+| `files/var/lib/cloud/scripts/per-instance/001_onboot` | First-boot SSH unlock + Caddy IP config |
+| `listing.md` | Marketplace catalog copy |
+
+## Smoke Test Checklist
+
+After creating a Droplet from the snapshot:
+
+- [ ] Packer build finished with no interactive/TTY hang
+- [ ] `https://<ip>` reaches the Jellyfin setup wizard
+- [ ] Port 8096 is not publicly open (`ufw status` / external probe)
+- [ ] `systemctl status jellyfin` and `systemctl status caddy` are active
+- [ ] MOTD shows HTTPS URL and helper commands
+- [ ] `sudo /opt/setup-jellyfin-domain.sh` configures TLS for a custom domain

--- a/jellyfin-24-04/files/etc/caddy/Caddyfile.tmp
+++ b/jellyfin-24-04/files/etc/caddy/Caddyfile.tmp
@@ -1,0 +1,10 @@
+PLACEHOLDER_DOMAIN {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+    reverse_proxy localhost:8096
+    header X-DO-MARKETPLACE "jellyfin"
+}

--- a/jellyfin-24-04/files/etc/systemd/system/jellyfin.service
+++ b/jellyfin-24-04/files/etc/systemd/system/jellyfin.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Jellyfin Media Server
+Documentation=https://jellyfin.org
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/opt/jellyfin.env
+ExecStart=/opt/start-jellyfin.sh
+ExecStop=/opt/stop-jellyfin.sh
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/jellyfin-24-04/files/etc/systemd/system/jellyfin.service
+++ b/jellyfin-24-04/files/etc/systemd/system/jellyfin.service
@@ -9,8 +9,8 @@ Wants=network-online.target
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/opt/jellyfin.env
-ExecStart=/opt/start-jellyfin.sh
-ExecStop=/opt/stop-jellyfin.sh
+ExecStart=/opt/jellyfin-docker.sh start
+ExecStop=/opt/jellyfin-docker.sh stop
 TimeoutStartSec=0
 
 [Install]

--- a/jellyfin-24-04/files/etc/update-motd.d/99-one-click
+++ b/jellyfin-24-04/files/etc/update-motd.d/99-one-click
@@ -2,33 +2,44 @@
 #
 # Configured as part of the DigitalOcean 1-Click Image build process
 
-myip=$(hostname -I | awk '{print$1}')
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print$1}')}"
 
 cat <<EOF
 ********************************************************************************
 
 Welcome to DigitalOcean's 1-Click Jellyfin Droplet.
 To keep this Droplet secure, the UFW firewall is enabled.
-All ports are BLOCKED except 22 (SSH), 80 (HTTP), 443 (HTTPS), and 8096 (Jellyfin).
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
 
-- Access Jellyfin:
-  * http://$myip:8096
+- Access Jellyfin (complete the setup wizard immediately after create):
+  * https://$myip
 
-- Jellyfin is running as a systemd service.
-  To view service status run the following command:
+- Jellyfin runs in Docker behind Caddy (TLS). Port 8096 is localhost-only.
 
-  systemctl status jellyfin
+- Service control:
+    systemctl status jellyfin
+    systemctl status caddy
 
-- On first visit, complete the Jellyfin setup wizard to create an admin account
-  and add your media libraries.
+- Helper scripts:
+    /opt/start-jellyfin.sh
+    /opt/stop-jellyfin.sh
+    /opt/restart-jellyfin.sh
+    /opt/status-jellyfin.sh
+    /opt/update-jellyfin.sh
+
+- Custom domain with Let's Encrypt:
+    sudo /opt/setup-jellyfin-domain.sh
 
 On the server:
-  * Jellyfin configuration is stored in /etc/jellyfin
-  * Jellyfin data is stored in /var/lib/jellyfin
+  * Config: /var/lib/jellyfin/config
+  * Cache:  /var/lib/jellyfin/cache
+  * Media:  /var/lib/jellyfin/media
 
 For more information, please refer to the Getting Started Guide:
 https://marketplace.digitalocean.com/apps/jellyfin
 
 ********************************************************************************
-To delete this message of the day: rm -rf /etc/update-motd.d/99-one-click
+To delete this message of the day: rm -rf $(readlink -f ${0})
 EOF

--- a/jellyfin-24-04/files/etc/update-motd.d/99-one-click
+++ b/jellyfin-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's 1-Click Jellyfin Droplet.
+To keep this Droplet secure, the UFW firewall is enabled.
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), 443 (HTTPS), and 8096 (Jellyfin).
+
+- Access Jellyfin:
+  * http://$myip:8096
+
+- Jellyfin is running as a systemd service.
+  To view service status run the following command:
+
+  systemctl status jellyfin
+
+- On first visit, complete the Jellyfin setup wizard to create an admin account
+  and add your media libraries.
+
+On the server:
+  * Jellyfin configuration is stored in /etc/jellyfin
+  * Jellyfin data is stored in /var/lib/jellyfin
+
+For more information, please refer to the Getting Started Guide:
+https://marketplace.digitalocean.com/apps/jellyfin
+
+********************************************************************************
+To delete this message of the day: rm -rf /etc/update-motd.d/99-one-click
+EOF

--- a/jellyfin-24-04/files/etc/update-motd.d/99-one-click
+++ b/jellyfin-24-04/files/etc/update-motd.d/99-one-click
@@ -5,6 +5,15 @@
 pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
   http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
 myip="${pub:-$(hostname -I | awk '{print$1}')}"
+if [ -z "$myip" ]; then
+  access_url="https://<your-droplet-ip>"
+else
+  access_url="https://$myip"
+fi
+
+# shellcheck disable=SC1091
+. /var/lib/digitalocean/application.info 2>/dev/null
+APP_VERSION="${application_version:-unknown}"
 
 cat <<EOF
 ********************************************************************************
@@ -13,8 +22,15 @@ Welcome to DigitalOcean's 1-Click Jellyfin Droplet.
 To keep this Droplet secure, the UFW firewall is enabled.
 All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
 
-- Access Jellyfin (complete the setup wizard immediately after create):
-  * https://$myip
+Installed version: ${APP_VERSION}
+
+IMPORTANT FIRST STEPS:
+  1. Visit ${access_url} in your browser
+  2. Complete the Jellyfin setup wizard IMMEDIATELY to create your admin account
+  3. The first person to finish the wizard gets full administrative access
+
+- Access Jellyfin:
+  * ${access_url}
 
 - Jellyfin runs in Docker behind Caddy (TLS). Port 8096 is localhost-only.
 
@@ -27,7 +43,7 @@ All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
     /opt/stop-jellyfin.sh
     /opt/restart-jellyfin.sh
     /opt/status-jellyfin.sh
-    /opt/update-jellyfin.sh
+    /opt/update-jellyfin.sh <version>
 
 - Custom domain with Let's Encrypt:
     sudo /opt/setup-jellyfin-domain.sh
@@ -37,8 +53,8 @@ On the server:
   * Cache:  /var/lib/jellyfin/cache
   * Media:  /var/lib/jellyfin/media
 
-For more information, please refer to the Getting Started Guide:
-https://marketplace.digitalocean.com/apps/jellyfin
+For more information, please refer to the Jellyfin documentation:
+https://jellyfin.org/docs/
 
 ********************************************************************************
 To delete this message of the day: rm -rf $(readlink -f ${0})

--- a/jellyfin-24-04/files/etc/update-motd.d/99-one-click
+++ b/jellyfin-24-04/files/etc/update-motd.d/99-one-click
@@ -15,6 +15,13 @@ fi
 . /var/lib/digitalocean/application.info 2>/dev/null
 APP_VERSION="${application_version:-unknown}"
 
+if [ -f /var/lib/digitalocean/jellyfin_access_claimed ]; then
+  access_status="HTTPS unlocked (Caddy enabled)"
+else
+  # MOTD runs before .bashrc on this login; claim unlocks HTTPS immediately after
+  access_status="HTTPS unlock pending (claim runs on this SSH login via .bashrc)"
+fi
+
 cat <<EOF
 ********************************************************************************
 
@@ -23,27 +30,32 @@ To keep this Droplet secure, the UFW firewall is enabled.
 All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
 
 Installed version: ${APP_VERSION}
+Access status: ${access_status}
 
 IMPORTANT FIRST STEPS:
-  1. Visit ${access_url} in your browser
-  2. Complete the Jellyfin setup wizard IMMEDIATELY to create your admin account
-  3. The first person to finish the wizard gets full administrative access
+  1. On first SSH, /opt/claim-jellyfin-access.sh unlocks HTTPS (runs from .bashrc after this MOTD)
+  2. Visit ${access_url} in your browser
+  3. Complete the Jellyfin setup wizard IMMEDIATELY to create your admin account
+  4. The first person to finish the wizard gets full administrative access
 
 - Access Jellyfin:
   * ${access_url}
 
 - Jellyfin runs in Docker behind Caddy (TLS). Port 8096 is localhost-only.
+  Caddy stays disabled until the first SSH claim so strangers cannot reach
+  the setup wizard before you do.
 
 - Service control:
     systemctl status jellyfin
     systemctl status caddy
 
-- Helper scripts:
+- Helper scripts (wrap systemctl):
     /opt/start-jellyfin.sh
     /opt/stop-jellyfin.sh
     /opt/restart-jellyfin.sh
     /opt/status-jellyfin.sh
     /opt/update-jellyfin.sh <version>
+    /opt/claim-jellyfin-access.sh
 
 - Custom domain with Let's Encrypt:
     sudo /opt/setup-jellyfin-domain.sh

--- a/jellyfin-24-04/files/opt/claim-jellyfin-access.sh
+++ b/jellyfin-24-04/files/opt/claim-jellyfin-access.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# First-SSH claim: enable public HTTPS (Caddy) only after the droplet owner logs in.
+set -euo pipefail
+
+MARKER=/var/lib/digitalocean/jellyfin_access_claimed
+
+remove_first_login_hook() {
+    if [ -f /root/.bashrc ]; then
+        sed -i '/claim-jellyfin-access\.sh/d' /root/.bashrc
+    fi
+}
+
+if [ -f "${MARKER}" ]; then
+    remove_first_login_hook
+    exit 0
+fi
+
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print $1}')}"
+if [ -n "$myip" ]; then
+  access_url="https://${myip}"
+else
+  access_url="https://<your-droplet-ip>"
+fi
+
+echo "========================================================================"
+echo " Claiming Jellyfin HTTPS access (first SSH login)"
+echo "========================================================================"
+echo ""
+echo "Public HTTPS was held back until you SSH'd in so strangers cannot reach"
+echo "the setup wizard. Enabling Caddy now..."
+echo ""
+
+if [ ! -f /etc/caddy/Caddyfile ]; then
+    echo "ERROR: Missing /etc/caddy/Caddyfile. Re-run cloud-init/onboot or restore it." >&2
+    exit 1
+fi
+
+systemctl enable --now jellyfin >/dev/null 2>&1 || systemctl start jellyfin
+systemctl enable caddy
+systemctl restart caddy
+
+mkdir -p "$(dirname "${MARKER}")"
+touch "${MARKER}"
+remove_first_login_hook
+
+echo "HTTPS is unlocked."
+echo ""
+echo "IMPORTANT NEXT STEP:"
+echo "  1. Open ${access_url} in your browser"
+echo "  2. Complete the Jellyfin setup wizard IMMEDIATELY to create your admin account"
+echo "  3. The first person to finish the wizard gets full administrative access"
+echo ""
+echo "Custom domain later: sudo /opt/setup-jellyfin-domain.sh"
+echo "========================================================================"
+echo ""

--- a/jellyfin-24-04/files/opt/jellyfin-docker.sh
+++ b/jellyfin-24-04/files/opt/jellyfin-docker.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Container lifecycle used by the jellyfin systemd unit (ExecStart/ExecStop).
+# User-facing helpers should call systemctl, not this script directly.
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /opt/jellyfin.env
+
+IMAGE="${JELLYFIN_IMAGE:-jellyfin/jellyfin:${JELLYFIN_VERSION}}"
+PUBLISHED_URL="${JELLYFIN_PUBLISHED_SERVER_URL:-}"
+
+usage() {
+    echo "Usage: $0 {start|stop}"
+    exit 1
+}
+
+start_container() {
+    if docker ps -a --format '{{.Names}}' | grep -qx jellyfin; then
+        echo "Starting existing Jellyfin container..."
+        docker start jellyfin
+    else
+        echo "Creating Jellyfin container from ${IMAGE}..."
+        mkdir -p /var/lib/jellyfin/config /var/lib/jellyfin/cache /var/lib/jellyfin/media
+        run_args=(
+            -d
+            --name jellyfin
+            --restart unless-stopped
+            -p 127.0.0.1:8096:8096
+            -v /var/lib/jellyfin/config:/config
+            -v /var/lib/jellyfin/cache:/cache
+            -v /var/lib/jellyfin/media:/media
+        )
+        if [ -n "${PUBLISHED_URL}" ]; then
+            run_args+=(-e "JELLYFIN_PublishedServerUrl=${PUBLISHED_URL}")
+        fi
+        docker run "${run_args[@]}" "${IMAGE}"
+    fi
+    echo "Jellyfin is running on 127.0.0.1:8096 (proxied via Caddy after access is claimed)."
+}
+
+stop_container() {
+    echo "Stopping Jellyfin..."
+    docker stop jellyfin 2>/dev/null || true
+    # Remove so the next start recreates with current /opt/jellyfin.env
+    # (Docker env vars like JELLYFIN_PublishedServerUrl are only applied at create time).
+    docker rm jellyfin 2>/dev/null || true
+    echo "Jellyfin stopped."
+}
+
+case "${1:-}" in
+    start) start_container ;;
+    stop) stop_container ;;
+    *) usage ;;
+esac

--- a/jellyfin-24-04/files/opt/restart-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/restart-jellyfin.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
   http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
 myip="${pub:-$(hostname -I | awk '{print $1}')}"
+if [ -n "$myip" ]; then
+  access_url="https://${myip}"
+else
+  access_url="https://<your-droplet-ip>"
+fi
 
 echo "Restarting Jellyfin..."
 /opt/stop-jellyfin.sh
@@ -13,7 +18,7 @@ sleep 2
 
 if docker ps --format '{{.Names}}' | grep -qx jellyfin; then
     echo "Jellyfin restarted successfully!"
-    echo "Access via https://${myip}"
+    echo "Access via ${access_url}"
 else
     echo "Error: Failed to restart Jellyfin"
     echo "Check logs with: docker logs jellyfin"

--- a/jellyfin-24-04/files/opt/restart-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/restart-jellyfin.sh
@@ -10,17 +10,21 @@ else
   access_url="https://<your-droplet-ip>"
 fi
 
-echo "Restarting Jellyfin..."
-/opt/stop-jellyfin.sh
-/opt/start-jellyfin.sh
+echo "Restarting Jellyfin via systemd..."
+systemctl restart jellyfin
 
 sleep 2
 
-if docker ps --format '{{.Names}}' | grep -qx jellyfin; then
+if systemctl is-active --quiet jellyfin && docker ps --format '{{.Names}}' | grep -qx jellyfin; then
     echo "Jellyfin restarted successfully!"
-    echo "Access via ${access_url}"
+    if [ -f /var/lib/digitalocean/jellyfin_access_claimed ]; then
+        echo "Access via ${access_url}"
+    else
+        echo "HTTPS is not public yet. Run /opt/claim-jellyfin-access.sh after SSH if needed."
+    fi
 else
     echo "Error: Failed to restart Jellyfin"
-    echo "Check logs with: docker logs jellyfin"
+    echo "Check logs with: journalctl -u jellyfin -xe"
+    echo "Container logs: docker logs jellyfin"
     exit 1
 fi

--- a/jellyfin-24-04/files/opt/restart-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/restart-jellyfin.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print $1}')}"
+
+echo "Restarting Jellyfin..."
+/opt/stop-jellyfin.sh
+/opt/start-jellyfin.sh
+
+sleep 2
+
+if docker ps --format '{{.Names}}' | grep -qx jellyfin; then
+    echo "Jellyfin restarted successfully!"
+    echo "Access via https://${myip}"
+else
+    echo "Error: Failed to restart Jellyfin"
+    echo "Check logs with: docker logs jellyfin"
+    exit 1
+fi

--- a/jellyfin-24-04/files/opt/setup-jellyfin-domain.sh
+++ b/jellyfin-24-04/files/opt/setup-jellyfin-domain.sh
@@ -12,7 +12,11 @@ fi
 
 read -rp "Enter an email for Let's Encrypt notifications (optional): " EMAIL
 
-cat > /etc/caddy/Caddyfile << CADDYEOF
+{
+    if [ -n "${EMAIL}" ]; then
+        echo "email ${EMAIL}"
+    fi
+    cat << CADDYEOF
 ${DOMAIN} {
     tls {
         issuer acme {
@@ -24,10 +28,7 @@ ${DOMAIN} {
     header X-DO-MARKETPLACE "jellyfin"
 }
 CADDYEOF
-
-if [ -n "${EMAIL}" ]; then
-    sed -i "1iemail ${EMAIL}" /etc/caddy/Caddyfile
-fi
+} > /etc/caddy/Caddyfile
 
 systemctl enable caddy
 systemctl restart caddy

--- a/jellyfin-24-04/files/opt/setup-jellyfin-domain.sh
+++ b/jellyfin-24-04/files/opt/setup-jellyfin-domain.sh
@@ -40,8 +40,8 @@ if [ -f /opt/jellyfin.env ]; then
 fi
 
 # Recreate the container so the new PublishedServerUrl is applied
+# (systemctl stop removes the container via jellyfin-docker.sh)
 systemctl stop jellyfin 2>/dev/null || true
-docker rm -f jellyfin 2>/dev/null || true
 systemctl start jellyfin
 
 # Domain setup implies the owner is present; unlock HTTPS if not yet claimed

--- a/jellyfin-24-04/files/opt/setup-jellyfin-domain.sh
+++ b/jellyfin-24-04/files/opt/setup-jellyfin-domain.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+PORT=8096
+BIND_IP=127.0.0.1
+
+read -rp "Enter the domain you pointed at this droplet (e.g. media.example.com): " DOMAIN
+if [ -z "${DOMAIN}" ]; then
+    echo "Domain cannot be empty."
+    exit 1
+fi
+
+read -rp "Enter an email for Let's Encrypt notifications (optional): " EMAIL
+
+cat > /etc/caddy/Caddyfile << CADDYEOF
+${DOMAIN} {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+    reverse_proxy ${BIND_IP}:${PORT}
+    header X-DO-MARKETPLACE "jellyfin"
+}
+CADDYEOF
+
+if [ -n "${EMAIL}" ]; then
+    sed -i "1iemail ${EMAIL}" /etc/caddy/Caddyfile
+fi
+
+systemctl enable caddy
+systemctl restart caddy
+
+echo "Caddy is now proxying https://${DOMAIN} to ${BIND_IP}:${PORT}."
+echo "SSL certificate will be provisioned automatically via Let's Encrypt."

--- a/jellyfin-24-04/files/opt/setup-jellyfin-domain.sh
+++ b/jellyfin-24-04/files/opt/setup-jellyfin-domain.sh
@@ -30,8 +30,30 @@ ${DOMAIN} {
 CADDYEOF
 } > /etc/caddy/Caddyfile
 
+# Keep Jellyfin's advertised URL in sync with the custom domain
+if [ -f /opt/jellyfin.env ]; then
+    if grep -q '^JELLYFIN_PUBLISHED_SERVER_URL=' /opt/jellyfin.env; then
+        sed -i "s|^JELLYFIN_PUBLISHED_SERVER_URL=.*|JELLYFIN_PUBLISHED_SERVER_URL=https://${DOMAIN}|" /opt/jellyfin.env
+    else
+        echo "JELLYFIN_PUBLISHED_SERVER_URL=https://${DOMAIN}" >> /opt/jellyfin.env
+    fi
+fi
+
+# Recreate the container so the new PublishedServerUrl is applied
+systemctl stop jellyfin 2>/dev/null || true
+docker rm -f jellyfin 2>/dev/null || true
+systemctl start jellyfin
+
+# Domain setup implies the owner is present; unlock HTTPS if not yet claimed
+mkdir -p /var/lib/digitalocean
+touch /var/lib/digitalocean/jellyfin_access_claimed
+if [ -f /root/.bashrc ]; then
+    sed -i '/claim-jellyfin-access\.sh/d' /root/.bashrc
+fi
+
 systemctl enable caddy
 systemctl restart caddy
 
 echo "Caddy is now proxying https://${DOMAIN} to ${BIND_IP}:${PORT}."
+echo "JELLYFIN_PublishedServerUrl set to https://${DOMAIN}."
 echo "SSL certificate will be provisioned automatically via Let's Encrypt."

--- a/jellyfin-24-04/files/opt/start-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/start-jellyfin.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /opt/jellyfin.env
+
+IMAGE="${JELLYFIN_IMAGE:-jellyfin/jellyfin:${JELLYFIN_VERSION}}"
+
+if docker ps -a --format '{{.Names}}' | grep -qx jellyfin; then
+    echo "Starting existing Jellyfin container..."
+    docker start jellyfin
+else
+    echo "Creating Jellyfin container from ${IMAGE}..."
+    mkdir -p /var/lib/jellyfin/config /var/lib/jellyfin/cache /var/lib/jellyfin/media
+    docker run -d \
+      --name jellyfin \
+      --restart unless-stopped \
+      -p 127.0.0.1:8096:8096 \
+      -v /var/lib/jellyfin/config:/config \
+      -v /var/lib/jellyfin/cache:/cache \
+      -v /var/lib/jellyfin/media:/media \
+      "${IMAGE}"
+fi
+
+echo "Jellyfin is running on 127.0.0.1:8096 (proxied via Caddy)."

--- a/jellyfin-24-04/files/opt/start-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/start-jellyfin.sh
@@ -1,25 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
-# shellcheck source=/dev/null
-source /opt/jellyfin.env
-
-IMAGE="${JELLYFIN_IMAGE:-jellyfin/jellyfin:${JELLYFIN_VERSION}}"
-
-if docker ps -a --format '{{.Names}}' | grep -qx jellyfin; then
-    echo "Starting existing Jellyfin container..."
-    docker start jellyfin
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print $1}')}"
+if [ -n "$myip" ]; then
+  access_url="https://${myip}"
 else
-    echo "Creating Jellyfin container from ${IMAGE}..."
-    mkdir -p /var/lib/jellyfin/config /var/lib/jellyfin/cache /var/lib/jellyfin/media
-    docker run -d \
-      --name jellyfin \
-      --restart unless-stopped \
-      -p 127.0.0.1:8096:8096 \
-      -v /var/lib/jellyfin/config:/config \
-      -v /var/lib/jellyfin/cache:/cache \
-      -v /var/lib/jellyfin/media:/media \
-      "${IMAGE}"
+  access_url="https://<your-droplet-ip>"
 fi
 
-echo "Jellyfin is running on 127.0.0.1:8096 (proxied via Caddy)."
+echo "Starting Jellyfin via systemd..."
+systemctl start jellyfin
+
+sleep 1
+if systemctl is-active --quiet jellyfin; then
+    echo "Jellyfin started successfully."
+    if [ -f /var/lib/digitalocean/jellyfin_access_claimed ]; then
+        echo "Access via ${access_url}"
+    else
+        echo "HTTPS is not public yet. SSH claim runs /opt/claim-jellyfin-access.sh on first login."
+    fi
+else
+    echo "Error: Failed to start Jellyfin"
+    echo "Check logs with: journalctl -u jellyfin -xe"
+    exit 1
+fi

--- a/jellyfin-24-04/files/opt/status-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/status-jellyfin.sh
@@ -3,6 +3,11 @@
 pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
   http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
 myip="${pub:-$(hostname -I | awk '{print $1}')}"
+if [ -n "$myip" ]; then
+  access_url="https://${myip}"
+else
+  access_url="https://<your-droplet-ip>"
+fi
 
 echo "=== Jellyfin systemd status ==="
 systemctl status jellyfin --no-pager || true
@@ -13,6 +18,9 @@ docker ps -a --filter name=^jellyfin$ --format 'table {{.Names}}\t{{.Status}}\t{
 
 echo ""
 echo "=== Version ==="
+# shellcheck source=/dev/null
+. /var/lib/digitalocean/application.info 2>/dev/null || true
+echo "Image tag (application.info): ${application_version:-unknown}"
 if [ -f /opt/jellyfin.env ]; then
     # shellcheck source=/dev/null
     source /opt/jellyfin.env
@@ -21,5 +29,5 @@ fi
 
 echo ""
 echo "=== Access URL ==="
-echo "https://${myip} (proxied via Caddy with TLS)"
+echo "${access_url} (proxied via Caddy with TLS)"
 echo "http://127.0.0.1:8096 (localhost only — not publicly exposed)"

--- a/jellyfin-24-04/files/opt/status-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/status-jellyfin.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print $1}')}"
+
+echo "=== Jellyfin systemd status ==="
+systemctl status jellyfin --no-pager || true
+
+echo ""
+echo "=== Jellyfin container ==="
+docker ps -a --filter name=^jellyfin$ --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}' || true
+
+echo ""
+echo "=== Version ==="
+if [ -f /opt/jellyfin.env ]; then
+    # shellcheck source=/dev/null
+    source /opt/jellyfin.env
+    echo "Configured image: ${JELLYFIN_IMAGE:-jellyfin/jellyfin:${JELLYFIN_VERSION}}"
+fi
+
+echo ""
+echo "=== Access URL ==="
+echo "https://${myip} (proxied via Caddy with TLS)"
+echo "http://127.0.0.1:8096 (localhost only — not publicly exposed)"

--- a/jellyfin-24-04/files/opt/status-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/status-jellyfin.sh
@@ -13,6 +13,10 @@ echo "=== Jellyfin systemd status ==="
 systemctl status jellyfin --no-pager || true
 
 echo ""
+echo "=== Caddy systemd status ==="
+systemctl status caddy --no-pager || true
+
+echo ""
 echo "=== Jellyfin container ==="
 docker ps -a --filter name=^jellyfin$ --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}' || true
 
@@ -25,9 +29,15 @@ if [ -f /opt/jellyfin.env ]; then
     # shellcheck source=/dev/null
     source /opt/jellyfin.env
     echo "Configured image: ${JELLYFIN_IMAGE:-jellyfin/jellyfin:${JELLYFIN_VERSION}}"
+    echo "PublishedServerUrl: ${JELLYFIN_PUBLISHED_SERVER_URL:-unset}"
 fi
 
 echo ""
-echo "=== Access URL ==="
-echo "${access_url} (proxied via Caddy with TLS)"
+echo "=== Access ==="
+if [ -f /var/lib/digitalocean/jellyfin_access_claimed ]; then
+    echo "HTTPS claim: unlocked"
+    echo "${access_url} (proxied via Caddy with TLS)"
+else
+    echo "HTTPS claim: locked (run /opt/claim-jellyfin-access.sh or SSH in once)"
+fi
 echo "http://127.0.0.1:8096 (localhost only — not publicly exposed)"

--- a/jellyfin-24-04/files/opt/stop-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/stop-jellyfin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "Stopping Jellyfin..."
-docker stop jellyfin 2>/dev/null || true
+echo "Stopping Jellyfin via systemd..."
+systemctl stop jellyfin
 echo "Jellyfin stopped."

--- a/jellyfin-24-04/files/opt/stop-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/stop-jellyfin.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Stopping Jellyfin..."
+docker stop jellyfin 2>/dev/null || true
+echo "Jellyfin stopped."

--- a/jellyfin-24-04/files/opt/update-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/update-jellyfin.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source /opt/jellyfin.env
+
+CURRENT_VERSION="${JELLYFIN_VERSION:-unknown}"
+TARGET_VERSION="${1:-}"
+
+if [ -z "${TARGET_VERSION}" ]; then
+    echo "Current version: ${CURRENT_VERSION}"
+    echo "Usage: $0 <version>"
+    echo "Example: $0 10.11.11"
+    echo ""
+    read -rp "Enter Jellyfin version to install (or leave blank to cancel): " TARGET_VERSION
+    if [ -z "${TARGET_VERSION}" ]; then
+        echo "Update cancelled."
+        exit 0
+    fi
+fi
+
+IMAGE="jellyfin/jellyfin:${TARGET_VERSION}"
+
+echo "Updating Jellyfin from ${CURRENT_VERSION} to ${TARGET_VERSION}..."
+
+echo "Pulling ${IMAGE}..."
+docker pull "${IMAGE}"
+
+echo "Stopping existing container..."
+docker stop jellyfin 2>/dev/null || true
+docker rm jellyfin 2>/dev/null || true
+
+cat > /opt/jellyfin.env <<EOF
+JELLYFIN_VERSION=${TARGET_VERSION}
+JELLYFIN_IMAGE=${IMAGE}
+EOF
+
+echo "Starting Jellyfin ${TARGET_VERSION}..."
+/opt/start-jellyfin.sh
+
+sleep 2
+
+if docker ps --format '{{.Names}}' | grep -qx jellyfin; then
+    echo "Jellyfin updated successfully to ${TARGET_VERSION}."
+else
+    echo "Error: Failed to start Jellyfin after update"
+    echo "Check logs with: docker logs jellyfin"
+    exit 1
+fi

--- a/jellyfin-24-04/files/opt/update-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/update-jellyfin.sh
@@ -6,12 +6,23 @@ source /opt/jellyfin.env
 
 CURRENT_VERSION="${JELLYFIN_VERSION:-unknown}"
 TARGET_VERSION="${1:-}"
+PUBLISHED_URL="${JELLYFIN_PUBLISHED_SERVER_URL:-}"
 
 if [ -z "${TARGET_VERSION}" ]; then
     echo "Current version: ${CURRENT_VERSION}"
     echo "Usage: $0 <version>"
     echo "Example: $0 10.11.11"
     exit 1
+fi
+
+# Keep PublishedServerUrl across updates; if missing, derive like 001_onboot
+if [ -z "${PUBLISHED_URL}" ]; then
+    pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+      http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+    myip="${pub:-$(hostname -I | awk '{print $1}')}"
+    if [ -n "${myip}" ]; then
+        PUBLISHED_URL="https://${myip}"
+    fi
 fi
 
 IMAGE="jellyfin/jellyfin:${TARGET_VERSION}"
@@ -21,21 +32,25 @@ echo "Updating Jellyfin from ${CURRENT_VERSION} to ${TARGET_VERSION}..."
 echo "Pulling ${IMAGE}..."
 docker pull "${IMAGE}"
 
-echo "Stopping existing container..."
-docker stop jellyfin 2>/dev/null || true
-docker rm jellyfin 2>/dev/null || true
+echo "Stopping Jellyfin via systemd..."
+systemctl stop jellyfin 2>/dev/null || true
 
-cat > /opt/jellyfin.env <<EOF
-JELLYFIN_VERSION=${TARGET_VERSION}
-JELLYFIN_IMAGE=${IMAGE}
-EOF
+{
+    echo "JELLYFIN_VERSION=${TARGET_VERSION}"
+    echo "JELLYFIN_IMAGE=${IMAGE}"
+    if [ -n "${PUBLISHED_URL}" ]; then
+        echo "JELLYFIN_PUBLISHED_SERVER_URL=${PUBLISHED_URL}"
+    else
+        echo "WARNING: JELLYFIN_PUBLISHED_SERVER_URL unset; container will start without it." >&2
+    fi
+} > /opt/jellyfin.env
 
-echo "Starting Jellyfin ${TARGET_VERSION}..."
-/opt/start-jellyfin.sh
+echo "Starting Jellyfin ${TARGET_VERSION} via systemd..."
+systemctl start jellyfin
 
 sleep 2
 
-if docker ps --format '{{.Names}}' | grep -qx jellyfin; then
+if systemctl is-active --quiet jellyfin && docker ps --format '{{.Names}}' | grep -qx jellyfin; then
     if [ -f /var/lib/digitalocean/application.info ]; then
         if grep -q '^application_version=' /var/lib/digitalocean/application.info; then
             sed -i "s/^application_version=.*/application_version=\"${TARGET_VERSION}\"/" \
@@ -45,8 +60,12 @@ if docker ps --format '{{.Names}}' | grep -qx jellyfin; then
         fi
     fi
     echo "Jellyfin updated successfully to ${TARGET_VERSION}."
+    if [ -n "${PUBLISHED_URL}" ]; then
+        echo "PublishedServerUrl: ${PUBLISHED_URL}"
+    fi
 else
     echo "Error: Failed to start Jellyfin after update"
-    echo "Check logs with: docker logs jellyfin"
+    echo "Check logs with: journalctl -u jellyfin -xe"
+    echo "Container logs: docker logs jellyfin"
     exit 1
 fi

--- a/jellyfin-24-04/files/opt/update-jellyfin.sh
+++ b/jellyfin-24-04/files/opt/update-jellyfin.sh
@@ -11,12 +11,7 @@ if [ -z "${TARGET_VERSION}" ]; then
     echo "Current version: ${CURRENT_VERSION}"
     echo "Usage: $0 <version>"
     echo "Example: $0 10.11.11"
-    echo ""
-    read -rp "Enter Jellyfin version to install (or leave blank to cancel): " TARGET_VERSION
-    if [ -z "${TARGET_VERSION}" ]; then
-        echo "Update cancelled."
-        exit 0
-    fi
+    exit 1
 fi
 
 IMAGE="jellyfin/jellyfin:${TARGET_VERSION}"
@@ -41,6 +36,14 @@ echo "Starting Jellyfin ${TARGET_VERSION}..."
 sleep 2
 
 if docker ps --format '{{.Names}}' | grep -qx jellyfin; then
+    if [ -f /var/lib/digitalocean/application.info ]; then
+        if grep -q '^application_version=' /var/lib/digitalocean/application.info; then
+            sed -i "s/^application_version=.*/application_version=\"${TARGET_VERSION}\"/" \
+                /var/lib/digitalocean/application.info
+        else
+            echo "application_version=\"${TARGET_VERSION}\"" >> /var/lib/digitalocean/application.info
+        fi
+    fi
     echo "Jellyfin updated successfully to ${TARGET_VERSION}."
 else
     echo "Error: Failed to start Jellyfin after update"

--- a/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh

--- a/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,4 +1,14 @@
-#!/bin/sh
+#!/bin/bash
+
+# Configure Caddy with this droplet's public IP for HTTPS access
+meta() { curl -fsS --retry 10 --retry-connrefused --max-time 2 "$1"; }
+DROPLET_PUBLIC_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+DROPLET_PRIVATE_IP="$(hostname -I | awk '{print $1}')"
+DROPLET_IP="${DROPLET_PUBLIC_IP:-$DROPLET_PRIVATE_IP}"
+
+if [ -f /etc/caddy/Caddyfile.tmp ]; then
+    sed "s/PLACEHOLDER_DOMAIN/${DROPLET_IP}/" /etc/caddy/Caddyfile.tmp > /etc/caddy/Caddyfile
+fi
 
 # Remove the ssh force logout command
 sed -e '/Match User root/d' \
@@ -6,3 +16,14 @@ sed -e '/Match User root/d' \
     -i /etc/ssh/sshd_config
 
 systemctl restart ssh
+
+systemctl enable docker
+systemctl start docker
+
+# Create/start Jellyfin on first boot so config is unique to this droplet
+systemctl enable jellyfin
+systemctl start jellyfin
+
+# Enable Caddy only after the Jellyfin Caddyfile is in place
+systemctl enable caddy
+systemctl restart caddy

--- a/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -euo pipefail
+
+# Remove the ssh force logout command first so SSH is not left locked if later steps fail
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh
 
 # Configure Caddy with this droplet's public IP for HTTPS access
 meta() { curl -fsS --retry 10 --retry-connrefused --max-time 2 "$1"; }
@@ -6,16 +14,17 @@ DROPLET_PUBLIC_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0
 DROPLET_PRIVATE_IP="$(hostname -I | awk '{print $1}')"
 DROPLET_IP="${DROPLET_PUBLIC_IP:-$DROPLET_PRIVATE_IP}"
 
-if [ -f /etc/caddy/Caddyfile.tmp ]; then
-    sed "s/PLACEHOLDER_DOMAIN/${DROPLET_IP}/" /etc/caddy/Caddyfile.tmp > /etc/caddy/Caddyfile
+if [ -z "${DROPLET_IP}" ]; then
+    echo "ERROR: Unable to determine droplet IP; cannot configure Caddy." >&2
+    exit 1
 fi
 
-# Remove the ssh force logout command
-sed -e '/Match User root/d' \
-    -e '/.*ForceCommand.*droplet.*/d' \
-    -i /etc/ssh/sshd_config
+if [ ! -f /etc/caddy/Caddyfile.tmp ]; then
+    echo "ERROR: Missing /etc/caddy/Caddyfile.tmp; cannot configure Caddy." >&2
+    exit 1
+fi
 
-systemctl restart ssh
+sed "s/PLACEHOLDER_DOMAIN/${DROPLET_IP}/" /etc/caddy/Caddyfile.tmp > /etc/caddy/Caddyfile
 
 systemctl enable docker
 systemctl start docker

--- a/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/jellyfin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -8,7 +8,7 @@ sed -e '/Match User root/d' \
 
 systemctl restart ssh
 
-# Configure Caddy with this droplet's public IP for HTTPS access
+# Configure Caddy with this droplet's public IP for HTTPS access (enabled on first SSH claim)
 meta() { curl -fsS --retry 10 --retry-connrefused --max-time 2 "$1"; }
 DROPLET_PUBLIC_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
 DROPLET_PRIVATE_IP="$(hostname -I | awk '{print $1}')"
@@ -26,13 +26,30 @@ fi
 
 sed "s/PLACEHOLDER_DOMAIN/${DROPLET_IP}/" /etc/caddy/Caddyfile.tmp > /etc/caddy/Caddyfile
 
+# Publish the HTTPS URL Jellyfin should advertise behind Caddy
+if [ -f /opt/jellyfin.env ]; then
+    if grep -q '^JELLYFIN_PUBLISHED_SERVER_URL=' /opt/jellyfin.env; then
+        sed -i "s|^JELLYFIN_PUBLISHED_SERVER_URL=.*|JELLYFIN_PUBLISHED_SERVER_URL=https://${DROPLET_IP}|" /opt/jellyfin.env
+    else
+        echo "JELLYFIN_PUBLISHED_SERVER_URL=https://${DROPLET_IP}" >> /opt/jellyfin.env
+    fi
+fi
+
 systemctl enable docker
 systemctl start docker
 
-# Create/start Jellyfin on first boot so config is unique to this droplet
+# Create/start Jellyfin on first boot (localhost only). Keep Caddy off until first SSH claim.
 systemctl enable jellyfin
 systemctl start jellyfin
 
-# Enable Caddy only after the Jellyfin Caddyfile is in place
-systemctl enable caddy
-systemctl restart caddy
+# Ensure Caddy stays disabled until /opt/claim-jellyfin-access.sh runs on first SSH
+systemctl disable --now caddy || true
+
+# First-login hook: unlock public HTTPS after the droplet owner SSHs in
+# Two-line form (OpenClaw/Coolify) so sed '/claim-jellyfin-access\.sh/d' removes the whole hook
+if ! grep -q 'claim-jellyfin-access.sh' /root/.bashrc 2>/dev/null; then
+    cat >> /root/.bashrc <<'EOM'
+chmod +x /opt/claim-jellyfin-access.sh
+/opt/claim-jellyfin-access.sh
+EOM
+fi

--- a/jellyfin-24-04/listing.md
+++ b/jellyfin-24-04/listing.md
@@ -24,8 +24,10 @@ Deploy [Jellyfin](https://jellyfin.org), a free and open-source media system tha
 ## Getting Started
 
 1. **Create a Droplet** from this 1-Click image (use at least **2 GB RAM**).
-2. **Open Jellyfin** at `https://your-droplet-ip` and finish the setup wizard right away to create your admin account.
+2. **Open Jellyfin** at `https://your-droplet-ip` and finish the setup wizard **immediately** to create your admin account.
 3. **Add media** by uploading or mounting files under `/var/lib/jellyfin/media`, then configure libraries in the Jellyfin UI.
+
+**Security note:** Until the setup wizard is completed, anyone who can reach your Droplet URL can claim the admin account. The first person to finish the wizard gets full administrative access.
 
 Jellyfin listens on `127.0.0.1:8096` only. Public access is through Caddy on ports 80/443.
 

--- a/jellyfin-24-04/listing.md
+++ b/jellyfin-24-04/listing.md
@@ -24,12 +24,13 @@ Deploy [Jellyfin](https://jellyfin.org), a free and open-source media system tha
 ## Getting Started
 
 1. **Create a Droplet** from this 1-Click image (use at least **2 GB RAM**).
-2. **Open Jellyfin** at `https://your-droplet-ip` and finish the setup wizard **immediately** to create your admin account.
-3. **Add media** by uploading or mounting files under `/var/lib/jellyfin/media`, then configure libraries in the Jellyfin UI.
+2. **SSH in once** — first login runs `/opt/claim-jellyfin-access.sh`, which enables Caddy and unlocks HTTPS. Until then, the setup wizard is not publicly reachable.
+3. **Open Jellyfin** at `https://your-droplet-ip` and finish the setup wizard **immediately** to create your admin account.
+4. **Add media** by uploading or mounting files under `/var/lib/jellyfin/media`, then configure libraries in the Jellyfin UI.
 
-**Security note:** Until the setup wizard is completed, anyone who can reach your Droplet URL can claim the admin account. The first person to finish the wizard gets full administrative access.
+**Security note:** Public HTTPS stays disabled until the first SSH claim. After claim, complete the setup wizard right away — the first person to finish it gets full administrative access.
 
-Jellyfin listens on `127.0.0.1:8096` only. Public access is through Caddy on ports 80/443.
+Jellyfin listens on `127.0.0.1:8096` only. Public access is through Caddy on ports 80/443 after claim.
 
 ### Custom Domain (Recommended)
 
@@ -55,11 +56,14 @@ systemctl status jellyfin
 
 ### Helper scripts
 
+Helpers wrap `systemctl` so unit state stays consistent:
+
 ```bash
 /opt/start-jellyfin.sh
 /opt/stop-jellyfin.sh
 /opt/restart-jellyfin.sh
 /opt/status-jellyfin.sh
+/opt/claim-jellyfin-access.sh
 sudo /opt/update-jellyfin.sh 10.11.11
 ```
 

--- a/jellyfin-24-04/listing.md
+++ b/jellyfin-24-04/listing.md
@@ -1,0 +1,84 @@
+# Jellyfin 1-Click Application
+
+Deploy [Jellyfin](https://jellyfin.org), a free and open-source media system that lets you manage and stream your media library from your own server.
+
+## System Components
+
+| Component | Details |
+|-----------|---------|
+| Ubuntu | 24.04 LTS |
+| Docker | Container runtime (`docker.io`) |
+| Jellyfin | `jellyfin/jellyfin:10.11.11` |
+| Caddy | Reverse proxy with automatic Let's Encrypt TLS |
+| UFW | Firewall (SSH 22, HTTP 80, HTTPS 443) |
+
+## System Requirements
+
+**Minimum Droplet size: `s-1vcpu-2gb` (2 GB RAM).** Jellyfin's media transcoding benefits from additional CPU and memory for larger libraries or concurrent streams.
+
+| Use case | Recommended |
+|----------|-------------|
+| Light / small library | 2 GB RAM, 1 vCPU |
+| Multiple streams / transcoding | 4 GB+ RAM, 2+ vCPU |
+
+## Getting Started
+
+1. **Create a Droplet** from this 1-Click image (use at least **2 GB RAM**).
+2. **Open Jellyfin** at `https://your-droplet-ip` and finish the setup wizard right away to create your admin account.
+3. **Add media** by uploading or mounting files under `/var/lib/jellyfin/media`, then configure libraries in the Jellyfin UI.
+
+Jellyfin listens on `127.0.0.1:8096` only. Public access is through Caddy on ports 80/443.
+
+### Custom Domain (Recommended)
+
+1. Create a DNS A record pointing your domain to the Droplet IP.
+2. SSH in and run:
+
+```bash
+sudo /opt/setup-jellyfin-domain.sh
+```
+
+3. Visit `https://your-domain` — Caddy obtains a Let's Encrypt certificate automatically.
+
+## Managing Jellyfin
+
+### systemd
+
+```bash
+systemctl start jellyfin
+systemctl stop jellyfin
+systemctl restart jellyfin
+systemctl status jellyfin
+```
+
+### Helper scripts
+
+```bash
+/opt/start-jellyfin.sh
+/opt/stop-jellyfin.sh
+/opt/restart-jellyfin.sh
+/opt/status-jellyfin.sh
+sudo /opt/update-jellyfin.sh 10.11.11
+```
+
+### Update
+
+```bash
+sudo /opt/update-jellyfin.sh <version>
+```
+
+This pulls the requested `jellyfin/jellyfin` image tag, recreates the container, and keeps data under `/var/lib/jellyfin`.
+
+## Data Locations
+
+| Path | Purpose |
+|------|---------|
+| `/var/lib/jellyfin/config` | Server configuration |
+| `/var/lib/jellyfin/cache` | Transcoding / metadata cache |
+| `/var/lib/jellyfin/media` | Suggested media library root |
+
+## Support
+
+- [Jellyfin Documentation](https://jellyfin.org/docs/)
+- [Jellyfin Docker Hub](https://hub.docker.com/r/jellyfin/jellyfin)
+- [DigitalOcean Community](https://www.digitalocean.com/community)

--- a/jellyfin-24-04/scripts/01-setup.sh
+++ b/jellyfin-24-04/scripts/01-setup.sh
@@ -1,34 +1,49 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-export DEBIAN_FRONTEND=noninteractive
+APP_VERSION="${application_version:?application_version must be set}"
 
-echo "==> Updating system packages..."
-apt-get update && apt-get upgrade -y
+echo "==> Enabling Docker..."
+systemctl enable docker
+systemctl start docker
 
-echo "==> Installing prerequisites..."
-apt-get install -y curl gnupg apt-transport-https
+echo "==> Installing Caddy..."
+curl -1sLf "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" > /etc/apt/sources.list.d/caddy-stable.list
+apt-get update -y
+apt-get install -y caddy
 
-echo "==> Downloading and verifying official Jellyfin installer..."
-cd /tmp
-curl -s https://repo.jellyfin.org/install-debuntu.sh -O
-curl -s https://repo.jellyfin.org/install-debuntu.sh.sha256sum -O
+mkdir -p /var/log/caddy
+chown -R caddy:caddy /var/log/caddy
+touch /var/log/caddy/access.json
+chown caddy:caddy /var/log/caddy/access.json
 
-# Validate checksum before running
-sha256sum -c install-debuntu.sh.sha256sum
+# Defer Caddy until 001_onboot writes the Jellyfin Caddyfile (avoid stock config).
+systemctl disable --now caddy || true
 
-echo "==> Executing Jellyfin installation script..."
-bash install-debuntu.sh
+echo "==> Preparing Jellyfin data directories..."
+mkdir -p /var/lib/jellyfin/config /var/lib/jellyfin/cache /var/lib/jellyfin/media
 
-echo "==> Ensuring Jellyfin starts on boot..."
+cat > /opt/jellyfin.env <<EOF
+JELLYFIN_VERSION=${APP_VERSION}
+JELLYFIN_IMAGE=jellyfin/jellyfin:${APP_VERSION}
+EOF
+chmod 644 /opt/jellyfin.env
+
+echo "==> Pulling Jellyfin ${APP_VERSION} (start deferred to first boot)..."
+docker pull "jellyfin/jellyfin:${APP_VERSION}"
+
+echo "==> Setting script permissions..."
+chmod +x /opt/start-jellyfin.sh
+chmod +x /opt/stop-jellyfin.sh
+chmod +x /opt/restart-jellyfin.sh
+chmod +x /opt/status-jellyfin.sh
+chmod +x /opt/update-jellyfin.sh
+chmod +x /opt/setup-jellyfin-domain.sh
+chmod +x /etc/update-motd.d/99-one-click
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+
+echo "==> Registering Jellyfin unit (enabled/started on first boot)..."
 systemctl daemon-reload
-systemctl enable jellyfin
-systemctl start jellyfin
 
-echo "==> Opening Jellyfin web UI port in UFW..."
-ufw allow 8096/tcp
-
-echo "==> Cleaning up build history..."
-rm -f /tmp/install-debuntu.sh*
-apt-get autoremove -y
-apt-get clean
+echo "==> Jellyfin setup complete."

--- a/jellyfin-24-04/scripts/01-setup.sh
+++ b/jellyfin-24-04/scripts/01-setup.sh
@@ -18,7 +18,7 @@ chown -R caddy:caddy /var/log/caddy
 touch /var/log/caddy/access.json
 chown caddy:caddy /var/log/caddy/access.json
 
-# Defer Caddy until 001_onboot writes the Jellyfin Caddyfile (avoid stock config).
+# Defer Caddy until first-SSH claim (after onboot writes the Jellyfin Caddyfile).
 systemctl disable --now caddy || true
 
 echo "==> Preparing Jellyfin data directories..."
@@ -34,6 +34,8 @@ echo "==> Pulling Jellyfin ${APP_VERSION} (start deferred to first boot)..."
 docker pull "jellyfin/jellyfin:${APP_VERSION}"
 
 echo "==> Setting script permissions..."
+chmod +x /opt/jellyfin-docker.sh
+chmod +x /opt/claim-jellyfin-access.sh
 chmod +x /opt/start-jellyfin.sh
 chmod +x /opt/stop-jellyfin.sh
 chmod +x /opt/restart-jellyfin.sh

--- a/jellyfin-24-04/scripts/01-setup.sh
+++ b/jellyfin-24-04/scripts/01-setup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "==> Updating system packages..."
+apt-get update && apt-get upgrade -y
+
+echo "==> Installing prerequisites..."
+apt-get install -y curl gnupg apt-transport-https
+
+echo "==> Downloading and verifying official Jellyfin installer..."
+cd /tmp
+curl -s https://repo.jellyfin.org/install-debuntu.sh -O
+curl -s https://repo.jellyfin.org/install-debuntu.sh.sha256sum -O
+
+# Validate checksum before running
+sha256sum -c install-debuntu.sh.sha256sum
+
+echo "==> Executing Jellyfin installation script..."
+bash install-debuntu.sh
+
+echo "==> Ensuring Jellyfin starts on boot..."
+systemctl daemon-reload
+systemctl enable jellyfin
+systemctl start jellyfin
+
+echo "==> Opening Jellyfin web UI port in UFW..."
+ufw allow 8096/tcp
+
+echo "==> Cleaning up build history..."
+rm -f /tmp/install-debuntu.sh*
+apt-get autoremove -y
+apt-get clean

--- a/jellyfin-24-04/template.json
+++ b/jellyfin-24-04/template.json
@@ -1,11 +1,10 @@
-
 {
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "jellyfin-24-04-snapshot-{{timestamp}}",
     "application_name": "Jellyfin",
-    "application_version": "10.11.x",
-    "apt_packages": "curl gnupg apt-transport-https"
+    "application_version": "10.11.11",
+    "apt_packages": "apt-transport-https ca-certificates curl software-properties-common jq unzip docker.io gnupg"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -14,7 +13,7 @@
       "api_token": "{{user `do_api_token`}}",
       "image": "ubuntu-24-04-x64",
       "region": "nyc3",
-      "size": "s-1vcpu-1gb",
+      "size": "s-1vcpu-2gb",
       "ssh_username": "root",
       "snapshot_name": "{{user `image_name`}}"
     }
@@ -40,6 +39,11 @@
       "type": "file",
       "source": "jellyfin-24-04/files/var/",
       "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "jellyfin-24-04/files/opt/",
+      "destination": "/opt/"
     },
     {
       "type": "shell",

--- a/jellyfin-24-04/template.json
+++ b/jellyfin-24-04/template.json
@@ -1,0 +1,78 @@
+
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "jellyfin-24-04-snapshot-{{timestamp}}",
+    "application_name": "Jellyfin",
+    "application_version": "10.11.x",
+    "apt_packages": "curl gnupg apt-transport-https"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "jellyfin-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "jellyfin-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "jellyfin-24-04/scripts/01-setup.sh",
+        "common/scripts/014-ufw-http.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Ubuntu 24.04 Jellyfin Marketplace 1-Click: Dockerized Jellyfin `10.11.11` behind Caddy with Let's Encrypt TLS
- Packer install pulls the image and prepares dirs; first boot (`001_onboot`) unlocks SSH, writes the Caddyfile with the droplet IP, then starts Jellyfin + Caddy
- Include systemd unit, `/opt` helpers (start/stop/restart/status/update/domain), MOTD, README, and marketplace `listing.md`

## Test plan
- [ ] `make validate-jellyfin-24-04` / Packer build succeeds
- [ ] New droplet: `https://<ip>` reaches Jellyfin setup wizard
- [ ] Port 8096 not publicly reachable
- [ ] `systemctl status jellyfin` and `systemctl status caddy` are active
- [ ] MOTD shows HTTPS URL and helper commands
- [ ] `sudo /opt/setup-jellyfin-domain.sh` configures custom-domain TLS

##Link
https://do-internal.atlassian.net/browse/MP-8458

