### PR TITLE
[MP-8464]: Create WordPress + phpMyAdmin 1-Click for Ubuntu 24.04

### DIFF
--- a/wordpress-phpmyadmin-24-04/README.md
+++ b/wordpress-phpmyadmin-24-04/README.md
@@ -1,0 +1,388 @@
+# WordPress + phpMyAdmin 1-Click with Easy Setup
+
+Deploy WordPress instantly with automatic configuration and a web-based MySQL manager. HTTPS is enabled automatically on first login, phpMyAdmin is available at `/phpmyadmin`, and you can add a custom domain anytime with `/root/wp_setup_domain.sh`.
+
+## Building this image
+
+From the repository root (requires Packer and `DIGITALOCEAN_API_TOKEN`):
+
+```bash
+export DIGITALOCEAN_API_TOKEN=your_token
+make validate-wordpress-phpmyadmin-24-04
+make build-wordpress-phpmyadmin-24-04
+```
+
+Or:
+
+```bash
+packer validate wordpress-phpmyadmin-24-04/template.json
+packer build wordpress-phpmyadmin-24-04/template.json
+```
+
+## What's New
+
+This WordPress + phpMyAdmin 1-Click includes:
+
+- **Automatic Setup Wizard**: Creates your admin account and configures WordPress on first login
+- **Setup Pending Page**: Professional loading page displayed until you complete the initial setup
+- **Quick Start**: Get WordPress running in ~2 minutes with automatic HTTPS
+- **phpMyAdmin**: Manage MySQL through a browser UI at `https://your-droplet-ip/phpmyadmin`
+- **Easy Custom Domain Setup**: Simple script to switch from IP-based access to a custom domain with Let's Encrypt SSL
+
+## What is WordPress?
+
+WordPress is the world's most popular content management system (CMS), powering over 40% of all websites on the internet. It's a free, open-source platform that makes it easy to create beautiful websites, blogs, and applications without needing to know how to code.
+
+Key features include:
+
+- **User-Friendly Interface** - Intuitive admin panel for managing content
+- **Themes** - Thousands of free and premium designs
+- **Plugins** - Extensible with 60,000+ plugins for any functionality
+- **SEO Optimized** - Built-in features for search engine visibility
+- **Mobile Responsive** - Works great on all devices
+- **Community Support** - Large, active community and extensive documentation
+
+## What is phpMyAdmin?
+
+phpMyAdmin is a free web application for administering MySQL and MariaDB. It lets you browse databases, run SQL, import/export data, and manage users from a browser — without using the MySQL command line.
+
+## System Requirements
+
+### Minimum Requirements
+- **CPU**: 1 core
+- **RAM**: 2 GB
+- **Storage**: 25 GB
+
+### Recommended for Production
+- **CPU**: 2+ cores
+- **RAM**: 4+ GB
+- **Storage**: 50+ GB
+
+**Note**: Requirements depend on your traffic and installed plugins. Monitor resource usage and scale up as needed.
+
+## Included Components
+
+This 1-Click installs and configures:
+
+- **Ubuntu 24.04 LTS** - Long-term support base operating system
+- **Caddy** - Web server and reverse proxy with automatic HTTPS (Let's Encrypt)
+- **PHP 8.3 FPM** - PHP FastCGI Process Manager for WordPress and phpMyAdmin
+- **MySQL 8.4** - Relational database (local; optional Managed Database)
+- **WordPress (Latest)** - Latest stable WordPress release (version recorded at image build)
+- **phpMyAdmin (Latest)** - Latest stable release from phpmyadmin.net at `/phpmyadmin`
+- **WP-CLI** - WordPress command-line interface
+- **WP-Fail2Ban Plugin** - Installed and activated during first-login setup
+- **UFW Firewall** - Pre-configured with secure defaults
+
+## Getting Started
+
+### 1. Deploy the Droplet
+
+- Select this 1-Click App from the DigitalOcean Marketplace
+- Choose a Droplet size (minimum 2 GB RAM)
+- Select your preferred datacenter region
+- Add your SSH key for secure access
+- Optionally select **Add a Database** to provision a DigitalOcean Managed MySQL database alongside your Droplet (see [Using a DigitalOcean Managed Database](#using-a-digitalocean-managed-database-optional))
+- Create the Droplet
+
+### 2. Initial Access
+
+Before running the setup script, you can visit your Droplet's IP address in a browser to see the setup pending page:
+
+```
+http://your-droplet-ip
+```
+
+This page will display instructions and automatically refresh until setup is complete.
+
+### 3. Run the Setup Script
+
+SSH into your Droplet:
+
+```bash
+ssh root@your-droplet-ip
+```
+
+The setup script will launch automatically on first login. It will:
+
+1. **Detect your server's IP address** - Automatically determines your public IP
+2. **Create admin account** - You'll be prompted for:
+   - Email address
+   - Admin username
+   - Admin password
+   - Site title
+3. **Obtain SSL certificate** - Caddy requests a Let's Encrypt certificate for your IP (short-lived profile)
+4. **Configure Caddy** - Serves WordPress over HTTPS with automatic HTTP→HTTPS redirect, and phpMyAdmin at `/phpmyadmin`
+5. **Install security plugins** - Adds and activates WP-Fail2Ban
+
+The entire process takes about 2-3 minutes.
+
+If you added a Managed Database during deployment, the setup script also configures WordPress **and phpMyAdmin** to use it instead of the local MySQL instance. The script waits for the database cluster to become available before continuing, which may add a few minutes to setup.
+
+### 4. Access Your WordPress Site
+
+After setup completes, access your site at:
+
+```
+https://your-droplet-ip
+```
+
+**Admin Login:**
+- URL: `https://your-droplet-ip/wp-admin`
+- Username: (the one you chose during setup)
+- Password: (the one you chose during setup)
+
+### 5. Access phpMyAdmin
+
+After setup completes, open:
+
+```
+https://your-droplet-ip/phpmyadmin
+```
+
+**Local MySQL** (default, when no Managed Database is added):
+
+- **Username**: `admin`
+- **Password**: value of `admin_mysql_pass` in `/root/.digitalocean_password`
+
+```bash
+grep admin_mysql_pass /root/.digitalocean_password
+```
+
+**DigitalOcean Managed Database** (when **Add a Database** was selected):
+
+- **Username**: the Managed Database user (also stored as `phpmyadmin_user` in `/root/.digitalocean_password`)
+- **Password**: value of `admin_mysql_pass` in `/root/.digitalocean_password` (same as WordPress `DB_PASSWORD`)
+- phpMyAdmin is preconfigured for SSL to your Managed Database host and port
+
+> **Security note**: phpMyAdmin is a powerful database UI. Use strong passwords, keep the Droplet firewalled, and consider restricting access (for example via Cloud Firewall source IP rules) in production.
+
+## Post-Installation
+
+### Using a DigitalOcean Managed Database (Optional)
+
+When creating your Droplet, you can select **Add a Database** to provision a DigitalOcean Managed MySQL database at the same time. A managed database replaces the local MySQL instance to better secure your data and gives you easy backups, connection pools, and metrics. The setup script handles configuration automatically — no manual DBaaS wiring required.
+
+#### What happens when you add a database
+
+When you choose this option during Droplet creation, DigitalOcean:
+
+1. Provisions a Managed MySQL cluster in the same region as your Droplet
+2. Passes connection credentials to your Droplet at first boot (stored temporarily in `/root/.digitalocean_dbaas_credentials`)
+
+When you complete the first-login setup script, the Droplet automatically:
+
+1. Configures WordPress to connect to the Managed Database instead of the local MySQL instance
+2. Updates `/var/www/html/wp-config.php` with the database host, port, name, username, and password
+3. Enables SSL for the MySQL connection
+4. Configures phpMyAdmin to use the same Managed Database host, port, and SSL settings
+5. Waits for the database cluster to become available (this may take a few minutes during first setup)
+6. Stops and disables the local MySQL instance on the Droplet
+7. Updates `/root/.digitalocean_password` with phpMyAdmin login details for the Managed Database
+
+After setup completes, your database connection details are stored in `/var/www/html/wp-config.php` and phpMyAdmin credentials are in `/root/.digitalocean_password`. The temporary `/root/.digitalocean_dbaas_credentials` file is removed.
+
+#### Security: Trusted Sources
+
+Your Droplet is not automatically added to the Managed Database's trusted sources. For better security, add your Droplet's public IP address to the database cluster's **Trusted Sources** in the [DigitalOcean control panel](https://cloud.digitalocean.com/databases):
+
+1. Open your database cluster in the control panel
+2. Go to **Settings** → **Trusted Sources**
+3. Add your Droplet's public IP address
+
+Without Trusted Sources configured, both WordPress and phpMyAdmin may fail to connect to the Managed Database.
+
+#### Modifying database settings later
+
+- **WordPress connection details**: View or update credentials in `/var/www/html/wp-config.php` (`DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`)
+- **phpMyAdmin connection details**: Update `/usr/share/phpmyadmin/config.inc.php` (`$cfg['Servers'][1]['host']`, `port`, and SSL options) to match
+- **Password rotation**: If you change the database password in the control panel, update both `wp-config.php` and `/root/.digitalocean_password` (`admin_mysql_pass`)
+- **Switching databases**: To point WordPress and phpMyAdmin at a different Managed Database, update `wp-config.php` and phpMyAdmin's `config.inc.php`, and ensure the new cluster allows connections from your Droplet
+
+### Adding a Custom Domain
+
+To use a custom domain instead of the IP address:
+
+1. Point your domain's DNS A record to your Droplet's IP
+2. Wait for DNS propagation (usually 5-60 minutes)
+3. Run the domain setup script:
+
+```bash
+/root/wp_setup_domain.sh
+```
+
+This script will:
+
+- Configure Caddy for your domain (including `/phpmyadmin`)
+- Obtain a domain-based SSL certificate
+- Update WordPress URLs
+- Set up automatic HTTP→HTTPS redirect
+
+After domain setup, phpMyAdmin is available at `https://your-domain/phpmyadmin`.
+
+### SSL Certificate Renewal
+
+Caddy obtains and renews Let's Encrypt certificates automatically. You do not need to run Certbot manually.
+
+To confirm Caddy is healthy:
+
+```bash
+systemctl status caddy
+journalctl -u caddy -n 50 --no-pager
+```
+
+### Database Credentials
+
+**Local MySQL** (default, when no Managed Database is added):
+
+```bash
+cat /root/.digitalocean_password
+```
+
+Keys include `root_mysql_pass`, `wordpress_mysql_pass`, and `admin_mysql_pass` (phpMyAdmin login).
+
+**DigitalOcean Managed Database** (when **Add a Database** was selected during deployment):
+
+After setup completes, connection details are in `/var/www/html/wp-config.php`. phpMyAdmin login details are in `/root/.digitalocean_password`. The local MySQL instance is stopped and disabled.
+
+### Security Best Practices
+
+1. **Change default admin username**: Create a new admin user with a unique username and delete the default one
+2. **Use strong passwords**: Consider using a password manager
+3. **Keep WordPress updated**: Regularly update WordPress core, themes, and plugins
+4. **Enable automatic updates**: Consider enabling automatic security updates
+5. **Regular backups**: Set up automated backups via DigitalOcean or a backup plugin
+6. **Install security plugins**: Additional plugins like Wordfence or Sucuri are recommended
+7. **Limit login attempts**: The WP-Fail2Ban plugin is installed and activated during first-login setup
+8. **Protect phpMyAdmin**: Prefer Cloud Firewall rules that allow `/phpmyadmin` (port 443) only from trusted IPs
+
+### Firewall Configuration
+
+UFW firewall is pre-configured with:
+
+- Port 22 (SSH) - Open
+- Port 80 (HTTP) - Open, redirects to HTTPS after setup
+- Port 443 (HTTPS) - Open
+
+### WP-CLI Usage
+
+WP-CLI is installed for command-line WordPress management:
+
+```bash
+# Update WordPress core
+wp core update --allow-root
+
+# List installed plugins
+wp plugin list --allow-root
+
+# Install a plugin
+wp plugin install <plugin-name> --activate --allow-root
+
+# Create a backup
+wp db export --allow-root
+```
+
+## Troubleshooting
+
+### Setup Script Didn't Run
+
+If the setup script didn't automatically run on first login:
+
+```bash
+chmod +x /root/wp_setup.sh
+/root/wp_setup.sh
+```
+
+### SSL Certificate Failed
+
+If HTTPS fails after setup, check Caddy's logs and configuration:
+
+```bash
+systemctl status caddy
+journalctl -u caddy -b --no-pager
+```
+
+Ensure ports 80 and 443 are open (`ufw status`). For a custom domain, run `/root/wp_setup_domain.sh` after DNS points to this Droplet.
+
+### Can't Access WordPress
+
+1. Check Caddy status:
+
+   ```bash
+   systemctl status caddy
+   ```
+
+2. Check Caddy logs:
+
+   ```bash
+   journalctl -u caddy -f
+   ```
+
+3. Verify PHP-FPM:
+
+   ```bash
+   systemctl status php8.3-fpm
+   ```
+
+4. Verify firewall rules:
+
+   ```bash
+   ufw status
+   ```
+
+### Can't Access phpMyAdmin
+
+1. Confirm setup has finished and HTTPS works for the WordPress site
+2. Open `https://your-droplet-ip/phpmyadmin/` (trailing slash)
+3. Verify credentials in `/root/.digitalocean_password`
+4. If using a Managed Database, confirm Trusted Sources includes this Droplet and that `/usr/share/phpmyadmin/config.inc.php` points at the managed host
+
+### Database Connection Errors
+
+**If using local MySQL:**
+
+1. Check MySQL status:
+
+   ```bash
+   systemctl status mysql
+   ```
+
+2. Verify credentials in `/var/www/html/wp-config.php` match those in `/root/.digitalocean_password`
+
+**If using a DigitalOcean Managed Database:**
+
+1. Confirm your Droplet's IP is listed under the database cluster's **Trusted Sources** in the [control panel](https://cloud.digitalocean.com/databases)
+2. Verify connection details in `/var/www/html/wp-config.php` match your Managed Database settings
+3. Test connectivity from the Droplet:
+
+   ```bash
+   mysqladmin ping -h "$(grep DB_HOST /var/www/html/wp-config.php | cut -d"'" -f4 | cut -d: -f1)" --silent
+   ```
+
+## File Locations
+
+- **WordPress Root**: `/var/www/html/`
+- **phpMyAdmin**: `/usr/share/phpmyadmin/`
+- **phpMyAdmin config**: `/usr/share/phpmyadmin/config.inc.php`
+- **Caddy config**: `/etc/caddy/Caddyfile`
+- **SSL certificates**: `/var/lib/caddy/.local/share/caddy/certificates/`
+- **MySQL Data**: `/var/lib/mysql/` (local MySQL only)
+- **PHP (FPM + CLI)**: `/etc/php/8.3/`
+
+## Additional Resources
+
+- [WordPress Documentation](https://wordpress.org/support/)
+- [phpMyAdmin Documentation](https://docs.phpmyadmin.net/)
+- [DigitalOcean WordPress Tutorials](https://www.digitalocean.com/community/tags/wordpress)
+- [Caddy Documentation](https://caddyserver.com/docs/)
+- [WP-CLI Documentation](https://wp-cli.org/)
+
+## Support
+
+For issues specific to this 1-Click deployment, please visit the [DigitalOcean Community](https://www.digitalocean.com/community/).
+
+For general WordPress questions, visit the [WordPress Support Forums](https://wordpress.org/support/forums/).
+
+---
+
+**Note**: The first-login setup uses Let's Encrypt with a short-lived certificate profile for access by IP. After you add a custom domain with `/root/wp_setup_domain.sh`, Caddy continues to manage issuance and renewal automatically.

--- a/wordpress-phpmyadmin-24-04/files/etc/caddy/Caddyfile.domain
+++ b/wordpress-phpmyadmin-24-04/files/etc/caddy/Caddyfile.domain
@@ -1,0 +1,44 @@
+{
+    email PLACEHOLDER_EMAIL
+}
+
+# HTTP redirect to HTTPS
+http://PLACEHOLDER_DOMAIN {
+    redir https://{host}{uri} permanent
+}
+
+# HTTPS with standard Let's Encrypt certificate for the custom domain
+https://PLACEHOLDER_DOMAIN {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+        }
+    }
+
+    encode gzip
+
+    # phpMyAdmin (must be before WordPress handle)
+    redir /phpmyadmin /phpmyadmin/ 308
+    handle /phpmyadmin/* {
+        root * /usr/share
+        php_fastcgi unix//run/php/php8.3-fpm.sock
+        file_server
+    }
+
+    handle {
+        root * /var/www/html
+        php_fastcgi unix//run/php/php8.3-fpm.sock
+        file_server
+
+        # WordPress permalinks
+        try_files {path} {path}/ /index.php?{query}
+
+        # Deny access to sensitive files
+        @blocked {
+            path */xmlrpc.php
+            path */.git/*
+            path */wp-config.php
+        }
+        respond @blocked 403
+    }
+}

--- a/wordpress-phpmyadmin-24-04/files/etc/caddy/Caddyfile.ip
+++ b/wordpress-phpmyadmin-24-04/files/etc/caddy/Caddyfile.ip
@@ -1,0 +1,45 @@
+{
+    email PLACEHOLDER_EMAIL
+}
+
+# HTTP redirect to HTTPS
+http://PLACEHOLDER_IP {
+    redir https://{host}{uri} permanent
+}
+
+# HTTPS with Let's Encrypt short-lived IP certificates
+https://PLACEHOLDER_IP {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+
+    encode gzip
+
+    # phpMyAdmin (must be before WordPress handle)
+    redir /phpmyadmin /phpmyadmin/ 308
+    handle /phpmyadmin/* {
+        root * /usr/share
+        php_fastcgi unix//run/php/php8.3-fpm.sock
+        file_server
+    }
+
+    handle {
+        root * /var/www/html
+        php_fastcgi unix//run/php/php8.3-fpm.sock
+        file_server
+
+        # WordPress permalinks
+        try_files {path} {path}/ /index.php?{query}
+
+        # Deny access to sensitive files
+        @blocked {
+            path */xmlrpc.php
+            path */.git/*
+            path */wp-config.php
+        }
+        respond @blocked 403
+    }
+}

--- a/wordpress-phpmyadmin-24-04/files/etc/update-motd.d/99-one-click
+++ b/wordpress-phpmyadmin-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,72 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+myip=$(hostname -I | awk '{print$1}')
+
+pma_user="admin"
+admin_mysql_pass="(see /root/.digitalocean_password)"
+if [ -f /root/.digitalocean_password ]; then
+  # shellcheck disable=SC1091
+  . /root/.digitalocean_password
+  if [ "${using_dbaas:-}" = "true" ]; then
+    pma_user="${phpmyadmin_user}"
+  else
+    pma_user="admin"
+  fi
+fi
+
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's One-Click WordPress + phpMyAdmin Droplet.
+To keep this Droplet secure, the UFW firewall is enabled.
+All ports are BLOCKED except 22 (SSH), 80 (HTTP), and 443 (HTTPS).
+
+🚀 AUTOMATIC SETUP WITH SSL:
+ * The automatic setup wizard will launch now (first login only)
+ * Your WordPress site will be secured with HTTPS using Caddy
+ * Uses Let's Encrypt short-lived certificates (supports IP addresses!)
+ * phpMyAdmin is available at /phpmyadmin after setup
+ * Setup takes ~2-3 minutes to complete
+
+In a web browser, you can view:
+ * Setup pending page (before setup): http://$myip
+ * Your WordPress site (after setup): https://$myip
+ * WordPress admin panel: https://$myip/wp-admin
+ * phpMyAdmin: https://$myip/phpmyadmin
+   Username: $pma_user
+   Password: $admin_mysql_pass
+   (If you selected Add a Database, these values are updated after setup)
+
+On the server:
+ * WordPress root: /var/www/html
+ * phpMyAdmin: /usr/share/phpmyadmin
+ * Caddy config: /etc/caddy/Caddyfile
+ * SSL certificates: /var/lib/caddy/.local/share/caddy/certificates/
+ * Database credentials: /root/.digitalocean_password
+   (If using DBaaS before setup: /root/.digitalocean_dbaas_credentials)
+ * WP-Fail2Ban: installed on first-login setup (wp plugin under /var/www/html)
+
+🔧 USEFUL COMMANDS:
+ * Add a custom domain: /root/wp_setup_domain.sh
+ * WordPress CLI: wp --allow-root --path="/var/www/html" [command]
+ * Reload Caddy config: systemctl reload caddy
+ * View Caddy logs: journalctl -u caddy -f
+ * View PHP logs: tail -f /var/log/php8.3-fpm.log
+
+📚 DOCUMENTATION:
+ * WordPress docs: https://wordpress.org/documentation/
+ * phpMyAdmin docs: https://docs.phpmyadmin.net/
+ * DigitalOcean Community: https://www.digitalocean.com/community/
+
+IMPORTANT:
+ * SSL certificates auto-renew every ~6 days (short-lived certificates)
+ * Caddy handles renewals automatically in the background
+ * For security, xmlrpc endpoint is blocked by default
+ * Restrict phpMyAdmin access (VPN, firewall, or strong passwords) in production
+ * You can switch to a custom domain anytime using /root/wp_setup_domain.sh
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/wordpress-phpmyadmin-24-04/files/root/wp_setup.sh
+++ b/wordpress-phpmyadmin-24-04/files/root/wp_setup.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+#
+# WordPress + phpMyAdmin automatic setup script with IP-based SSL
+#
+# Configures Caddy (HTTPS) and PHP-FPM with WordPress using a Let's Encrypt
+# certificate for the server's public IP. Serves phpMyAdmin at /phpmyadmin.
+
+set -e  # Exit on error
+
+echo "================================================================"
+echo "WordPress + phpMyAdmin Automatic Setup"
+echo "================================================================"
+echo ""
+echo "This script will automatically configure your WordPress installation"
+echo "with HTTPS using Let's Encrypt SSL certificate for your server's IP."
+echo ""
+
+# Enable WordPress on first login
+if [[ -d /var/www/wordpress ]]
+then
+  mv /var/www/html /var/www/html.old 2>/dev/null || true
+  mv /var/www/wordpress /var/www/html
+fi
+chown -Rf www-data:www-data /var/www/html
+
+# if applicable, configure wordpress (and phpMyAdmin) to use mysql dbaas
+if [ -f "/root/.digitalocean_dbaas_credentials" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)" = "mysql" ]; then
+  # grab all the data from the password file
+  username=$(sed -n "s/^db_username=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  password=$(sed -n "s/^db_password=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  host=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  port=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+  database=$(sed -n "s/^db_database=\"\(.*\)\"$/\1/p" /root/.digitalocean_dbaas_credentials)
+
+  # update the wp-config.php with stored credentials
+  sed -i "s/'DB_USER', '.*'/'DB_USER', '$username'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_NAME', '.*'/'DB_NAME', '$database'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_PASSWORD', '.*'/'DB_PASSWORD', '$password'/g" /var/www/html/wp-config.php;
+  sed -i "s/'DB_HOST', '.*'/'DB_HOST', '$host:$port'/g" /var/www/html/wp-config.php;
+
+  # add required SSL flag
+  cat >> /var/www/html/wp-config.php <<EOM
+/** Connect to MySQL cluster over SSL **/
+define( 'MYSQL_CLIENT_FLAGS', MYSQLI_CLIENT_SSL );
+EOM
+
+  # Point phpMyAdmin at the Managed Database (local MySQL will be disabled)
+  cat >> /usr/share/phpmyadmin/config.inc.php <<EOM
+
+/* DigitalOcean Managed Database */
+\$cfg['Servers'][1]['host'] = '$host';
+\$cfg['Servers'][1]['port'] = '$port';
+\$cfg['Servers'][1]['ssl'] = true;
+\$cfg['Servers'][1]['ssl_ca'] = '/etc/ssl/certs/ca-certificates.crt';
+EOM
+
+  # Persist DBaaS login details for MOTD / operators (password file is the source of truth)
+  cat > /root/.digitalocean_password <<EOM
+using_dbaas="true"
+phpmyadmin_user="${username}"
+admin_mysql_pass="${password}"
+dbaas_host="${host}"
+dbaas_port="${port}"
+dbaas_database="${database}"
+EOM
+
+  # wait for db to become available
+  echo -e "\nWaiting for your database to become available (this may take a few minutes)"
+  while ! mysqladmin ping -h "$host" -P "$port" --silent; do
+      printf .
+      sleep 2
+  done
+  echo -e "\nDatabase available!\n"
+
+  # cleanup
+  unset username password host port database
+  rm -f /root/.digitalocean_dbaas_credentials
+
+  # disable the local MySQL instance
+  systemctl stop mysql.service
+  systemctl disable mysql.service
+fi
+
+echo "Step 1: Detecting server IP address..."
+echo "----------------------------------------"
+
+# Get the server's IP address
+server_ip=$(hostname -I | awk '{print$1}')
+
+if [ -z "$server_ip" ]; then
+  echo "ERROR: Could not automatically detect server IP address."
+  echo "Please manually run: /root/wp_setup_domain.sh for domain-based setup"
+  exit 1
+fi
+
+echo "✓ Detected IP address: $server_ip"
+echo ""
+
+echo "Step 2: WordPress Admin Account Setup"
+echo "----------------------------------------"
+
+function wordpress_admin_account(){
+
+  while [ -z "$email" ]
+  do
+    read -p "Your Email Address: " email
+  done
+
+  while [ -z "$username" ]
+  do
+    read -p "Admin Username: " username
+  done
+
+  while [ -z "$pass" ]
+  do
+    read -s -p "Admin Password: " pass
+    echo ""
+  done
+
+  while [ -z "$title" ]
+  do
+    read -p "Site Title: " title
+  done
+}
+
+wordpress_admin_account
+
+echo ""
+while true
+do
+    read -p "Is the information correct? [Y/n] " confirmation
+    confirmation=${confirmation,,}
+    if [[ "${confirmation}" =~ ^(yes|y)$ ]] || [ -z $confirmation ]
+    then
+      break
+    else
+      unset email username pass title confirmation
+      echo ""
+      wordpress_admin_account
+      echo ""
+    fi
+done
+
+echo ""
+echo "Step 3: Installing WP-CLI..."
+echo "----------------------------------------"
+mkdir -p /usr/local/lib
+wget -q https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O /usr/local/lib/wp-cli.phar 2>/dev/null
+chmod +x /usr/local/lib/wp-cli.phar
+cat > /usr/bin/wp <<'EOF'
+#!/bin/sh
+exec /usr/local/lib/wp-cli.phar --allow-root "$@"
+EOF
+chmod +x /usr/bin/wp
+echo "✓ WP-CLI installed"
+echo ""
+
+echo "Step 4: Configuring WordPress..."
+echo "----------------------------------------"
+wp core install --allow-root --path="/var/www/html" --title="$title" --url="http://$server_ip" --admin_email="$email" --admin_password="$pass" --admin_user="$username" 2>/dev/null
+echo "✓ WordPress configured"
+echo ""
+
+echo "Step 5: Configuring Caddy with SSL..."
+echo "----------------------------------------"
+echo "Setting up automatic HTTPS with short-lived certificates for $server_ip"
+echo ""
+
+# Install shipped Caddyfile template (placeholders → IP + email)
+cp /etc/caddy/Caddyfile.ip /etc/caddy/Caddyfile
+sed -i "s|PLACEHOLDER_IP|${server_ip}|g; s|PLACEHOLDER_EMAIL|${email}|g" /etc/caddy/Caddyfile
+
+# Reload Caddy
+systemctl enable caddy 2>/dev/null
+systemctl restart caddy
+
+echo "✓ Caddy configured with automatic HTTPS"
+echo ""
+echo "Step 6: Installing security plugins..."
+echo "----------------------------------------"
+sleep 3
+
+# Update WordPress URLs to use HTTPS
+wp --allow-root --path="/var/www/html" option update home "https://$server_ip" 2>/dev/null
+wp --allow-root --path="/var/www/html" option update siteurl "https://$server_ip" 2>/dev/null
+
+wp plugin install wp-fail2ban --allow-root --path="/var/www/html" 2>/dev/null
+wp plugin activate wp-fail2ban --allow-root --path="/var/www/html" 2>/dev/null
+echo "✓ Security plugins installed"
+echo ""
+
+chown -Rf www-data:www-data /var/www/
+cp /etc/skel/.bashrc /root
+
+# Load phpMyAdmin credentials for the completion message
+# shellcheck disable=SC1091
+. /root/.digitalocean_password
+if [ "${using_dbaas:-}" = "true" ]; then
+  pma_user="${phpmyadmin_user}"
+else
+  pma_user="admin"
+fi
+
+echo ""
+echo "================================================================"
+echo "🎉 WordPress + phpMyAdmin Installation Complete!"
+echo "================================================================"
+echo ""
+echo "Your WordPress site is now accessible at:"
+echo ""
+echo "    👉  https://$server_ip"
+echo ""
+echo "Admin login:"
+echo "    Username: $username"
+echo "    Email: $email"
+echo ""
+echo "phpMyAdmin:"
+echo "    URL: https://$server_ip/phpmyadmin"
+echo "    Username: $pma_user"
+echo "    Password: stored in /root/.digitalocean_password (admin_mysql_pass)"
+echo ""
+echo "================================================================"
+echo ""
+echo "📝 Additional Information:"
+echo ""
+echo "• SSL: Short-lived certificates (auto-renew every ~6 days)"
+echo "• Web server: Caddy (automatic HTTPS)"
+echo "• Add custom domain: /root/wp_setup_domain.sh"
+echo ""
+echo "================================================================"
+echo ""

--- a/wordpress-phpmyadmin-24-04/files/root/wp_setup_domain.sh
+++ b/wordpress-phpmyadmin-24-04/files/root/wp_setup_domain.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# WordPress + phpMyAdmin domain configuration script
+#
+# This script will configure Caddy with a custom domain
+# and obtain a standard Let's Encrypt SSL certificate
+
+set -euo pipefail
+
+echo "================================================================"
+echo "WordPress + phpMyAdmin Domain Setup"
+echo "================================================================"
+echo ""
+echo "This script will configure your WordPress site and phpMyAdmin with a"
+echo "custom domain and obtain a Let's Encrypt SSL certificate."
+echo ""
+echo "⚠️  IMPORTANT: Your domain must already be pointed to this server's IP"
+echo ""
+
+# Get current IP
+current_ip=$(hostname -I | awk '{print$1}')
+echo "This server's IP address: $current_ip"
+echo ""
+
+# Prompt for domain
+while true; do
+  read -p "Enter your domain name (e.g., example.com or blog.example.com): " domain
+  if [ -z "$domain" ]; then
+    echo "Domain cannot be empty."
+  else
+    break
+  fi
+done
+
+# Prompt for email
+read -p "Enter your email for Let's Encrypt notifications (optional): " email
+
+echo ""
+echo "Configuring Caddy for domain: $domain"
+echo "----------------------------------------"
+
+# Install shipped domain Caddyfile template
+cp /etc/caddy/Caddyfile.domain /etc/caddy/Caddyfile
+sed -i "s|PLACEHOLDER_DOMAIN|${domain}|g" /etc/caddy/Caddyfile
+if [ -n "$email" ]; then
+  sed -i "s|PLACEHOLDER_EMAIL|${email}|g" /etc/caddy/Caddyfile
+else
+  # Remove global options block when no email was provided
+  sed -i '/^{$/,/^}$/d' /etc/caddy/Caddyfile
+fi
+
+# Reload Caddy
+systemctl reload caddy
+sleep 3
+
+echo "✓ Caddy configured"
+echo ""
+
+# Update WordPress URLs
+echo "Updating WordPress URLs..."
+wp --allow-root --path="/var/www/html" option update home "https://$domain" 2>/dev/null
+wp --allow-root --path="/var/www/html" option update siteurl "https://$domain" 2>/dev/null
+echo "✓ WordPress URLs updated"
+echo ""
+
+echo "================================================================"
+echo "🎉 Domain Setup Complete!"
+echo "================================================================"
+echo ""
+echo "Your WordPress site is now accessible at:"
+echo ""
+echo "    👉  https://$domain"
+echo ""
+echo "Admin panel: https://$domain/wp-admin"
+echo "phpMyAdmin:  https://$domain/phpmyadmin"
+echo ""
+echo "================================================================"
+echo ""
+echo "📝 Notes:"
+echo ""
+echo "• SSL certificate: Standard Let's Encrypt (90-day validity)"
+echo "• Auto-renewal: Caddy handles this automatically"
+echo "• Previous IP access: Still works but redirects to domain"
+echo ""
+echo "================================================================"
+echo ""

--- a/wordpress-phpmyadmin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/wordpress-phpmyadmin-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+#Generate Mysql root password and per-Droplet phpMyAdmin cookie secret.
+root_mysql_pass=$(openssl rand -hex 24)
+wordpress_mysql_pass=$(openssl rand -hex 24)
+admin_mysql_pass=$(openssl rand -hex 24)
+debian_sys_maint_mysql_pass=$(openssl rand -hex 24)
+blowfish_secret=$(openssl rand -hex 32)
+
+# Unique phpMyAdmin blowfish_secret per Droplet (must not be baked into the snapshot)
+if grep -q "blowfish_secret" /usr/share/phpmyadmin/config.inc.php; then
+  sed -i "s|\(\$cfg\['blowfish_secret'\] = '\)[^']*';|\1${blowfish_secret}';|" \
+    /usr/share/phpmyadmin/config.inc.php
+else
+  echo "\$cfg['blowfish_secret'] = '${blowfish_secret}';" >> /usr/share/phpmyadmin/config.inc.php
+fi
+unset blowfish_secret
+
+# Don't enable WordPress until first login
+cat >> /root/.bashrc <<EOM
+chmod +x /root/wp_setup.sh
+chmod +x /root/wp_setup_domain.sh
+/root/wp_setup.sh
+EOM
+
+# Save the passwords
+cat > /root/.digitalocean_password <<EOM
+root_mysql_pass="${root_mysql_pass}"
+wordpress_mysql_pass="${wordpress_mysql_pass}"
+admin_mysql_pass="${admin_mysql_pass}"
+EOM
+
+# there are no available memory for WP on tiny droplets sometimes. Simple fix: turn off mysql 
+# perfomance schema for these droplets
+dropletMemory=$(LANG=C free|awk '/^Mem:/{print $2}')
+if [ $dropletMemory -lt 2000000 ]; then
+	echo "[mysqld]
+performance_schema=off" > /etc/mysql/mysql.conf.d/performance.cnf
+	systemctl restart mysql
+fi
+
+# Set up Postfix defaults
+hostname=$(hostname)
+sed -i "s/myhostname \= wp-build/myhostname = $hostname/g" /etc/postfix/main.cf;
+sed -i "s/inet_interfaces = all/inet_interfaces = loopback-only/g" /etc/postfix/main.cf;
+systemctl restart postfix &
+
+mysqladmin -u root -h localhost create wordpress
+mysqladmin -u root -h localhost password ${root_mysql_pass}
+
+# populate the wordpress config file
+cp /var/www/wordpress/wp-config-sample.php /var/www/wordpress/wp-config.php
+sed -e "s/'DB_NAME', 'database_name_here'/'DB_NAME', 'wordpress'/g" \
+    -e "s/'DB_USER', 'username_here'/'DB_USER', 'wordpress'/g" \
+    -e "s/'DB_PASSWORD', 'password_here'/'DB_PASSWORD', '${wordpress_mysql_pass}'/g" \
+    -i /var/www/wordpress/wp-config.php
+
+chown -Rf www-data:www-data /var/www/wordpress
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "CREATE USER 'wordpress'@'localhost' IDENTIFIED BY '${wordpress_mysql_pass}'"
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "GRANT ALL PRIVILEGES ON wordpress.* TO wordpress@localhost"
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "GRANT RELOAD,PROCESS ON *.* TO wordpress@localhost"
+
+# phpMyAdmin login user (full privileges for database management UI)
+mysql -uroot -p${root_mysql_pass} \
+      -e "CREATE USER 'admin'@'localhost' IDENTIFIED BY '${admin_mysql_pass}'"
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "GRANT ALL PRIVILEGES ON *.* TO 'admin'@'localhost' WITH GRANT OPTION"
+
+mysql -uroot -p${root_mysql_pass} \
+      -e "ALTER USER 'debian-sys-maint'@'localhost' IDENTIFIED BY '${debian_sys_maint_mysql_pass}'"
+
+MYSQL_ROOT_PASSWORD=${root_mysql_pass}
+
+SECURE_MYSQL=$(expect -c "
+set timeout 10
+spawn mysql_secure_installation
+expect \"Enter current password for root (enter for none):\"
+send \"$MYSQL_ROOT_PASSWORD\r\"
+expect \"Change the root password?\"
+send \"n\r\"
+expect \"Remove anonymous users?\"
+send \"y\r\"
+expect \"Disallow root login remotely?\"
+send \"y\r\"
+expect \"Remove test database and access to it?\"
+send \"y\r\"
+expect \"Reload privilege tables now?\"
+send \"y\r\"
+expect eof
+")
+
+cat > /etc/mysql/debian.cnf <<EOM
+# Automatically generated for Debian scripts. DO NOT TOUCH!
+[client]
+host     = localhost
+user     = debian-sys-maint
+password = ${debian_sys_maint_mysql_pass}
+socket   = /var/run/mysqld/mysqld.sock
+[mysql_upgrade]
+host     = localhost
+user     = debian-sys-maint
+password = ${debian_sys_maint_mysql_pass}
+socket   = /var/run/mysqld/mysqld.sock
+EOM
+
+# WordPress Salts
+for i in `seq 1 8`
+do
+    wp_salt=$(</dev/urandom tr -dc 'a-zA-Z0-9!@#$%^&*()\-_ []{}<>~`+=,.;:/?|' | head -c 64 | sed -e 's/[\/&]/\\&/g')
+    sed -e "0,/put your unique phrase here/s/put your unique phrase here/${wp_salt}/" \
+        -i /var/www/wordpress/wp-config.php;
+done
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+systemctl restart ssh
+
+# Configure Caddy to show setup-pending page until first login setup completes
+cp /etc/caddy/Caddyfile.setup-pending /etc/caddy/Caddyfile
+systemctl enable caddy
+systemctl restart caddy

--- a/wordpress-phpmyadmin-24-04/listing.md
+++ b/wordpress-phpmyadmin-24-04/listing.md
@@ -1,0 +1,48 @@
+# WordPress + phpMyAdmin
+
+A DigitalOcean 1-Click Droplet running **WordPress** with **phpMyAdmin** on **Ubuntu 24.04 LTS**, using **Caddy** (automatic HTTPS), **PHP 8.3 FPM**, and **MySQL**. Optionally pair the Droplet with a DigitalOcean Managed MySQL database (**Add a Database**); first-login setup configures both WordPress and phpMyAdmin for DBaaS automatically.
+
+## System Components
+
+- Ubuntu 24.04 LTS
+- WordPress (latest stable)
+- phpMyAdmin (latest stable, served at `/phpmyadmin`)
+- Caddy (HTTP/HTTPS, Let's Encrypt)
+- PHP 8.3 FPM
+- MySQL 8.4 (local; disabled when Managed Database is used)
+- WP-CLI, WP-Fail2Ban, fail2ban, Postfix (loopback), UFW
+
+## Droplet size
+
+Minimum **2 GB RAM** (MySQL 8.4, PHP-FPM, Caddy, WordPress, and phpMyAdmin on one Droplet). For production traffic or heavier plugin sets, **4 GB+** is recommended.
+
+## Getting Started
+
+1. Create a Droplet from this image.
+2. Optionally select **Add a Database** for Managed MySQL, and add the Droplet IP to the cluster **Trusted Sources**.
+3. Visit `http://YOUR_IP` for the setup-pending page, then SSH in as **root** to finish automatic HTTPS setup.
+4. Open WordPress at `https://YOUR_IP` and phpMyAdmin at `https://YOUR_IP/phpmyadmin`.
+5. Local phpMyAdmin login: user `admin`, password in `/root/.digitalocean_password` (`admin_mysql_pass`). With Managed Database, use the credentials written to that same file after setup.
+6. Optional custom domain: `/root/wp_setup_domain.sh`
+
+## Service Management
+
+| Action | Command |
+|--------|---------|
+| Caddy status | `systemctl status caddy` |
+| Caddy start | `systemctl start caddy` |
+| Caddy stop | `systemctl stop caddy` |
+| Caddy restart | `systemctl restart caddy` |
+| PHP-FPM status | `systemctl status php8.3-fpm` |
+| PHP-FPM restart | `systemctl restart php8.3-fpm` |
+| MySQL status (local) | `systemctl status mysql` |
+| MySQL start | `systemctl start mysql` |
+| MySQL stop | `systemctl stop mysql` |
+| MySQL restart | `systemctl restart mysql` |
+| fail2ban status | `systemctl status fail2ban` |
+| Update WordPress | `wp core update --allow-root --path=/var/www/html` |
+| Update plugins | `wp plugin update --all --allow-root --path=/var/www/html` |
+| Update phpMyAdmin | Re-download from [phpMyAdmin releases](https://www.phpmyadmin.net/downloads/) into `/usr/share/phpmyadmin` (preserve `config.inc.php`) |
+| System packages | `apt update && apt upgrade` |
+
+WordPress CLI: `wp --allow-root --path=/var/www/html [command]`

--- a/wordpress-phpmyadmin-24-04/scripts/011-wordpress.sh
+++ b/wordpress-phpmyadmin-24-04/scripts/011-wordpress.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -e
+
+# Download the latest stable WordPress release at build time
+wget -q https://wordpress.org/wordpress-latest.tar.gz -O /tmp/wordpress.tar.gz
+
+mkdir -p /var/www
+tar -C /var/www -xzf /tmp/wordpress.tar.gz
+rm -f /tmp/wordpress.tar.gz
+
+# WP-CLI for first-login setup (wrapper always passes --allow-root; Packer/Droplet run as root)
+mkdir -p /usr/local/lib
+wget -q https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O /usr/local/lib/wp-cli.phar
+chmod +x /usr/local/lib/wp-cli.phar
+cat > /usr/bin/wp <<'EOF'
+#!/bin/sh
+exec /usr/local/lib/wp-cli.phar --allow-root "$@"
+EOF
+chmod +x /usr/bin/wp
+
+# Do not run `wp core update` here: wordpress-latest.tar.gz is already the current
+# stable release, and wp-config.php is created with secrets in 001_onboot.
+
+wget -q https://downloads.wordpress.org/plugin/wp-fail2ban.latest-stable.zip -O /tmp/wp-fail2ban.zip
+unzip -q /tmp/wp-fail2ban.zip -d /tmp/
+
+# install the fail2ban bits (plugin itself installed in first-login script)
+mkdir -p /etc/fail2ban/filter.d
+cp -au /tmp/wp-fail2ban/filters.d/* /etc/fail2ban/filter.d
+rm -rf /tmp/wp-fail2ban.zip /tmp/wp-fail2ban

--- a/wordpress-phpmyadmin-24-04/scripts/013-phpmyadmin.sh
+++ b/wordpress-phpmyadmin-24-04/scripts/013-phpmyadmin.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+# Install latest phpMyAdmin from upstream (same pattern as phpmyadmin-24-04).
+# No Apache package — WordPress uses Caddy + PHP-FPM.
+wget -q -O /tmp/phpMyAdmin-latest-all-languages.tar.gz \
+  https://www.phpmyadmin.net/downloads/phpMyAdmin-latest-all-languages.tar.gz
+
+mkdir -p /tmp/phpmyadmin-extract /usr/share/phpmyadmin
+tar xzf /tmp/phpMyAdmin-latest-all-languages.tar.gz -C /tmp/phpmyadmin-extract
+cp -a /tmp/phpmyadmin-extract/phpMyAdmin-*-all-languages/. /usr/share/phpmyadmin/
+rm -rf /tmp/phpMyAdmin-latest-all-languages.tar.gz /tmp/phpmyadmin-extract
+
+# Permissions: broad tree first, then lock down tmp (order matters)
+chmod -R 755 /usr/share/phpmyadmin
+mkdir -p /usr/share/phpmyadmin/tmp
+chown -R www-data:www-data /usr/share/phpmyadmin/tmp
+chmod 700 /usr/share/phpmyadmin/tmp
+
+cp /usr/share/phpmyadmin/config.sample.inc.php /usr/share/phpmyadmin/config.inc.php
+
+# Non-secret defaults only — blowfish_secret is set per Droplet in 001_onboot
+cat >> /usr/share/phpmyadmin/config.inc.php <<'EOM'
+
+/* DigitalOcean WordPress + phpMyAdmin 1-Click */
+$cfg['TempDir'] = '/usr/share/phpmyadmin/tmp';
+$cfg['PmaAbsoluteUri'] = '/phpmyadmin/';
+EOM
+
+systemctl enable fail2ban
+systemctl start fail2ban
+
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+chmod +x /etc/update-motd.d/99-one-click
+chmod +x /root/wp_setup.sh
+chmod +x /root/wp_setup_domain.sh

--- a/wordpress-phpmyadmin-24-04/scripts/020-application-tag.sh
+++ b/wordpress-phpmyadmin-24-04/scripts/020-application-tag.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+################################
+## PART: Write the application tag
+##
+## vi: syntax=sh expandtab ts=4
+
+build_date=$(date +%Y-%m-%d)
+distro="$(lsb_release -s  -i)"
+distro_release="$(lsb_release -s  -r)"
+distro_codename="$(lsb_release -s -c)"
+distro_arch="$(uname -m)"
+
+# Read version from core (no wp-config.php at build time — secrets land in 001_onboot)
+if [ -f /var/www/wordpress/wp-includes/version.php ]; then
+  application_version=$(sed -n "s/.*\$wp_version = '\\([^']*\\)'.*/\\1/p" \
+    /var/www/wordpress/wp-includes/version.php | head -1)
+elif [ -x /usr/bin/wp ] && [ -d /var/www/wordpress ]; then
+  application_version=$(wp core version --allow-root --path=/var/www/wordpress 2>/dev/null || true)
+fi
+
+phpmyadmin_version=""
+if [ -f /usr/share/phpmyadmin/libraries/classes/Version.php ]; then
+  phpmyadmin_version=$(sed -n "s/.*public const VERSION = '\\([^']*\\)'.*/\\1/p" \
+    /usr/share/phpmyadmin/libraries/classes/Version.php | head -1)
+fi
+
+cat >> /var/lib/digitalocean/application.info <<EOM
+application_name="${application_name}"
+build_date="${build_date}"
+distro="${distro}"
+distro_release="${distro_release}"
+distro_codename="${distro_codename}"
+distro_arch="${distro_arch}"
+application_version="${application_version}"
+phpmyadmin_version="${phpmyadmin_version}"
+EOM

--- a/wordpress-phpmyadmin-24-04/template.json
+++ b/wordpress-phpmyadmin-24-04/template.json
@@ -1,0 +1,104 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "wordpress-phpmyadmin-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "expect fail2ban mysql-server php8.3-fpm php8.3 php8.3-apcu php8.3-bz2 php8.3-curl php8.3-gd php8.3-gmp php8.3-intl php8.3-mbstring php8.3-mysql php8.3-pspell php8.3-soap php8.3-tidy php8.3-xml php8.3-xmlrpc php8.3-xsl php8.3-zip postfix software-properties-common unzip",
+    "application_name": "WordPress + phpMyAdmin",
+    "application_version": ""
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-2gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-24-04/files/root/",
+      "destination": "/root/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-phpmyadmin-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-phpmyadmin-24-04/files/root/",
+      "destination": "/root/"
+    },
+    {
+      "type": "file",
+      "source": "wordpress-phpmyadmin-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "add-apt-repository -y ppa:ondrej/php",
+        "wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.36-1_all.deb",
+        "dpkg -i mysql-apt-config_0.8.36-1_all.deb",
+        "echo 'deb [arch=amd64 trusted=yes] http://repo.mysql.com/apt/ubuntu/ noble mysql-apt-config mysql-8.4' | sudo tee /etc/apt/sources.list.d/mysql.list",
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "wordpress-24-04/scripts/010-php.sh",
+        "wordpress-phpmyadmin-24-04/scripts/011-wordpress.sh",
+        "wordpress-24-04/scripts/012-caddy.sh",
+        "wordpress-phpmyadmin-24-04/scripts/013-phpmyadmin.sh",
+        "common/scripts/014-ufw-http.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "wordpress-phpmyadmin-24-04/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a new **WordPress + phpMyAdmin** Marketplace 1-Click for Ubuntu 24.04 (`wordpress-phpmyadmin-24-04/`).
- Combines WordPress (Caddy + PHP 8.3 FPM + MySQL) with phpMyAdmin at `/phpmyadmin` on the same Droplet.

## Test plan
- [ ] `packer build wordpress-phpmyadmin-24-04/template.json` succeeds
- [ ] Create Droplet from snapshot (min 2 GB RAM)
- [ ] Before SSH: `http://DROPLET_IP` shows setup-pending page
- [ ] First SSH as root runs `/root/wp_setup.sh`; complete admin prompts
- [ ] After setup: `https://DROPLET_IP` loads WordPress; `/wp-admin` works with chosen credentials
- [ ] `https://DROPLET_IP/phpmyadmin` works with `admin` / `admin_mysql_pass` from `/root/.digitalocean_password`

## Link
https://do-internal.atlassian.net/browse/MP-8464