### PR TITLE
[MP-8487]: Test and Upgrade Wordpress 1-click to v7.0

### DIFF
--- a/wordpress-24-04/template.json
+++ b/wordpress-24-04/template.json
@@ -5,7 +5,7 @@
     "image_name": "wordpress-24-04-snapshot-{{timestamp}}",
     "apt_packages": "fail2ban mysql-server php8.3-fpm php8.3 php8.3-apcu php8.3-bz2 php8.3-curl php8.3-gd php8.3-gmp php8.3-intl php8.3-mbstring php8.3-mysql php8.3-pspell php8.3-soap php8.3-tidy php8.3-xml php8.3-xmlrpc php8.3-xsl php8.3-zip postfix software-properties-common unzip",
     "application_name": "WordPress",
-    "application_version": "6.9.5",
+    "application_version": "7.0.2",
     "fail2ban_version": ""
   },
   "sensitive-variables": ["do_api_token"],
@@ -57,7 +57,7 @@
       ],
       "inline": [
         "add-apt-repository -y ppa:ondrej/php",
-        "wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.36-1_all.deb",
+        "wget -c https://repo.mysql.com/apt/ubuntu/pool/mysql-apt-config/m/mysql-apt-config/mysql-apt-config_0.8.36-1_all.deb",
         "dpkg -i mysql-apt-config_0.8.36-1_all.deb",
         "echo 'deb [arch=amd64 trusted=yes] http://repo.mysql.com/apt/ubuntu/ noble mysql-apt-config mysql-8.4' | sudo tee /etc/apt/sources.list.d/mysql.list",
         "apt -qqy update",


### PR DESCRIPTION
## Summary
- Bump WordPress 24.04 1-Click `application_version to `7.0.2` so the image ships the current stable WordPress 7.0.x release.
- Image build continues to download the pinned tarball (`wordpress-${application_version}.tar.gz`), so metadata and installed files stay aligned.
- Switch the MySQL apt-config download to `repo.mysql.com` because `dev.mysql.com` now returns 403 and breaks Packer builds.

## Test plan
- [ ] Run `packer build wordpress-24-04/template.json`
- [ ] Confirm `/var/www/wordpress/wp-includes/version.php` reports `7.0.2` on the built snapshot
- [ ] Confirm `/var/lib/digitalocean/application.info` contains `application_version="7.0.2"`
- [ ] Deploy a Droplet from the new snapshot and verify first-login setup completes
- [ ] Verify HTTPS site loads and `/wp-admin` login works
- [ ] Run `wp --allow-root --path=/var/www/html core version` and confirm `7.0.2`