### PR TITLE
MP-8474 Create OpenHands Droplet 1-Click

### DIFF
--- a/openhands-24-04/README.md
+++ b/openhands-24-04/README.md
@@ -1,0 +1,92 @@
+# OpenHands 1-Click Droplet Builder
+
+This directory contains the Packer builder configuration for creating an OpenHands (Agent Canvas) 1-Click DigitalOcean Droplet image.
+
+## Overview
+
+[OpenHands](https://www.openhands.dev/) Agent Canvas is an open-source, self-hosted control center for AI coding agents and automations. This builder creates an Ubuntu 24.04 LTS Droplet with Agent Canvas pre-installed, running in public mode behind Caddy, with optional DigitalOcean Gradient AI configuration.
+
+## Directory Structure
+
+```
+openhands-24-04/
+├── template.json                    # Packer build configuration
+├── README.md                        # This file
+├── listing.md                       # Marketplace catalog copy
+├── scripts/
+│   └── 010-openhands.sh             # Main installation script
+└── files/
+    ├── etc/
+    │   ├── caddy/Caddyfile.tmp      # Shortlived TLS reverse proxy to :8000
+    │   ├── setup_wizard.sh          # First-login wizard (API key + Gradient)
+    │   ├── systemd/system/openhands.service
+    │   ├── systemd/system/openhands-apply-gradient.service
+    │   └── update-motd.d/99-one-click
+    ├── opt/
+    │   ├── openhands.env            # Secrets + optional GRADIENT_* vars
+    │   ├── apply-gradient-from-env.sh
+    │   ├── retry-apply-gradient-after-cloud-init.sh
+    │   ├── start-openhands.sh
+    │   ├── stop-openhands.sh
+    │   ├── restart-openhands.sh
+    │   ├── status-openhands.sh
+    │   ├── update-openhands.sh
+    │   └── setup-openhands-domain.sh
+    └── var/lib/cloud/scripts/per-instance/001_onboot
+```
+
+## Build Requirements
+
+1. **Packer**: https://www.packer.io/downloads
+2. **DigitalOcean API Token** with write access
+
+```bash
+export DIGITALOCEAN_API_TOKEN="your_api_token_here"
+```
+
+## Building the Image
+
+```bash
+# From the droplet-1-clicks repo root (after installing the DigitalOcean Packer plugin; see root README)
+packer validate openhands-24-04/template.json
+make build-openhands-24-04
+```
+
+## What Gets Installed
+
+- **OpenHands Agent Canvas** (`@openhands/agent-canvas`, version from `application_version` in `template.json`)
+- **Node.js 22** and **uv** (agent-server / automation via uvx)
+- **Caddy** – reverse proxy on ports 80/443 to `127.0.0.1:8000` with shortlived TLS by IP
+- **UFW** – SSH (rate-limited), HTTP, HTTPS
+- **fail2ban**
+- Dedicated **`openhands`** user and `/home/openhands/projects` workspace
+
+## First Boot Behavior
+
+1. Removes SSH force-logout
+2. Generates unique `LOCAL_BACKEND_API_KEY` and `OH_SECRET_KEY`
+3. Installs Caddyfile (shortlived TLS for droplet IP) and starts `openhands` + `caddy`
+4. If `GRADIENT_KEY` is set (droplet env or `/opt/openhands.env`), configures Gradient and skips the provider wizard
+5. Otherwise hooks `/etc/setup_wizard.sh` into root `.bashrc` for first login
+6. Writes `/root/openhands_info.txt`
+
+## First Login / Access
+
+1. Open `https://<droplet-ip>` and paste `LOCAL_BACKEND_API_KEY` from the MOTD or `/opt/openhands.env`
+2. If Gradient was not auto-configured, the SSH wizard can set a Gradient model access key
+3. Or configure any LLM under **Settings > LLM** in the UI (Advanced: custom model + base URL)
+
+### Auto-configuration from droplet environment
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GRADIENT_KEY` | Yes (for auto) | Gradient model access key |
+| `GRADIENT_MODEL` | No | Model id (default: `minimax-m2.5`) |
+
+## Version Pinning
+
+Edit `application_version` in `template.json` (Agent Canvas npm version), then rebuild.
+
+## License
+
+This builder configuration follows the same license as the droplet-1-clicks repository. OpenHands / Agent Canvas licensing is governed by the upstream project.

--- a/openhands-24-04/files/etc/caddy/Caddyfile.tmp
+++ b/openhands-24-04/files/etc/caddy/Caddyfile.tmp
@@ -1,0 +1,10 @@
+PLACEHOLDER_DOMAIN {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+    reverse_proxy localhost:8000
+    header X-DO-MARKETPLACE "openhands"
+}

--- a/openhands-24-04/files/etc/setup_wizard.sh
+++ b/openhands-24-04/files/etc/setup_wizard.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# OpenHands first-login setup wizard — API key reminder + optional Gradient config
+
+set -euo pipefail
+
+SETUP_DONE_MARKER=/home/openhands/.openhands/provider-configured
+ENV_FILE=/opt/openhands.env
+
+remove_first_login_hook() {
+  if [ -f /root/.bashrc ]; then
+    sed -i '/chmod +x \/etc\/setup_wizard\.sh/d' /root/.bashrc
+    sed -i '/\/etc\/setup_wizard\.sh/d' /root/.bashrc
+  fi
+}
+
+env_value_usable() {
+  local v="$1"
+  [ -n "$v" ] || return 1
+  case "$v" in
+    *'${'*|PLACEHOLDER*|your_*_here) return 1 ;;
+  esac
+  return 0
+}
+
+read_api_key() {
+  local line val
+  line=$(grep -E '^LOCAL_BACKEND_API_KEY=' "$ENV_FILE" 2>/dev/null | tail -n 1) || return 1
+  val="${line#LOCAL_BACKEND_API_KEY=}"
+  val="${val#\"}"; val="${val%\"}"; val="${val#\'}"; val="${val%\'}"
+  printf '%s' "$val"
+}
+
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print $1}')}"
+API_KEY="$(read_api_key || true)"
+
+cat <<EOF
+
+========================================================================
+  OpenHands (Agent Canvas) first-login setup
+========================================================================
+
+Web UI:  https://${myip}
+API Key: ${API_KEY:-"(see /opt/openhands.env or /home/openhands/.openhands/api-key.txt)"}
+
+Paste the API key when the browser prompts for it.
+
+Docs: https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/vm
+EOF
+
+if [ -f "$SETUP_DONE_MARKER" ] && [ "${1:-}" != "--force" ]; then
+  echo ""
+  echo "LLM provider already configured. Skipping Gradient wizard."
+  echo "Re-run with --force to configure again: /etc/setup_wizard.sh --force"
+  remove_first_login_hook
+  exit 0
+fi
+
+if [ "${1:-}" != "--force" ] && [ -x /opt/apply-gradient-from-env.sh ] && /opt/apply-gradient-from-env.sh; then
+  echo ""
+  echo "DigitalOcean Gradient configured from droplet environment."
+  remove_first_login_hook
+  exit 0
+fi
+
+cat <<'EOF'
+
+------------------------------------------------------------------------
+  Optional: DigitalOcean Gradient AI
+------------------------------------------------------------------------
+
+Configure Gradient so OpenHands can call models via a single model access key.
+Create a key at: https://cloud.digitalocean.com/gen-ai
+  (API Keys > Model Access Keys)
+
+Examples: minimax-m2.5 (default), kimi-k2.5, glm-5, llama3.3-70b-instruct
+
+You can also skip and set any provider later in Settings > LLM.
+
+EOF
+
+read -r -p "Enter your Gradient model access key (or press Enter to skip): " MODEL_KEY
+
+if [ -z "$MODEL_KEY" ]; then
+  echo ""
+  echo "Skipped Gradient setup. Configure LLM in the web UI (Settings > LLM),"
+  echo "or re-run: /etc/setup_wizard.sh"
+  echo ""
+  remove_first_login_hook
+  exit 0
+fi
+
+read -r -p "Gradient model id [minimax-m2.5]: " MODEL_ID
+MODEL_ID="${MODEL_ID:-minimax-m2.5}"
+
+# Persist into env file, then apply (plain KEY=value for systemd EnvironmentFile)
+tmp="${ENV_FILE}.tmp"
+touch "$ENV_FILE"
+grep -v -E '^(GRADIENT_KEY|GRADIENT_MODEL)=' "$ENV_FILE" >"$tmp" 2>/dev/null || : >"$tmp"
+printf 'GRADIENT_KEY=%s\n' "$MODEL_KEY" >>"$tmp"
+printf 'GRADIENT_MODEL=%s\n' "$MODEL_ID" >>"$tmp"
+mv "$tmp" "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+export GRADIENT_KEY="$MODEL_KEY"
+export GRADIENT_MODEL="$MODEL_ID"
+
+echo ""
+echo "Testing connection to DigitalOcean Gradient..."
+HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer ${MODEL_KEY}" \
+  -H "Content-Type: application/json" \
+  https://inference.do-ai.run/v1/models 2>/dev/null || echo "000")
+
+if [ "$HTTP_STATUS" = "200" ]; then
+  echo "Connection successful! Your key is valid."
+else
+  echo "Warning: Received HTTP ${HTTP_STATUS} from the Gradient API."
+  echo "Saving anyway — re-run /etc/setup_wizard.sh --force if needed."
+fi
+
+/opt/apply-gradient-from-env.sh
+
+remove_first_login_hook
+
+cat <<EOF
+
+========================================================================
+  Setup complete!
+
+  Open:     https://${myip}
+  API Key:  ${API_KEY}
+  Model:    openai/${MODEL_ID} via DigitalOcean Gradient
+
+  Projects workspace: /home/openhands/projects
+========================================================================
+
+EOF

--- a/openhands-24-04/files/etc/systemd/system/openhands-apply-gradient.service
+++ b/openhands-24-04/files/etc/systemd/system/openhands-apply-gradient.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Apply OpenHands Gradient config after cloud-init user-data
+After=cloud-init.service
+ConditionPathExists=!/home/openhands/.openhands/provider-configured
+
+[Service]
+Type=oneshot
+ExecStart=/opt/retry-apply-gradient-after-cloud-init.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/openhands-24-04/files/etc/systemd/system/openhands.service
+++ b/openhands-24-04/files/etc/systemd/system/openhands.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=OpenHands Agent Canvas
+Documentation=https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/vm
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=openhands
+Group=openhands
+WorkingDirectory=/home/openhands
+EnvironmentFile=/opt/openhands.env
+Environment=HOME=/home/openhands
+Environment=PATH=/home/openhands/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=OH_PERSISTENCE_DIR=/home/openhands/.openhands
+
+# Public mode: UI prompts for LOCAL_BACKEND_API_KEY (required for internet-facing droplets)
+ExecStart=/usr/local/bin/agent-canvas --public
+
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/openhands-24-04/files/etc/update-motd.d/99-one-click
+++ b/openhands-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print$1}')}"
+api_key=$(grep "^LOCAL_BACKEND_API_KEY=" /opt/openhands.env 2>/dev/null | cut -d= -f2-)
+
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's One-Click OpenHands Droplet.
+
+OpenHands Agent Canvas is a self-hosted control center for AI coding agents
+and automations. Run agents on this droplet and connect from your browser.
+
+🌐 Access:
+  Web UI:  https://$myip
+  API Key: $api_key
+
+  Paste the API key when the UI prompts for it.
+  Key file: /home/openhands/.openhands/api-key.txt
+
+📝 First steps:
+  1. Open the Web UI and enter the API key
+  2. Configure an LLM (Settings > LLM), or complete the SSH setup wizard
+     for DigitalOcean Gradient
+  3. Put projects in /home/openhands/projects and start a conversation
+
+🔧 Management:
+  Restart:  /opt/restart-openhands.sh
+  Status:   /opt/status-openhands.sh
+  Update:   /opt/update-openhands.sh
+  Domain:   /opt/setup-openhands-domain.sh
+  Setup:    /etc/setup_wizard.sh
+
+  systemctl {start|stop|restart|status} openhands
+  journalctl -u openhands -f
+
+📚 Docs: https://docs.openhands.dev/
+🔗 Site: https://www.openhands.dev/
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/openhands-24-04/files/opt/apply-gradient-from-env.sh
+++ b/openhands-24-04/files/opt/apply-gradient-from-env.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Apply DigitalOcean Gradient from droplet env or /opt/openhands.env.
+# Returns 0 when a key was applied; 1 when skipped (empty or unset placeholder).
+set -euo pipefail
+
+ENV_FILE=/opt/openhands.env
+OPENHANDS_HOME=/home/openhands
+SETTINGS_FILE="${OPENHANDS_HOME}/.openhands/agent_settings.json"
+SETUP_DONE_MARKER="${OPENHANDS_HOME}/.openhands/provider-configured"
+GRADIENT_BASE_URL="https://inference.do-ai.run/v1"
+
+remove_setup_wizard_bashrc_hook() {
+  [ -f /root/.bashrc ] || return 0
+  sed -i \
+    -e '/chmod +x \/etc\/setup_wizard\.sh/d' \
+    -e '/\/etc\/setup_wizard\.sh/d' \
+    /root/.bashrc
+}
+
+env_value_usable() {
+  local v="$1"
+  [ -n "$v" ] || return 1
+  case "$v" in
+    *'${'*|PLACEHOLDER*|your_*_here) return 1 ;;
+  esac
+  return 0
+}
+
+read_file_kv() {
+  local file="$1" key="$2" line val
+  [ -f "$file" ] || return 1
+  line=$(grep -E "^${key}=" "$file" 2>/dev/null | tail -n 1) || return 1
+  val="${line#${key}=}"
+  val="${val#\"}"; val="${val%\"}"; val="${val#\'}"; val="${val%\'}"
+  printf '%s' "$val"
+}
+
+read_config_value() {
+  local key="$1" val
+  val="${!key-}"
+  if env_value_usable "$val"; then
+    printf '%s' "$val"
+    return 0
+  fi
+  val=$(read_file_kv /etc/environment "$key" || true)
+  if env_value_usable "$val"; then
+    printf '%s' "$val"
+    return 0
+  fi
+  read_file_kv "$ENV_FILE" "$key"
+}
+
+write_env_file_kv() {
+  local key="$1" val="$2" tmp="${ENV_FILE}.tmp"
+  touch "$ENV_FILE"
+  grep -v "^${key}=" "$ENV_FILE" >"$tmp" 2>/dev/null || : >"$tmp"
+  # Plain KEY=value for systemd EnvironmentFile (no shell %q escaping)
+  printf '%s=%s\n' "$key" "$val" >>"$tmp"
+  mv "$tmp" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+}
+
+normalize_model() {
+  local m="$1"
+  case "$m" in
+    openai/*) printf '%s' "$m" ;;
+    "") printf '%s' "openai/minimax-m2.5" ;;
+    *) printf 'openai/%s' "$m" ;;
+  esac
+}
+
+GRADIENT_KEY=$(read_config_value GRADIENT_KEY || true)
+GRADIENT_MODEL=$(read_config_value GRADIENT_MODEL || true)
+
+if ! env_value_usable "$GRADIENT_KEY"; then
+  exit 1
+fi
+
+if ! env_value_usable "$GRADIENT_MODEL"; then
+  GRADIENT_MODEL="minimax-m2.5"
+fi
+
+PRIMARY_MODEL=$(normalize_model "$GRADIENT_MODEL")
+write_env_file_kv GRADIENT_KEY "$GRADIENT_KEY"
+write_env_file_kv GRADIENT_MODEL "${PRIMARY_MODEL#openai/}"
+
+mkdir -p "${OPENHANDS_HOME}/.openhands"
+
+# Seed agent settings for OpenHands / Agent Canvas (LiteLLM OpenAI-compatible)
+jq -n \
+  --arg model "$PRIMARY_MODEL" \
+  --arg key "$GRADIENT_KEY" \
+  --arg base "$GRADIENT_BASE_URL" \
+  '{
+    llm: {
+      model: $model,
+      api_key: $key,
+      base_url: $base
+    }
+  }' > "$SETTINGS_FILE"
+
+printf '%s\n' "DigitalOcean Gradient" > "$SETUP_DONE_MARKER"
+chown -R openhands:openhands "${OPENHANDS_HOME}/.openhands"
+chmod 700 "${OPENHANDS_HOME}/.openhands"
+chmod 600 "$SETTINGS_FILE" "$SETUP_DONE_MARKER"
+
+remove_setup_wizard_bashrc_hook
+
+# Restart if already running so settings are picked up
+if systemctl is-active --quiet openhands 2>/dev/null; then
+  systemctl restart openhands || true
+fi
+
+echo "OpenHands configured for DigitalOcean Gradient: ${PRIMARY_MODEL}"
+exit 0

--- a/openhands-24-04/files/opt/openhands.env
+++ b/openhands-24-04/files/opt/openhands.env
@@ -1,0 +1,30 @@
+# OpenHands (Agent Canvas) Environment Configuration
+#
+# After making changes to this file, restart with:
+#   systemctl restart openhands
+
+# Installed Agent Canvas version
+OPENHANDS_VERSION=${APP_VERSION}
+
+# Ingress binds to loopback; Caddy proxies public HTTP/HTTPS to this port
+# (set by agent-canvas; do not expose 8000 in UFW)
+
+# API key for public mode — generated on first boot
+LOCAL_BACKEND_API_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+
+# Secret used to protect stored settings / LLM keys — generated on first boot
+OH_SECRET_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+
+# DigitalOcean Gradient (optional):
+#   GRADIENT_KEY    Gradient model access key (Gen AI / Gradient in the control panel)
+#   GRADIENT_MODEL  Inference model id, e.g. minimax-m2.5, kimi-k2.5, glm-5
+#                   (stored as openai/<id> with Gradient base URL; default minimax-m2.5)
+# On first boot, 001_onboot reads /etc/environment first, then /opt/openhands.env.
+# If GRADIENT_KEY is set in either place, it configures Gradient and skips the
+# interactive provider section of the setup wizard.
+#
+# Run the interactive setup script if these are empty:
+#   sudo /etc/setup_wizard.sh
+
+GRADIENT_KEY=
+GRADIENT_MODEL=minimax-m2.5

--- a/openhands-24-04/files/opt/restart-openhands.sh
+++ b/openhands-24-04/files/opt/restart-openhands.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "Restarting OpenHands (Agent Canvas)..."
+systemctl restart openhands
+sleep 2
+if systemctl is-active --quiet openhands; then
+  echo "OpenHands restarted successfully."
+  echo "View logs: journalctl -u openhands -f"
+else
+  echo "Failed to restart OpenHands. Check: journalctl -u openhands -xe"
+  exit 1
+fi

--- a/openhands-24-04/files/opt/retry-apply-gradient-after-cloud-init.sh
+++ b/openhands-24-04/files/opt/retry-apply-gradient-after-cloud-init.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Retries Gradient apply after cloud-init may have written GRADIENT_KEY.
+set -euo pipefail
+
+set -a
+# shellcheck source=/dev/null
+source /etc/environment 2>/dev/null || true
+set +a
+
+if /opt/apply-gradient-from-env.sh; then
+  sed -i '/chmod +x \/etc\/setup_wizard\.sh/d' /root/.bashrc 2>/dev/null || true
+  sed -i '/\/etc\/setup_wizard\.sh/d' /root/.bashrc 2>/dev/null || true
+fi

--- a/openhands-24-04/files/opt/setup-openhands-domain.sh
+++ b/openhands-24-04/files/opt/setup-openhands-domain.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+PORT=8000
+BIND_IP=127.0.0.1
+
+read -rp "Enter the domain you pointed at this droplet (e.g. canvas.example.com): " DOMAIN
+if [ -z "${DOMAIN}" ]; then
+  echo "Domain cannot be empty."
+  exit 1
+fi
+
+read -rp "Enter an email for Let's Encrypt notifications (optional): " EMAIL
+
+{
+  cat > /etc/caddy/Caddyfile << CADDYEOC
+${DOMAIN} {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+    reverse_proxy ${BIND_IP}:${PORT}
+    header X-DO-MARKETPLACE "openhands"
+}
+CADDYEOC
+  if [ -n "$EMAIL" ]; then
+    # Prepend email directive for Let's Encrypt account binding
+    sed -i "1iemail ${EMAIL}" /etc/caddy/Caddyfile
+  fi
+}
+
+systemctl enable caddy
+systemctl restart caddy
+systemctl restart openhands
+
+echo "Caddy is now proxying https://${DOMAIN} to ${BIND_IP}:${PORT}."
+echo "Ensure DNS A record for ${DOMAIN} points at this droplet and ports 80/443 are open."

--- a/openhands-24-04/files/opt/start-openhands.sh
+++ b/openhands-24-04/files/opt/start-openhands.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+echo "Starting OpenHands (Agent Canvas)..."
+systemctl start openhands
+systemctl start caddy
+sleep 2
+if systemctl is-active --quiet openhands; then
+  echo "OpenHands started successfully."
+else
+  echo "Failed to start OpenHands. Check: journalctl -u openhands -xe"
+  exit 1
+fi

--- a/openhands-24-04/files/opt/status-openhands.sh
+++ b/openhands-24-04/files/opt/status-openhands.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+echo "=== OpenHands Service Status ==="
+systemctl status openhands --no-pager || true
+
+echo ""
+echo "=== Caddy Status ==="
+systemctl is-active caddy >/dev/null 2>&1 && echo "caddy: active" || echo "caddy: inactive"
+
+echo ""
+echo "=== API Key ==="
+if [ -f /opt/openhands.env ]; then
+  grep "^LOCAL_BACKEND_API_KEY=" /opt/openhands.env | cut -d= -f2-
+else
+  echo "Env file missing."
+fi
+
+echo ""
+echo "=== Web UI ==="
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+priv=$(hostname -I | awk '{print $1}')
+host="${pub:-$priv}"
+echo "  https://${host}/   (Caddy -> Agent Canvas on 127.0.0.1:8000)"
+echo "  Loopback (SSH tunnel): http://127.0.0.1:8000"

--- a/openhands-24-04/files/opt/stop-openhands.sh
+++ b/openhands-24-04/files/opt/stop-openhands.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Stopping OpenHands (Agent Canvas)..."
+systemctl stop openhands
+echo "OpenHands stopped. Caddy left running (use: systemctl stop caddy)."

--- a/openhands-24-04/files/opt/update-openhands.sh
+++ b/openhands-24-04/files/opt/update-openhands.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Update @openhands/agent-canvas from npm and restart the service
+
+set -euo pipefail
+
+APP_VERSION="latest"
+if [ -f /opt/openhands.env ]; then
+  APP_VERSION_VALUE=$(grep -E '^OPENHANDS_VERSION=' /opt/openhands.env | tail -n 1 | cut -d= -f2-)
+  if [ -n "$APP_VERSION_VALUE" ]; then
+    APP_VERSION="$APP_VERSION_VALUE"
+  fi
+fi
+case "$APP_VERSION" in *'$'*) APP_VERSION="latest" ;; esac
+
+TARGET="${1:-$APP_VERSION}"
+if [ "$TARGET" = "Latest" ] || [ "$TARGET" = "latest" ]; then
+  TARGET="latest"
+fi
+
+echo "Updating OpenHands Agent Canvas (target: ${TARGET})..."
+systemctl stop openhands
+
+if [ "$TARGET" = "latest" ]; then
+  npm install -g @openhands/agent-canvas@latest
+else
+  npm install -g "@openhands/agent-canvas@${TARGET}"
+fi
+
+CANVAS_BIN="$(command -v agent-canvas)"
+if [ -n "$CANVAS_BIN" ]; then
+  ln -sfn "$CANVAS_BIN" /usr/local/bin/agent-canvas
+fi
+
+INSTALLED_VERSION=$(npm list -g @openhands/agent-canvas --depth=0 2>/dev/null \
+  | grep '@openhands/agent-canvas@' | sed 's/.*@openhands\/agent-canvas@//' | sed 's/ .*//' || true)
+
+if [ -n "$INSTALLED_VERSION" ] && [ -f /opt/openhands.env ]; then
+  sed -i "s/^OPENHANDS_VERSION=.*/OPENHANDS_VERSION=${INSTALLED_VERSION}/" /opt/openhands.env
+fi
+
+systemctl start openhands
+sleep 2
+
+if systemctl is-active --quiet openhands; then
+  echo "OpenHands updated and restarted successfully."
+  echo "Version: ${INSTALLED_VERSION:-unknown}"
+else
+  echo "Update installed but service failed to start. Check: journalctl -u openhands -xe"
+  exit 1
+fi

--- a/openhands-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/openhands-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,142 @@
+#!/bin/bash
+set -euo pipefail
+
+set -a
+# shellcheck source=/dev/null
+source /etc/environment 2>/dev/null || true
+set +a
+
+ENV_FILE=/opt/openhands.env
+OPENHANDS_HOME=/home/openhands
+INFO_FILE=/root/openhands_info.txt
+
+meta() { curl -fsS --retry 10 --retry-connrefused --max-time 2 "$1"; }
+DROPLET_PUBLIC_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+DROPLET_PRIVATE_IP="$(hostname -I | awk '{print $1}')"
+DROPLET_IP="${DROPLET_PUBLIC_IP:-$DROPLET_PRIVATE_IP}"
+
+# Generate per-droplet secrets
+if grep -q "PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT" "$ENV_FILE" 2>/dev/null; then
+  echo "Generating LOCAL_BACKEND_API_KEY and OH_SECRET_KEY..."
+  NEW_API_KEY="$(openssl rand -base64 32)"
+  NEW_SECRET_KEY="$(openssl rand -base64 32)"
+  sed -i "s|LOCAL_BACKEND_API_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|LOCAL_BACKEND_API_KEY=${NEW_API_KEY}|" "$ENV_FILE"
+  sed -i "s|OH_SECRET_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|OH_SECRET_KEY=${NEW_SECRET_KEY}|" "$ENV_FILE"
+
+  mkdir -p "$OPENHANDS_HOME/.openhands"
+  printf '%s\n' "$NEW_API_KEY" > "$OPENHANDS_HOME/.openhands/api-key.txt"
+  chown -R openhands:openhands "$OPENHANDS_HOME/.openhands"
+  chmod 700 "$OPENHANDS_HOME/.openhands"
+  chmod 600 "$OPENHANDS_HOME/.openhands/api-key.txt"
+  chmod 600 "$ENV_FILE"
+fi
+
+# Install Caddyfile and substitute droplet IP for shortlived TLS
+if [ -f /etc/caddy/Caddyfile.tmp ]; then
+  mv /etc/caddy/Caddyfile.tmp /etc/caddy/Caddyfile
+fi
+if grep -q "PLACEHOLDER_DOMAIN" /etc/caddy/Caddyfile 2>/dev/null; then
+  echo "Configuring Caddy with droplet IP address..."
+  sed -i "s/PLACEHOLDER_DOMAIN/$DROPLET_IP/" /etc/caddy/Caddyfile
+  systemctl enable caddy
+fi
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+chmod +x /opt/apply-gradient-from-env.sh
+chmod +x /opt/retry-apply-gradient-after-cloud-init.sh
+
+GRADIENT_APPLIED=0
+if /opt/apply-gradient-from-env.sh; then
+  GRADIENT_APPLIED=1
+  echo "Gradient pre-configured from droplet environment."
+elif ! grep -q 'setup_wizard.sh' /root/.bashrc 2>/dev/null; then
+  cat >> /root/.bashrc <<'EOM'
+
+chmod +x /etc/setup_wizard.sh
+/etc/setup_wizard.sh
+EOM
+
+  # Startup scripts may write GRADIENT_KEY after this script; retry after cloud-init.
+  systemctl daemon-reload
+  systemctl enable openhands-apply-gradient.service
+  systemctl start openhands-apply-gradient.service || true
+fi
+
+# Ensure persistence dirs exist with correct ownership
+mkdir -p "$OPENHANDS_HOME/.openhands" "$OPENHANDS_HOME/projects"
+chown -R openhands:openhands "$OPENHANDS_HOME"
+chmod 700 "$OPENHANDS_HOME/.openhands"
+
+API_KEY="$(grep -E '^LOCAL_BACKEND_API_KEY=' "$ENV_FILE" | tail -n 1 | cut -d= -f2-)"
+
+cat > "$INFO_FILE" << EOF
+================================================================================
+OpenHands 1-Click Droplet - Getting Started
+================================================================================
+
+OpenHands Agent Canvas is a self-hosted control center for AI coding agents.
+It is running in public mode behind Caddy with shortlived TLS.
+
+ACCESS:
+  Web UI:     https://${DROPLET_IP}
+  API Key:    ${API_KEY}
+
+  Paste the API key when the UI prompts for it (X-Session-API-Key).
+  The key is also saved at: /home/openhands/.openhands/api-key.txt
+  And in: /opt/openhands.env (LOCAL_BACKEND_API_KEY)
+
+LLM / GRADIENT:
+EOF
+
+if [ "$GRADIENT_APPLIED" = "1" ]; then
+  cat >> "$INFO_FILE" << 'EOF'
+  DigitalOcean Gradient was auto-configured from GRADIENT_KEY.
+  Confirm or change models under Settings > LLM in the web UI.
+EOF
+else
+  cat >> "$INFO_FILE" << 'EOF'
+  On first SSH login, the setup wizard can configure DigitalOcean Gradient.
+  Or set GRADIENT_KEY / GRADIENT_MODEL as droplet env vars and recreate,
+  or run: sudo /etc/setup_wizard.sh
+  Or configure any provider in Settings > LLM (Advanced: Base URL).
+EOF
+fi
+
+cat >> "$INFO_FILE" << 'EOF'
+
+MANAGEMENT:
+  Start:     /opt/start-openhands.sh   (or systemctl start openhands)
+  Stop:      /opt/stop-openhands.sh
+  Restart:   /opt/restart-openhands.sh
+  Status:    /opt/status-openhands.sh
+  Update:    /opt/update-openhands.sh
+  Domain TLS:/opt/setup-openhands-domain.sh
+
+WORKSPACE:
+  Projects:  /home/openhands/projects
+  Settings:  /home/openhands/.openhands
+  Env file:  /opt/openhands.env
+
+SECURITY:
+  Agent Canvas runs as the 'openhands' user with access to that account's
+  filesystem. Keep LOCAL_BACKEND_API_KEY private. Prefer restricting SSH and
+  (optionally) HTTP to your IP via a DigitalOcean Cloud Firewall.
+
+DOCS:
+  https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/vm
+  https://www.openhands.dev/
+
+================================================================================
+EOF
+chmod 600 "$INFO_FILE"
+
+systemctl restart ssh
+systemctl restart openhands
+systemctl restart caddy
+
+echo "OpenHands first-boot initialization complete!"
+echo "Access info saved to ${INFO_FILE}"

--- a/openhands-24-04/listing.md
+++ b/openhands-24-04/listing.md
@@ -1,0 +1,127 @@
+# OpenHands 1-Click Application
+
+Deploy OpenHands Agent Canvas, an open-source self-hosted control center for AI coding agents and automations. Run agents on your Droplet, connect from the browser, and optionally use DigitalOcean Gradient AI for inference.
+
+## What is OpenHands?
+
+OpenHands is the open platform for cloud coding agents. Agent Canvas is the self-hosted developer control center: start conversations, run automations, and work with OpenHands or other ACP-compatible agents across local and remote backends.
+
+- **Self-hosted** – Agents and settings stay on your Droplet
+- **Browser UI** – Agent Canvas on your droplet IP (Caddy reverse proxy)
+- **Public mode** – Protected by a generated API key (`LOCAL_BACKEND_API_KEY`)
+- **DigitalOcean Gradient AI** – Optional one-key setup for OpenAI-compatible models
+- **Workspace** – Projects under `/home/openhands/projects`
+
+## Key Features
+
+- Always-on agent backend for coding tasks and automations
+- Web UI with API-key gate for internet-facing deployments
+- Optional Gradient model access key configuration at first login
+- Helper scripts for start/stop/restart/status/update and custom domain TLS
+- Ubuntu 24.04 LTS with UFW and fail2ban
+
+## System Requirements
+
+OpenHands Agent Canvas runs the agent server on the host. Prefer at least 4 GB RAM.
+
+| Use Case | RAM | CPU | Storage |
+|----------|-----|-----|---------|
+| Minimum (single user) | 4 GB | 2 vCPU | 50 GB |
+| Recommended | 8 GB | 4 vCPU | 100 GB |
+
+## Included System Components
+
+- **Ubuntu 24.04 LTS**
+- **OpenHands Agent Canvas** (version pinned in the image build)
+- **Node.js 22** and **uv**
+- **Caddy** reverse proxy (ports 80/443 → Agent Canvas on localhost:8000)
+- **UFW** and **fail2ban**
+- Dedicated **`openhands`** system user
+
+## Getting Started
+
+### 1. Deploy the Droplet
+
+1. Select this 1-Click App from the DigitalOcean Marketplace
+2. Choose a Droplet size (4 GB RAM minimum recommended)
+3. Add your SSH key
+4. Optionally set droplet environment variables `GRADIENT_KEY` and `GRADIENT_MODEL`
+5. Create the Droplet
+
+### 2. Open the Web UI
+
+1. Visit `https://your-droplet-ip`
+2. Paste the **API key** shown in the SSH MOTD (also in `/opt/openhands.env` as `LOCAL_BACKEND_API_KEY`)
+
+### 3. SSH (optional setup wizard)
+
+```bash
+ssh root@your-droplet-ip
+```
+
+If Gradient was not passed at create time, the first-login wizard can configure a DigitalOcean Gradient model access key. Create keys at https://cloud.digitalocean.com/gen-ai/model-access-keys.
+
+### 4. Configure LLM and start working
+
+1. In the UI, open **Settings > LLM** (confirm Gradient settings or add another provider)
+2. Place code under `/home/openhands/projects`
+3. Start a conversation from the home screen
+
+## Managing OpenHands
+
+| Action | Command |
+|--------|---------|
+| Start | `/opt/start-openhands.sh` |
+| Stop | `/opt/stop-openhands.sh` |
+| Restart | `/opt/restart-openhands.sh` |
+| Status | `/opt/status-openhands.sh` |
+| Update | `/opt/update-openhands.sh` |
+| Domain TLS | `/opt/setup-openhands-domain.sh` |
+| Re-run setup | `/etc/setup_wizard.sh` |
+
+systemd: `systemctl {start|stop|restart|status} openhands`  
+Logs: `journalctl -u openhands -f`
+
+### Configuration paths
+
+- Env / secrets: `/opt/openhands.env`
+- API key file: `/home/openhands/.openhands/api-key.txt`
+- Settings: `/home/openhands/.openhands/`
+- Getting started: `/root/openhands_info.txt`
+
+### DigitalOcean Gradient
+
+When configured, OpenHands uses the OpenAI-compatible Gradient endpoint:
+
+- Base URL: `https://inference.do-ai.run/v1`
+- Model form: `openai/<model-id>` (default `openai/minimax-m2.5`)
+
+You can change the model in Settings > LLM or by re-running the setup wizard.
+
+### Custom domain (HTTPS)
+
+Point a DNS A record at the droplet, then:
+
+```bash
+sudo /opt/setup-openhands-domain.sh
+```
+
+## Security notes
+
+- Agent Canvas runs as the `openhands` user and can read/write that user's filesystem and run commands in that context
+- Keep `LOCAL_BACKEND_API_KEY` private; anyone with the key can use the agent
+- Prefer a DigitalOcean Cloud Firewall restricting SSH (and optionally HTTP/HTTPS) to your IP
+- For production, use a custom domain with TLS via `/opt/setup-openhands-domain.sh`
+
+## Additional Resources
+
+- Product: https://www.openhands.dev/
+- Self-hosting: https://docs.openhands.dev/openhands/usage/agent-canvas/backend-setup/vm
+- Docs: https://docs.openhands.dev/
+- GitHub: https://github.com/OpenHands/agent-canvas
+
+## Support
+
+For OpenHands-specific issues: https://docs.openhands.dev/ and the OpenHands community Slack.
+
+For DigitalOcean Droplet issues: https://www.digitalocean.com/support

--- a/openhands-24-04/scripts/010-openhands.sh
+++ b/openhands-24-04/scripts/010-openhands.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_VERSION="${application_version:-1.4.0}"
+OPENHANDS_USER=openhands
+OPENHANDS_HOME=/home/openhands
+
+# HTTP/HTTPS via Caddy; Agent Canvas ingress stays on loopback :8000
+ufw allow 80/tcp comment 'HTTP'
+ufw allow 443/tcp comment 'HTTPS'
+ufw limit ssh/tcp
+ufw --force enable
+
+# Node.js 22 (required by Agent Canvas)
+curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+apt-get install -y nodejs
+
+# Caddy reverse proxy
+curl -1sLf "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" \
+  | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" \
+  > /etc/apt/sources.list.d/caddy-stable.list
+apt-get update -y
+apt-get install -y caddy
+mkdir -p /var/log/caddy
+chown -R caddy:caddy /var/log/caddy
+
+# Dedicated application user
+useradd -m -s /bin/bash "$OPENHANDS_USER" || true
+mkdir -p "$OPENHANDS_HOME/.openhands" "$OPENHANDS_HOME/projects" "$OPENHANDS_HOME/.local/bin"
+chown -R openhands:openhands "$OPENHANDS_HOME"
+chmod 0700 "$OPENHANDS_HOME/.openhands"
+
+# uv for agent-server / automation (uvx)
+su - "$OPENHANDS_USER" -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+# Ensure uv is on PATH for non-login systemd sessions
+if [ -x "$OPENHANDS_HOME/.local/bin/uv" ]; then
+  ln -sfn "$OPENHANDS_HOME/.local/bin/uv" /usr/local/bin/uv
+  ln -sfn "$OPENHANDS_HOME/.local/bin/uvx" /usr/local/bin/uvx
+fi
+
+# Install Agent Canvas (OpenHands product UI)
+npm install -g "@openhands/agent-canvas@${APP_VERSION}"
+
+if ! command -v agent-canvas >/dev/null 2>&1; then
+  echo "ERROR: agent-canvas not found on PATH after npm install." >&2
+  exit 1
+fi
+
+# Stable absolute path for systemd ExecStart
+CANVAS_BIN="$(command -v agent-canvas)"
+ln -sfn "$CANVAS_BIN" /usr/local/bin/agent-canvas
+agent-canvas --version || true
+
+# Persist version into env template
+if [ -f /opt/openhands.env ]; then
+  sed -i "s|\${APP_VERSION}|${APP_VERSION}|g" /opt/openhands.env
+  chmod 600 /opt/openhands.env
+fi
+
+systemctl enable fail2ban
+systemctl restart fail2ban
+
+# Helper scripts and MOTD
+chmod +x /opt/restart-openhands.sh
+chmod +x /opt/status-openhands.sh
+chmod +x /opt/update-openhands.sh
+chmod +x /opt/start-openhands.sh
+chmod +x /opt/stop-openhands.sh
+chmod +x /opt/apply-gradient-from-env.sh
+chmod +x /opt/retry-apply-gradient-after-cloud-init.sh
+chmod +x /opt/setup-openhands-domain.sh
+chmod +x /etc/setup_wizard.sh
+chmod +x /etc/update-motd.d/99-one-click
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+
+# Enable but do not start yet — first boot generates secrets and starts services
+systemctl daemon-reload
+systemctl enable openhands
+systemctl enable caddy
+
+echo "OpenHands (Agent Canvas ${APP_VERSION}) installation complete."
+echo "Service will start on first boot after secrets are generated."

--- a/openhands-24-04/template.json
+++ b/openhands-24-04/template.json
@@ -1,0 +1,81 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "openhands-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "procps file apt-transport-https ca-certificates curl software-properties-common git build-essential jq unzip gnupg fail2ban ufw",
+    "application_name": "OpenHands",
+    "application_version": "1.4.0"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-2vcpu-4gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "openhands-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "openhands-24-04/files/opt/",
+      "destination": "/opt/"
+    },
+    {
+      "type": "file",
+      "source": "openhands-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "openhands-24-04/scripts/010-openhands.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a new DigitalOcean Marketplace 1-Click Packer image for **OpenHands Agent Canvas** (`openhands-24-04`) based on Ubuntu 24.04.
- Installs Agent Canvas (`@openhands/agent-canvas`), Node.js 22, uv, Caddy (shortlived TLS by IP → `127.0.0.1:8000`), UFW, and fail2ban; runs Agent Canvas in public mode behind Caddy as a dedicated `openhands` user.
- On first boot, generates `LOCAL_BACKEND_API_KEY` / `OH_SECRET_KEY`, configures Caddy with the droplet IP, starts services, and optionally configures DigitalOcean Gradient via `GRADIENT_KEY` / `GRADIENT_MODEL` or the first-login setup wizard (with a post–cloud-init retry unit if the key arrives late).
- Includes management helpers (start/stop/restart/status/update/domain), MOTD, `listing.md`, and builder docs.

## JIRA

- **Ticket:** [MP-8474](https://do-internal.atlassian.net/browse/MP-8474) — Create OpenHands Droplet 1-Click

## Test plan

- [x] Build image with Packer (`make build-openhands-24-04`) and create a Droplet from the snapshot
- [x] Confirm Web UI loads at `https://<droplet-ip>` (Caddy shortlived TLS by IP; browser cert warning is expected)
- [x] Paste `LOCAL_BACKEND_API_KEY` from MOTD / `/opt/openhands.env` and unlock Agent Canvas
- [x] Explore UI options and confirm core navigation works
- [x] Create a DigitalOcean Gradient model access key and configure LLM (Advanced: model `openai/<id>`, base URL `https://inference.do-ai.run/v1`)
- [x] Send a test chat and confirm the agent responds end-to-end
- [ ] (Optional) Re-test Gradient auto-config via droplet env `GRADIENT_KEY` / `GRADIENT_MODEL`
- [ ] (Optional) Run `/opt/setup-openhands-domain.sh` with a DNS A record and verify HTTPS
- [ ] (Optional) Run `/opt/update-openhands.sh` and confirm service restarts cleanly

[MP-8474]: https://do-internal.atlassian.net/browse/MP-8474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ