### PR TITLE
MP-8505: Remove GPT-5.1 grok build

### DIFF
--- a/grok-build-24-04/files/etc/update-motd.d/99-one-click
+++ b/grok-build-24-04/files/etc/update-motd.d/99-one-click
@@ -12,8 +12,8 @@ write, review, and refactor code. This droplet is pre-configured to run Grok
 Build on DigitalOcean Serverless Inference.
 
 PRE-CONFIGURED MODELS (via DigitalOcean Serverless Inference, default GPT-5.5):
-  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5-1-codex-max,
-  gpt-5, gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
+  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5,
+  gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
   claude-haiku-4-5, deepseek-v4-pro, kimi-k2-6, minimax-m2-5, glm-5,
   qwen3-coder-flash, llama-4-maverick, nemotron-3-super-120b, router
 

--- a/grok-build-24-04/files/root/.grok/config.toml
+++ b/grok-build-24-04/files/root/.grok/config.toml
@@ -55,12 +55,6 @@ base_url = "https://inference.do-ai.run/v1"
 name = "GPT-5.2 (DigitalOcean Inference)"
 env_key = "MODEL_ACCESS_KEY"
 
-[model.gpt-5-1-codex-max]
-model = "openai-gpt-5.1-codex-max"
-base_url = "https://inference.do-ai.run/v1"
-name = "GPT-5.1 Codex Max (DigitalOcean Inference)"
-env_key = "MODEL_ACCESS_KEY"
-
 [model.gpt-5]
 model = "openai-gpt-5"
 base_url = "https://inference.do-ai.run/v1"

--- a/grok-build-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/grok-build-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -54,8 +54,8 @@ Authentication was configured automatically from the droplet environment
 
 PRE-CONFIGURED MODELS (DigitalOcean Serverless Inference, default GPT-5.5):
 
-  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5-1-codex-max,
-  gpt-5, gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
+  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5,
+  gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
   claude-haiku-4-5, deepseek-v4-pro, deepseek-4-flash, kimi-k2-6,
   minimax-m2-5, glm-5, qwen3-coder-flash, qwen3-5, llama-4-maverick,
   nemotron-3-super-120b, router
@@ -104,8 +104,8 @@ DigitalOcean Serverless Inference (https://inference.do-ai.run/v1).
 
 PRE-CONFIGURED MODELS (DigitalOcean Serverless Inference, default GPT-5.5):
 
-  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5-1-codex-max,
-  gpt-5, gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
+  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5,
+  gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
   claude-haiku-4-5, deepseek-v4-pro, deepseek-4-flash, kimi-k2-6,
   minimax-m2-5, glm-5, qwen3-coder-flash, qwen3-5, llama-4-maverick,
   nemotron-3-super-120b, router

--- a/grok-build-24-04/listing.md
+++ b/grok-build-24-04/listing.md
@@ -97,7 +97,6 @@ All models below are available via DigitalOcean Serverless Inference with just a
 | `gpt-5-4` | GPT-5.4 | `openai-gpt-5.4` |
 | `gpt-5-3-codex` | GPT-5.3 Codex | `openai-gpt-5.3-codex` |
 | `gpt-5-2` | GPT-5.2 | `openai-gpt-5.2` |
-| `gpt-5-1-codex-max` | GPT-5.1 Codex Max | `openai-gpt-5.1-codex-max` |
 | `gpt-5` | GPT-5 | `openai-gpt-5` |
 | `gpt-4-1` | GPT-4.1 | `openai-gpt-4.1` |
 | `claude-opus-4-8` | Claude Opus 4.8 | `anthropic-claude-opus-4.8` |


### PR DESCRIPTION
## Summary
- Remove deprecated **GPT-5.1 Codex Max** (`openai-gpt-5.1-codex-max`) from the Grok Build 1-Click model selections, since it is being removed from the Gradient / DigitalOcean Inference provider.
- Drop the model entry from `config.toml`, Marketplace `listing.md`, MOTD, and first-boot getting-started text so new droplets no longer offer or document it.
- Default remains **GPT-5.5**; other pre-configured models are unchanged.

## Test plan
- [ ] Confirm `gpt-5-1-codex-max` / `openai-gpt-5.1-codex-max` no longer appears in `grok-build-24-04/`
- [ ] Review `/root/.grok/config.toml` — no `[model.gpt-5-1-codex-max]` block
- [ ] Review MOTD and `/root/grok_build_info.txt` model lists after boot
- [ ] Confirm listing.md Pre-Configured Models table omits GPT-5.1 Codex Max
- [ ] Smoke: default model still `gpt-5-5`; `/model` / `-m` still work for remaining aliases