### PR TITLE
MP-8489: allow supabase postgre dbaas

### DIFF
--- a/supabase-24-04/README.md
+++ b/supabase-24-04/README.md
@@ -68,6 +68,10 @@ docker compose -f docker-compose.yml -f docker-compose.dbaas.yml up -d
 
 DigitalOcean Managed Postgres allows about **25 connections per 1GB RAM** (minus 3 reserved for maintenance). The Supabase stack opens many pools (Supavisor, PostgREST, Auth, Storage, Realtime, Logflare). On first boot with DBaaS, this 1-Click lowers pool sizes so a small Marketplace DB can start. Prefer a **2GB+** Managed Database for production; if you see `remaining connection slots are reserved for roles with the SUPERUSER attribute`, resize the DB or lower `POOLER_DEFAULT_POOL_SIZE` in `/srv/supabase/supabase/docker/.env` and restart Compose.
 
+### TLS to Managed Postgres
+
+Compose connection URLs are patched with `sslmode=require`. Auth/Realtime/Meta/Analytics use service SSL flags (`GOTRUE_DB_SSLMODE`, `DB_SSL`, `PGSSLMODE`). Storage relies on the same `DATABASE_URL` SSL query param (and `PGSSLMODE=require` in the DBaaS overlay) — **not** `NODE_TLS_REJECT_UNAUTHORIZED=0`, which would disable TLS verification process-wide for the Storage container.
+
 ### Modifying database settings later
 
 - **Managed DB credentials:** `/root/.digitalocean_dbaas_credentials` and `/root/.digitalocean_passwords` (`POSTGRES_*`, `DATABASE_URL`)

--- a/supabase-24-04/README.md
+++ b/supabase-24-04/README.md
@@ -1,12 +1,12 @@
 # Supabase 1-Click
 
-Deploy self-hosted Supabase on Ubuntu 24.04 with Docker Compose and Nginx. Postgres for the Supabase stack runs as the local `db` container. You can optionally attach a DigitalOcean Managed PostgreSQL database during deployment for your own application data.
+Deploy self-hosted Supabase on Ubuntu 24.04 with Docker Compose and Nginx. By default Postgres runs as the local `db` container. When you select **Add a Database** at create time, Supabase is configured to use DigitalOcean Managed PostgreSQL instead.
 
 ## Getting Started
 
 1. Select the Supabase 1-Click from the DigitalOcean Marketplace
 2. Choose a Droplet size and region (2GB RAM minimum recommended)
-3. Optionally select **Add a Database** to provision a Managed PostgreSQL database (see below)
+3. Optionally select **Add a Database** to provision Managed PostgreSQL (see below)
 4. Create the Droplet and SSH in as `root`
 
 On first boot, the Supabase Docker stack starts automatically and Nginx proxies to Kong.
@@ -43,10 +43,9 @@ When you choose this option during Droplet creation, DigitalOcean:
 During first-boot setup, the Droplet automatically:
 
 1. Waits for the PostgreSQL cluster to become available (up to a few minutes)
-2. Saves connection details and a `DATABASE_URL` in `/root/.digitalocean_passwords` and `/etc/environment`
-3. Starts the Supabase stack with its **local** `db` container (unchanged)
-
-The Supabase services are not automatically pointed at Managed Postgres. Supabase requires its specialized Postgres image; use the managed database for your own apps or tooling alongside Supabase.
+2. Points Supabase `.env` / Compose at Managed Postgres (and disables the local `db` container)
+3. Bootstraps Supabase roles and schemas on the managed database (best-effort)
+4. Saves connection details in `/root/.digitalocean_passwords` and `DATABASE_URL` in `/etc/environment`
 
 ### Security: Trusted Sources
 
@@ -58,9 +57,9 @@ Your Droplet is not automatically added to the Managed Database's trusted source
 
 ### Modifying database settings later
 
-- **Managed DB credentials:** `/root/.digitalocean_dbaas_credentials` and `/root/.digitalocean_passwords` (`DATABASE_URL`, `DB_*`)
+- **Managed DB credentials:** `/root/.digitalocean_dbaas_credentials` and `/root/.digitalocean_passwords` (`POSTGRES_*`, `DATABASE_URL`)
 - **Supabase stack env:** `/srv/supabase/supabase/docker/.env`
-- **Password rotation:** If you change managed DB credentials in the control panel, update `/root/.digitalocean_passwords` and `/etc/environment` to match
+- **Password rotation:** If you change managed DB credentials in the control panel, update `/root/.digitalocean_passwords`, `/etc/environment`, and `/srv/supabase/supabase/docker/.env` to match, then restart the stack
 
 ## File Locations
 

--- a/supabase-24-04/README.md
+++ b/supabase-24-04/README.md
@@ -48,13 +48,21 @@ During first-boot setup, the Droplet automatically:
 4. Enables TLS for analytics/auth/storage/realtime (`docker-compose.dbaas.yml`; Logflare SSL runtime is patched at image build and verified on first boot)
 5. Saves connection details in `/root/.digitalocean_passwords` and `DATABASE_URL` in `/etc/environment`
 
+Required roles/schemas (`supabase_admin`, `authenticator`, `auth`/`storage`, `_supabase` / `_analytics` / `_supavisor`, JWT settings) are created with **fail-fast** checks. Optional `webhooks.sql` (needs `pg_net`) is best-effort.
+
+When bumping `application_version` in `template.json`, re-test the DBaaS compose edit (local `db` service removal must keep `vector`) against the new upstream `docker-compose.yml`.
+
 ### Security: Trusted Sources
 
-Your Droplet is not automatically added to the Managed Database's trusted sources. For better security, add your Droplet's public IP address to the database cluster's **Trusted Sources** in the [DigitalOcean control panel](https://cloud.digitalocean.com/databases):
+Your Droplet is not automatically added to the Managed Database's trusted sources. Add your Droplet's public IP under **Settings → Trusted Sources** in the [control panel](https://cloud.digitalocean.com/databases) **before or right after create**.
 
-1. Open your database cluster in the control panel
-2. Go to **Settings** → **Trusted Sources**
-3. Add your Droplet's public IP address
+If the Droplet cannot reach Managed Postgres within ~5 minutes on first boot, DBaaS setup **aborts** (it will not rewire Supabase to an unreachable DB). Check `/var/log/one_click_setup.log`, add Trusted Sources, then re-run:
+
+```bash
+/var/lib/digitalocean/setup-dbaas.sh
+cd /srv/supabase/supabase/docker
+docker compose -f docker-compose.yml -f docker-compose.dbaas.yml up -d
+```
 
 ### Connection limits
 

--- a/supabase-24-04/README.md
+++ b/supabase-24-04/README.md
@@ -1,0 +1,76 @@
+# Supabase 1-Click
+
+Deploy self-hosted Supabase on Ubuntu 24.04 with Docker Compose and Nginx. Postgres for the Supabase stack runs as the local `db` container. You can optionally attach a DigitalOcean Managed PostgreSQL database during deployment for your own application data.
+
+## Getting Started
+
+1. Select the Supabase 1-Click from the DigitalOcean Marketplace
+2. Choose a Droplet size and region (2GB RAM minimum recommended)
+3. Optionally select **Add a Database** to provision a Managed PostgreSQL database (see below)
+4. Create the Droplet and SSH in as `root`
+
+On first boot, the Supabase Docker stack starts automatically and Nginx proxies to Kong.
+
+**Supabase Studio / API:**
+
+- **URL:** `http://your-droplet-ip`
+- **Dashboard username/password:** stored in `/root/.digitalocean_passwords`
+
+## Using a DigitalOcean Managed Database (Optional)
+
+When creating your Supabase Droplet, you can select **Add a Database** to provision a DigitalOcean Managed PostgreSQL database at the same time. Managed databases give you easy backups, connection pools, and metrics.
+
+### Marketplace Vendor Portal (required for predeploy)
+
+**Add a Database** only appears if PostgreSQL is enabled for this 1-Click in the Vendor Portal. Image scripts cannot turn that UI on by themselves.
+
+Before customers can use DBaaS with this app:
+
+1. Open the [Vendor Portal](https://cloud.digitalocean.com/vendorportal)
+2. Edit the Supabase Droplet 1-Click listing
+3. Enable the **PostgreSQL** managed database (predeploy) option
+4. Save and publish/update the listing
+
+Until that is done, droplets will not receive `/root/.digitalocean_dbaas_credentials` and the DBaaS first-boot path will not run.
+
+### What happens when you add a database
+
+When you choose this option during Droplet creation, DigitalOcean:
+
+1. Provisions a Managed PostgreSQL cluster in the same region as your Droplet
+2. Passes connection credentials to your Droplet at first boot in `/root/.digitalocean_dbaas_credentials`
+
+During first-boot setup, the Droplet automatically:
+
+1. Waits for the PostgreSQL cluster to become available (up to a few minutes)
+2. Saves connection details and a `DATABASE_URL` in `/root/.digitalocean_passwords` and `/etc/environment`
+3. Starts the Supabase stack with its **local** `db` container (unchanged)
+
+The Supabase services are not automatically pointed at Managed Postgres. Supabase requires its specialized Postgres image; use the managed database for your own apps or tooling alongside Supabase.
+
+### Security: Trusted Sources
+
+Your Droplet is not automatically added to the Managed Database's trusted sources. For better security, add your Droplet's public IP address to the database cluster's **Trusted Sources** in the [DigitalOcean control panel](https://cloud.digitalocean.com/databases):
+
+1. Open your database cluster in the control panel
+2. Go to **Settings** → **Trusted Sources**
+3. Add your Droplet's public IP address
+
+### Modifying database settings later
+
+- **Managed DB credentials:** `/root/.digitalocean_dbaas_credentials` and `/root/.digitalocean_passwords` (`DATABASE_URL`, `DB_*`)
+- **Supabase stack env:** `/srv/supabase/supabase/docker/.env`
+- **Password rotation:** If you change managed DB credentials in the control panel, update `/root/.digitalocean_passwords` and `/etc/environment` to match
+
+## File Locations
+
+- **Supabase stack:** `/srv/supabase/supabase/docker`
+- **Passwords and keys:** `/root/.digitalocean_passwords`
+- **Managed DB credentials (when used):** `/root/.digitalocean_dbaas_credentials`
+- **SSL / domain setup:** `/var/supabase/supabase-setup.sh`
+- **Setup log:** `/var/log/one_click_setup.log`
+
+## Additional Resources
+
+- Marketplace listing: https://marketplace.digitalocean.com/apps/supabase
+- Supabase self-hosting docs: https://supabase.com/docs/guides/self-hosting/docker

--- a/supabase-24-04/README.md
+++ b/supabase-24-04/README.md
@@ -44,8 +44,9 @@ During first-boot setup, the Droplet automatically:
 
 1. Waits for the PostgreSQL cluster to become available (up to a few minutes)
 2. Points Supabase `.env` / Compose at Managed Postgres (and disables the local `db` container)
-3. Bootstraps Supabase roles and schemas on the managed database (best-effort)
-4. Saves connection details in `/root/.digitalocean_passwords` and `DATABASE_URL` in `/etc/environment`
+3. Bootstraps Supabase roles and schemas on the managed database (`auth`, `storage`, `_supabase`, etc.)
+4. Enables TLS for analytics/auth/storage/realtime (`docker-compose.dbaas.yml`; Logflare SSL runtime is patched at image build and verified on first boot)
+5. Saves connection details in `/root/.digitalocean_passwords` and `DATABASE_URL` in `/etc/environment`
 
 ### Security: Trusted Sources
 
@@ -54,6 +55,10 @@ Your Droplet is not automatically added to the Managed Database's trusted source
 1. Open your database cluster in the control panel
 2. Go to **Settings** → **Trusted Sources**
 3. Add your Droplet's public IP address
+
+### Connection limits
+
+DigitalOcean Managed Postgres allows about **25 connections per 1GB RAM** (minus 3 reserved for maintenance). The Supabase stack opens many pools (Supavisor, PostgREST, Auth, Storage, Realtime, Logflare). On first boot with DBaaS, this 1-Click lowers pool sizes so a small Marketplace DB can start. Prefer a **2GB+** Managed Database for production; if you see `remaining connection slots are reserved for roles with the SUPERUSER attribute`, resize the DB or lower `POOLER_DEFAULT_POOL_SIZE` in `/srv/supabase/supabase/docker/.env` and restart Compose.
 
 ### Modifying database settings later
 

--- a/supabase-24-04/files/etc/update-motd.d/99-one-click
+++ b/supabase-24-04/files/etc/update-motd.d/99-one-click
@@ -7,12 +7,21 @@
 dbaas_text=""
 if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
     . /root/.digitalocean_dbaas_credentials
-    dbaas_text="Supabase is configured to use managed Postgres as its database. Use the following credentials to manage the database:
+    if [ "${SUPABASE_DBAAS}" = "failed" ]; then
+        dbaas_text="Managed Postgres was selected but first-boot DBaaS setup FAILED (often Trusted Sources).
+    Check /var/log/one_click_setup.log, add this Droplet IP under the database Trusted Sources,
+    then re-run:
+      /var/lib/digitalocean/setup-dbaas.sh
+      cd /srv/supabase/supabase/docker && docker compose -f docker-compose.yml -f docker-compose.dbaas.yml up -d
+    Host: ${db_host}  Port: ${db_port}  Database: ${db_database}  User: ${db_username}"
+    else
+        dbaas_text="Supabase is configured to use managed Postgres as its database. Use the following credentials to manage the database:
     Database: ${db_database}
     Host:     ${db_host}
     Port:     ${db_port}
     User:     ${db_username}
     Pass:     ${POSTGRES_PASSWORD}"
+    fi
 else
     dbaas_text="Supabase is configured to use local Postgres as its database. Use the following credentials to manage the database:
     Database: ${POSTGRES_DB}

--- a/supabase-24-04/files/etc/update-motd.d/99-one-click
+++ b/supabase-24-04/files/etc/update-motd.d/99-one-click
@@ -7,20 +7,26 @@
 dbaas_text=""
 if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
     . /root/.digitalocean_dbaas_credentials
-    if [ "${SUPABASE_DBAAS}" = "failed" ]; then
-        dbaas_text="Managed Postgres was selected but first-boot DBaaS setup FAILED (often Trusted Sources).
-    Check /var/log/one_click_setup.log, add this Droplet IP under the database Trusted Sources,
-    then re-run:
-      /var/lib/digitalocean/setup-dbaas.sh
-      cd /srv/supabase/supabase/docker && docker compose -f docker-compose.yml -f docker-compose.dbaas.yml up -d
-    Host: ${db_host}  Port: ${db_port}  Database: ${db_database}  User: ${db_username}"
-    else
+    # Only claim Managed DB success when setup completed (SUPABASE_DBAAS=true).
+    if [ "${SUPABASE_DBAAS}" = "true" ]; then
         dbaas_text="Supabase is configured to use managed Postgres as its database. Use the following credentials to manage the database:
     Database: ${db_database}
     Host:     ${db_host}
     Port:     ${db_port}
     User:     ${db_username}
     Pass:     ${POSTGRES_PASSWORD}"
+    else
+        err_extra=""
+        if [ -n "${SUPABASE_DBAAS_ERROR}" ]; then
+            err_extra=" — ${SUPABASE_DBAAS_ERROR}"
+        fi
+        dbaas_text="Managed Postgres was selected but DBaaS setup did NOT complete successfully.
+    Status: ${SUPABASE_DBAAS:-unknown}${err_extra}
+    Check /var/log/one_click_setup.log, add this Droplet IP under the database Trusted Sources if needed,
+    then re-run:
+      /var/lib/digitalocean/setup-dbaas.sh
+      cd /srv/supabase/supabase/docker && docker compose -f docker-compose.yml -f docker-compose.dbaas.yml up -d
+    Host: ${db_host}  Port: ${db_port}  Database: ${db_database}  User: ${db_username}"
     fi
 else
     dbaas_text="Supabase is configured to use local Postgres as its database. Use the following credentials to manage the database:

--- a/supabase-24-04/files/etc/update-motd.d/99-one-click
+++ b/supabase-24-04/files/etc/update-motd.d/99-one-click
@@ -7,18 +7,17 @@
 dbaas_text=""
 if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
     . /root/.digitalocean_dbaas_credentials
-    dbaas_text="A DigitalOcean Managed PostgreSQL database was provisioned with this Droplet.
-Supabase itself still uses the local Postgres container (service: db).
-Use the managed database for your own app data or tooling:
-
-    Host:     ${DB_HOST:-$db_host}
-    Port:     ${DB_PORT:-$db_port}
-    Database: ${DB_DATABASE:-$db_database}
-    User:     ${DB_USERNAME:-$db_username}
-    Pass:     (see DB_PASSWORD / DATABASE_URL in /root/.digitalocean_passwords)
-    File:     /root/.digitalocean_dbaas_credentials"
+    dbaas_text="Supabase is configured to use managed Postgres as its database. Use the following credentials to manage the database:
+    Database: ${db_database}
+    Host:     ${db_host}
+    Port:     ${db_port}
+    User:     ${db_username}
+    Pass:     ${POSTGRES_PASSWORD}"
 else
-    dbaas_text="No managed database was attached. Supabase uses the local Postgres container (service: db)."
+    dbaas_text="Supabase is configured to use local Postgres as its database. Use the following credentials to manage the database:
+    Database: ${POSTGRES_DB}
+    User:     postgres
+    Pass:     ${POSTGRES_PASSWORD}"
 fi
 
 myip=$(hostname -I | awk '{print$1}')

--- a/supabase-24-04/files/etc/update-motd.d/99-one-click
+++ b/supabase-24-04/files/etc/update-motd.d/99-one-click
@@ -2,16 +2,46 @@
 #
 # Configured as part of the DigitalOcean 1-Click Image build process
 
+. /root/.digitalocean_passwords
+
+dbaas_text=""
+if [ -f "/root/.digitalocean_dbaas_credentials" ]; then
+    . /root/.digitalocean_dbaas_credentials
+    dbaas_text="A DigitalOcean Managed PostgreSQL database was provisioned with this Droplet.
+Supabase itself still uses the local Postgres container (service: db).
+Use the managed database for your own app data or tooling:
+
+    Host:     ${DB_HOST:-$db_host}
+    Port:     ${DB_PORT:-$db_port}
+    Database: ${DB_DATABASE:-$db_database}
+    User:     ${DB_USERNAME:-$db_username}
+    Pass:     (see DB_PASSWORD / DATABASE_URL in /root/.digitalocean_passwords)
+    File:     /root/.digitalocean_dbaas_credentials"
+else
+    dbaas_text="No managed database was attached. Supabase uses the local Postgres container (service: db)."
+fi
+
 myip=$(hostname -I | awk '{print$1}')
 cat <<EOF
 ********************************************************************************
 
 Welcome to the DigitalOcean Supabase 1-Click Application
 
-On your first login you will be prompted to configure your Supabase installation.
+Supabase Studio / API (via Nginx):
+    URL: http://${myip}
+    Dashboard user: ${DASHBOARD_USERNAME}
+    Dashboard pass: ${DASHBOARD_PASSWORD}
+
+${dbaas_text}
+
+Run setup manually when you are ready to configure a custom domain and TLS:
+    /var/supabase/supabase-setup.sh
 
 All Supabase scripts and files may be found in /srv/supabase and the setup
 utility can be run again by launching supabase-setup in that directory.
+
+Passwords are saved in /root/.digitalocean_passwords
+Setup log: /var/log/one_click_setup.log
 
 For help and more information, visit https://marketplace.digitalocean.com/apps/supabase
 

--- a/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -64,9 +64,30 @@ COMPOSE_ARGS=(-f docker-compose.yml)
 if [ -f docker-compose.dbaas.yml ]; then
   COMPOSE_ARGS+=(-f docker-compose.dbaas.yml)
 fi
-docker compose "${COMPOSE_ARGS[@]}" up -d
 
+# Switch nginx first so users never see the default "Welcome to nginx!" page if
+# Compose is still pulling images / waiting on Studio health.
 ln -sf /etc/nginx/sites-available/supabase /etc/nginx/sites-enabled/supabase
 unlink /etc/nginx/sites-enabled/default 2>/dev/null || true
-
 systemctl restart nginx
+
+# First boot often pulls many images; Studio health can lag behind "Started"
+# (Kong waits on studio healthy). Retry instead of aborting mid-stack.
+compose_up_with_retry() {
+  local attempt rc
+  for attempt in 1 2 3; do
+    set +e
+    docker compose "${COMPOSE_ARGS[@]}" up -d
+    rc=$?
+    set -e
+    if [ "${rc}" -eq 0 ]; then
+      return 0
+    fi
+    echo "WARNING: docker compose up failed (attempt ${attempt}/3, rc=${rc}); retrying in 30s..." >&2
+    sleep 30
+  done
+  echo "ERROR: docker compose up failed after retries" >&2
+  return 1
+}
+
+compose_up_with_retry

--- a/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -4,27 +4,39 @@
 # created from your image.  Things like generating passwords, configuration requiring IP address
 # or other items that will be unique to each instance should be done in scripts here.
 
-# Install latest updates on first boot
+exec > >(tee /var/log/one_click_setup.log) 2>&1
+
+unlock_ssh() {
+  sed -e '/Match User root/d' \
+      -e '/.*ForceCommand.*droplet.*/d' \
+      -i /etc/ssh/sshd_config
+  systemctl restart ssh
+}
+trap unlock_ssh EXIT
+
+set -e
+
 cd /srv/supabase/supabase/docker
 
 #git pull  ### it was broken two times because of updates, so this process should be manual
 
 export SUPABASE_PASSWORD=`openssl rand -base64 12`
+cat > /root/.digitalocean_passwords <<EOM
+DASHBOARD_USERNAME=supabase
+DASHBOARD_PASSWORD=${SUPABASE_PASSWORD}
+EOM
+
 cat >> /srv/supabase/supabase/docker/.env <<EOM
 DASHBOARD_USERNAME=supabase
 DASHBOARD_PASSWORD=${SUPABASE_PASSWORD}
 EOM
 
+chmod +x /var/lib/digitalocean/setup-dbaas.sh
+/var/lib/digitalocean/setup-dbaas.sh
+
 docker compose up -d
 
-ln -s /etc/nginx/sites-available/supabase /etc/nginx/sites-enabled/supabase
-unlink /etc/nginx/sites-enabled/default
+ln -sf /etc/nginx/sites-available/supabase /etc/nginx/sites-enabled/supabase
+unlink /etc/nginx/sites-enabled/default 2>/dev/null || true
 
 systemctl restart nginx
-
-# Remove the ssh force logout command
-sed -e '/Match User root/d' \
-    -e '/.*ForceCommand.*droplet.*/d' \
-    -i /etc/ssh/sshd_config
-
-systemctl restart ssh

--- a/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -19,6 +19,21 @@ set -euo pipefail
 COMPOSE_DIR="/srv/supabase/supabase/docker"
 ENV_FILE="${COMPOSE_DIR}/.env"
 GENERATE_KEYS="${COMPOSE_DIR}/utils/generate-keys.sh"
+PASSWORDS_FILE="/root/.digitalocean_passwords"
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+upsert_password_var() {
+  local key="$1"
+  local value="$2"
+  touch "${PASSWORDS_FILE}"
+  sed -i "/^${key}=/d" "${PASSWORDS_FILE}"
+  printf '%s=%s\n' "${key}" "$(shell_quote "${value}")" >> "${PASSWORDS_FILE}"
+}
 
 cd "${COMPOSE_DIR}"
 
@@ -35,15 +50,25 @@ sh "${GENERATE_KEYS}" --update-env
 rm -f "${ENV_FILE}.old"
 
 # Ensure dashboard user and a unique pooler tenant (not covered by generate-keys).
+# Quote values so special characters cannot break Compose .env parsing.
 sed -i '/^DASHBOARD_USERNAME=/d' "${ENV_FILE}"
-printf 'DASHBOARD_USERNAME=supabase\n' >> "${ENV_FILE}"
+printf 'DASHBOARD_USERNAME=%s\n' "$(shell_quote "supabase")" >> "${ENV_FILE}"
 sed -i '/^POOLER_TENANT_ID=/d' "${ENV_FILE}"
-printf 'POOLER_TENANT_ID=%s\n' "$(openssl rand -hex 16)" >> "${ENV_FILE}"
+printf 'POOLER_TENANT_ID=%s\n' "$(shell_quote "$(openssl rand -hex 16)")" >> "${ENV_FILE}"
 
-# Prefer last assignment if duplicates exist
+# Prefer last assignment if duplicates exist; strip surrounding single quotes.
 read_env() {
   local key="$1"
-  sed -n "s/^${key}=//p" "${ENV_FILE}" | tail -n1
+  local v
+  v=$(sed -n "s/^${key}=//p" "${ENV_FILE}" | tail -n1)
+  case "${v}" in
+    \'*\')
+      v="${v#\'}"
+      v="${v%\'}"
+      v=$(printf '%s' "${v}" | sed "s/'\\\\''/'/g")
+      ;;
+  esac
+  printf '%s' "${v}"
 }
 
 DASHBOARD_PASSWORD="$(read_env DASHBOARD_PASSWORD)"
@@ -52,12 +77,21 @@ if [ -z "${DASHBOARD_PASSWORD}" ]; then
   exit 1
 fi
 
-cat > /root/.digitalocean_passwords <<EOM
-DASHBOARD_USERNAME=supabase
-DASHBOARD_PASSWORD=${DASHBOARD_PASSWORD}
-EOM
+# Re-quote dashboard password in .env (generate-keys writes unquoted).
+sed -i '/^DASHBOARD_PASSWORD=/d' "${ENV_FILE}"
+printf 'DASHBOARD_PASSWORD=%s\n' "$(shell_quote "${DASHBOARD_PASSWORD}")" >> "${ENV_FILE}"
+
+upsert_password_var DASHBOARD_USERNAME supabase
+upsert_password_var DASHBOARD_PASSWORD "${DASHBOARD_PASSWORD}"
+
+# Enable supabase nginx ASAP so a later Compose health race never leaves the
+# default "Welcome to nginx!" page (no Basic-auth popup).
+ln -sf /etc/nginx/sites-available/supabase /etc/nginx/sites-enabled/supabase
+unlink /etc/nginx/sites-enabled/default 2>/dev/null || true
+systemctl restart nginx
 
 chmod +x /var/lib/digitalocean/setup-dbaas.sh
+# On DBaaS failure setup-dbaas exits 1 after writing SUPABASE_DBAAS=failed for MOTD.
 /var/lib/digitalocean/setup-dbaas.sh
 
 COMPOSE_ARGS=(-f docker-compose.yml)
@@ -65,14 +99,8 @@ if [ -f docker-compose.dbaas.yml ]; then
   COMPOSE_ARGS+=(-f docker-compose.dbaas.yml)
 fi
 
-# Switch nginx first so users never see the default "Welcome to nginx!" page if
-# Compose is still pulling images / waiting on Studio health.
-ln -sf /etc/nginx/sites-available/supabase /etc/nginx/sites-enabled/supabase
-unlink /etc/nginx/sites-enabled/default 2>/dev/null || true
-systemctl restart nginx
-
-# First boot often pulls many images; Studio health can lag behind "Started"
-# (Kong waits on studio healthy). Retry instead of aborting mid-stack.
+# First boot often pulls many images; Studio health can lag (Kong waits on studio
+# healthy). Retry instead of aborting mid-stack with Kong never started.
 compose_up_with_retry() {
   local attempt rc
   for attempt in 1 2 3; do
@@ -87,6 +115,7 @@ compose_up_with_retry() {
     sleep 30
   done
   echo "ERROR: docker compose up failed after retries" >&2
+  echo "ERROR: nginx already points at Kong — check: docker compose ${COMPOSE_ARGS[*]} ps" >&2
   return 1
 }
 

--- a/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -14,21 +14,47 @@ unlock_ssh() {
 }
 trap unlock_ssh EXIT
 
-set -e
+set -euo pipefail
 
-cd /srv/supabase/supabase/docker
+COMPOSE_DIR="/srv/supabase/supabase/docker"
+ENV_FILE="${COMPOSE_DIR}/.env"
+GENERATE_KEYS="${COMPOSE_DIR}/utils/generate-keys.sh"
 
-#git pull  ### it was broken two times because of updates, so this process should be manual
+cd "${COMPOSE_DIR}"
 
-export SUPABASE_PASSWORD=`openssl rand -base64 12`
+# Rotate all material secrets from the Packer-baked .env.example defaults so each
+# Droplet gets unique JWT/API keys (Coolify-style; uses upstream generate-keys.sh).
+if [ ! -x "${GENERATE_KEYS}" ] && [ -f "${GENERATE_KEYS}" ]; then
+  chmod +x "${GENERATE_KEYS}"
+fi
+if [ ! -f "${GENERATE_KEYS}" ]; then
+  echo "ERROR: missing ${GENERATE_KEYS}" >&2
+  exit 1
+fi
+sh "${GENERATE_KEYS}" --update-env
+rm -f "${ENV_FILE}.old"
+
+# Ensure dashboard user and a unique pooler tenant (not covered by generate-keys).
+sed -i '/^DASHBOARD_USERNAME=/d' "${ENV_FILE}"
+printf 'DASHBOARD_USERNAME=supabase\n' >> "${ENV_FILE}"
+sed -i '/^POOLER_TENANT_ID=/d' "${ENV_FILE}"
+printf 'POOLER_TENANT_ID=%s\n' "$(openssl rand -hex 16)" >> "${ENV_FILE}"
+
+# Prefer last assignment if duplicates exist
+read_env() {
+  local key="$1"
+  sed -n "s/^${key}=//p" "${ENV_FILE}" | tail -n1
+}
+
+DASHBOARD_PASSWORD="$(read_env DASHBOARD_PASSWORD)"
+if [ -z "${DASHBOARD_PASSWORD}" ]; then
+  echo "ERROR: DASHBOARD_PASSWORD missing after generate-keys" >&2
+  exit 1
+fi
+
 cat > /root/.digitalocean_passwords <<EOM
 DASHBOARD_USERNAME=supabase
-DASHBOARD_PASSWORD=${SUPABASE_PASSWORD}
-EOM
-
-cat >> /srv/supabase/supabase/docker/.env <<EOM
-DASHBOARD_USERNAME=supabase
-DASHBOARD_PASSWORD=${SUPABASE_PASSWORD}
+DASHBOARD_PASSWORD=${DASHBOARD_PASSWORD}
 EOM
 
 chmod +x /var/lib/digitalocean/setup-dbaas.sh

--- a/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/supabase-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -34,7 +34,11 @@ EOM
 chmod +x /var/lib/digitalocean/setup-dbaas.sh
 /var/lib/digitalocean/setup-dbaas.sh
 
-docker compose up -d
+COMPOSE_ARGS=(-f docker-compose.yml)
+if [ -f docker-compose.dbaas.yml ]; then
+  COMPOSE_ARGS+=(-f docker-compose.dbaas.yml)
+fi
+docker compose "${COMPOSE_ARGS[@]}" up -d
 
 ln -sf /etc/nginx/sites-available/supabase /etc/nginx/sites-enabled/supabase
 unlink /etc/nginx/sites-enabled/default 2>/dev/null || true

--- a/supabase-24-04/files/var/lib/digitalocean/prepare-logflare-ssl.sh
+++ b/supabase-24-04/files/var/lib/digitalocean/prepare-logflare-ssl.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Extract Logflare runtime.exs from the image used by docker-compose.yml and
+# patch it for DigitalOcean Managed Postgres TLS (no client cert PEMs).
+# Used at Packer build time and as a first-boot fallback.
+
+set -euo pipefail
+
+COMPOSE_DIR="${1:-/srv/supabase/supabase/docker}"
+COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
+ANALYTICS_VOL="${COMPOSE_DIR}/volumes/analytics"
+RUNTIME_EXS="${ANALYTICS_VOL}/runtime.exs"
+VERSION_FILE="${ANALYTICS_VOL}/logflare_version"
+
+logflare_ssl_ok() {
+  local f="$1"
+  [ -f "${f}" ] || return 1
+  grep -q 'System.get_env("DB_SSL") == "true" do' "${f}" || return 1
+  grep -q 'verify: :verify_none' "${f}" || return 1
+  # Stock gate must be gone
+  ! grep -q 'File.exists?("db-server-ca.pem")' "${f}"
+}
+
+patch_logflare_ssl() {
+  local f="$1"
+  local tmp
+
+  if logflare_ssl_ok "${f}"; then
+    echo "Logflare SSL block already patched in ${f}"
+    return 0
+  fi
+
+  tmp=$(mktemp)
+  # Replace the stock PEM-gated DB_SSL block with a DO Managed DB friendly block.
+  if ! perl -0pe 's/if\(\s*\n\s*System\.get_env\("DB_SSL"\) == "true" && File\.exists\?\("db-server-ca\.pem"\) &&\s*\n\s*File\.exists\?\("db-client-ca\.pem"\) && File\.exists\?\("db-client-key\.pem"\)\s*\n\) do\n.*?ssl_opts: \[\n.*?\n\s*\]\nend/if System.get_env("DB_SSL") == "true" do\n  # DigitalOcean Managed DB: require TLS without client certificates\n  config :logflare, Logflare.Repo,\n    ssl: true,\n    ssl_opts: [\n      verify: :verify_none,\n      versions: [:"tlsv1.2", :"tlsv1.3"]\n    ]\nend/s' "${f}" > "${tmp}"; then
+    rm -f "${tmp}"
+    echo "ERROR: perl failed while patching ${f}" >&2
+    return 1
+  fi
+
+  if ! grep -q 'verify: :verify_none' "${tmp}" || grep -q 'File.exists?("db-server-ca.pem")' "${tmp}"; then
+    # Fallback: relax PEM condition and force verify_none
+    cp -f "${f}" "${tmp}"
+    perl -i -0pe 's/System\.get_env\("DB_SSL"\) == "true" && File\.exists\?\("db-server-ca\.pem"\).*?File\.exists\?\("db-client-key\.pem"\)/System.get_env("DB_SSL") == "true"/s' "${tmp}"
+    perl -i -pe 's/verify:\s*:verify_peer,/verify: :verify_none,/' "${tmp}"
+    perl -i -pe 's/^\s*cacertfile: "db-server-ca\.pem",\s*$//' "${tmp}"
+    perl -i -pe 's/^\s*certfile: "db-client-cert\.pem",\s*$//' "${tmp}"
+    perl -i -pe 's/^\s*keyfile: "db-client-key\.pem",\s*$//' "${tmp}"
+  fi
+
+  if ! logflare_ssl_ok "${tmp}"; then
+    rm -f "${tmp}"
+    echo "ERROR: Logflare SSL patch verification failed for ${f}" >&2
+    return 1
+  fi
+
+  mv -f "${tmp}" "${f}"
+  echo "Patched Logflare SSL block in ${f}"
+}
+
+if [ ! -f "${COMPOSE_FILE}" ]; then
+  echo "ERROR: missing ${COMPOSE_FILE}" >&2
+  exit 1
+fi
+
+# Match top-level analytics service only (not nested depends_on: analytics:).
+LOGFLARE_IMAGE=$(awk '
+  /^[[:space:]]{2}analytics:[[:space:]]*$/ { f=1; next }
+  f && /^[[:space:]]{2}[a-zA-Z0-9_]+:/ { f=0 }
+  f && /^[[:space:]]+image:[[:space:]]*/ { print $2; exit }
+' "${COMPOSE_FILE}")
+LOGFLARE_IMAGE="${LOGFLARE_IMAGE:-supabase/logflare:1.36.1}"
+LOGFLARE_VER="${LOGFLARE_IMAGE##*:}"
+
+mkdir -p "${ANALYTICS_VOL}"
+
+# Reuse an already-valid baked file when present
+if logflare_ssl_ok "${RUNTIME_EXS}"; then
+  if [ ! -f "${VERSION_FILE}" ]; then
+    printf '%s\n' "${LOGFLARE_VER}" > "${VERSION_FILE}"
+  fi
+  echo "Logflare SSL runtime already ready at ${RUNTIME_EXS}"
+  exit 0
+fi
+
+echo "Preparing Logflare runtime.exs from ${LOGFLARE_IMAGE}"
+docker pull "${LOGFLARE_IMAGE}"
+lf_cid=$(docker create "${LOGFLARE_IMAGE}")
+cleanup() { docker rm -f "${lf_cid}" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+docker cp "${lf_cid}:/opt/app/rel/logflare/releases/${LOGFLARE_VER}/runtime.exs" "${RUNTIME_EXS}"
+cleanup
+trap - EXIT
+
+patch_logflare_ssl "${RUNTIME_EXS}"
+printf '%s\n' "${LOGFLARE_VER}" > "${VERSION_FILE}"
+echo "Logflare SSL runtime ready (${LOGFLARE_VER}) at ${RUNTIME_EXS}"

--- a/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
+++ b/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
@@ -1,93 +1,248 @@
 #!/bin/bash
-# Prepare DigitalOcean Managed PostgreSQL credentials when provided via
-# Marketplace predeploy (Add a Database).
+# Configure Supabase to use a DigitalOcean Managed PostgreSQL database when
+# credentials are provided via Marketplace predeploy (Add a Database).
 #
-# The Supabase stack keeps using its local `db` (supabase/postgres) container.
-# Managed DB credentials are validated, waited on, and saved for the user.
+# When DBaaS credentials are present:
+#   - Point Supabase .env at Managed Postgres
+#   - Remove the local db (supabase/postgres) service from compose
+#   - Bootstrap roles/schemas needed by Supabase (best-effort)
+# When absent, keep the local db container (default).
 
-set -u
+set -uo pipefail
 
+COMPOSE_DIR="/srv/supabase/supabase/docker"
+COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
+ENV_FILE="${COMPOSE_DIR}/.env"
 DBAAS_FILE="/root/.digitalocean_dbaas_credentials"
 DBAAS_WAIT_SECONDS="${DBAAS_WAIT_SECONDS:-300}"
 
-if [ ! -f "${DBAAS_FILE}" ]; then
-  cat >> /root/.digitalocean_passwords <<EOM
-SUPABASE_DBAAS=false
-EOM
-  exit 0
-fi
-
-if [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")" != "postgresql" ]; then
-  echo "Managed database protocol is not postgresql; skipping DBaaS setup."
-  cat >> /root/.digitalocean_passwords <<EOM
-SUPABASE_DBAAS=false
-EOM
-  exit 0
-fi
-
-PG_HOST=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
-PG_PORT=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
-PG_USER=$(sed -n "s/^db_username=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
-PG_DB=$(sed -n "s/^db_database=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
-PG_PASS=$(sed -n "s/^db_password=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
-
-# URL-encode password for DATABASE_URL
-urlencode() {
-  if command -v jq >/dev/null 2>&1; then
-    jq -nr --arg p "$1" '$p|@uri'
-  else
-    printf '%s' "$1"
-  fi
-}
-
-PG_PASS_ENC=$(urlencode "${PG_PASS}")
-DATABASE_URL="postgresql://${PG_USER}:${PG_PASS_ENC}@${PG_HOST}:${PG_PORT}/${PG_DB}?sslmode=require"
-
-# Single-quote a value for safe sourcing from MOTD / shell
 shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
   printf "'"
 }
 
-write_dbaas_passwords() {
-  local ready="$1"
-  cat >> /root/.digitalocean_passwords <<EOM
-SUPABASE_DBAAS=true
-SUPABASE_DBAAS_READY=${ready}
-DB_HOST=$(shell_quote "${PG_HOST}")
-DB_PORT=$(shell_quote "${PG_PORT}")
-DB_DATABASE=$(shell_quote "${PG_DB}")
-DB_USERNAME=$(shell_quote "${PG_USER}")
-DB_PASSWORD=$(shell_quote "${PG_PASS}")
-DATABASE_URL=$(shell_quote "${DATABASE_URL}")
-EOM
+update_env_var() {
+  local key="$1"
+  local value="$2"
+  sed -i "/^${key}=/d" "${ENV_FILE}"
+  printf '%s=%s\n' "${key}" "${value}" >> "${ENV_FILE}"
 }
 
-echo -e "\nWaiting for your managed database to become available (up to ${DBAAS_WAIT_SECONDS}s)"
-elapsed=0
-until PGPASSWORD="${PG_PASS}" psql \
-  "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" \
-  -c 'SELECT 1' >/dev/null 2>&1; do
-  if [ "${elapsed}" -ge "${DBAAS_WAIT_SECONDS}" ]; then
-    echo -e "\nTimed out waiting for managed database. Credentials are still saved; check Trusted Sources and retry connectivity."
-    write_dbaas_passwords false
-    exit 0
+read_env_var() {
+  local key="$1"
+  sed -n "s/^${key}=//p" "${ENV_FILE}" | tail -n1
+}
+
+using_dbaas=false
+
+if [ -f "${DBAAS_FILE}" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")" = "postgresql" ]; then
+  using_dbaas=true
+
+  PG_HOST=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+  PG_PORT=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+  PG_USER=$(sed -n "s/^db_username=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+  PG_DB=$(sed -n "s/^db_database=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+  PG_PASS=$(sed -n "s/^db_password=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+  PG_PASS_SQL=$(printf '%s' "${PG_PASS}" | sed "s/'/''/g")
+  JWT_SECRET=$(read_env_var JWT_SECRET)
+  JWT_EXPIRY=$(read_env_var JWT_EXPIRY)
+  JWT_EXPIRY="${JWT_EXPIRY:-3600}"
+
+  echo -e "\nWaiting for your managed database to become available (up to ${DBAAS_WAIT_SECONDS}s)"
+  elapsed=0
+  until PGPASSWORD="${PG_PASS}" psql \
+    "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" \
+    -c 'SELECT 1' >/dev/null 2>&1; do
+    if [ "${elapsed}" -ge "${DBAAS_WAIT_SECONDS}" ]; then
+      echo -e "\nTimed out waiting for managed database. Continuing with Managed Postgres config; check Trusted Sources if services fail to connect."
+      break
+    fi
+    printf .
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+  if [ "${elapsed}" -lt "${DBAAS_WAIT_SECONDS}" ]; then
+    echo -e "\nManaged database available!\n"
   fi
-  printf .
-  sleep 2
-  elapsed=$((elapsed + 2))
-done
-echo -e "\nManaged database available!\n"
 
-write_dbaas_passwords true
+  # Point Supabase services at the managed Postgres instance
+  update_env_var POSTGRES_HOST "${PG_HOST}"
+  update_env_var POSTGRES_PORT "${PG_PORT}"
+  update_env_var POSTGRES_DB "${PG_DB}"
+  update_env_var POSTGRES_PASSWORD "${PG_PASS}"
 
-# Persist DATABASE_URL for shells/apps (Marketplace predeploy convention)
-if ! grep -q '^DATABASE_URL=' /etc/environment 2>/dev/null; then
-  echo "DATABASE_URL=\"${DATABASE_URL}\"" >> /etc/environment
-else
-  sed -i "/^DATABASE_URL=/d" /etc/environment
-  echo "DATABASE_URL=\"${DATABASE_URL}\"" >> /etc/environment
+  # Remove depends_on entries that require the local db container
+  perl -i -0pe 's/\n[ \t]+db:\n[ \t]+# Disable this if you are using an external Postgres database\n[ \t]+condition: service_healthy//g' "${COMPOSE_FILE}"
+  perl -i -0pe 's/\n[ \t]+db:\n[ \t]+condition: service_healthy//g' "${COMPOSE_FILE}"
+  # Remove empty depends_on keys left behind
+  perl -i -0pe 's/\n(    depends_on:)\n(    [a-z#])/\n$2/g' "${COMPOSE_FILE}"
+
+  # Drop the embedded db service; keep supavisor and the rest of the stack
+  perl -i -0pe 's/\n  # Comment out everything below this point if you are using an external Postgres database\n  db:.*?(?=\n  # Update the DATABASE_URL if you are using an external Postgres database)//s' "${COMPOSE_FILE}"
+
+  # Require SSL for managed database connection strings in compose
+  # Ecto uses ssl=true; libpq URLs use sslmode=require (apply ecto first)
+  perl -i -pe 's#(ecto://supabase_admin:\$\{POSTGRES_PASSWORD\}@\$\{POSTGRES_HOST\}:\$\{POSTGRES_PORT\}/_supabase)(?!\?ssl=true)#$1?ssl=true#g' "${COMPOSE_FILE}"
+  perl -i -pe 's#((?:postgres|postgresql)://[^[:space:]]+@\$\{POSTGRES_HOST\}:\$\{POSTGRES_PORT\}/(?:\$\{POSTGRES_DB\}|_supabase))(?!\?sslmode=require)#$1?sslmode=require#g' "${COMPOSE_FILE}"
+
+  psql_admin() {
+    PGPASSWORD="${PG_PASS}" psql \
+      "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" "$@"
+  }
+
+  # Create roles expected by Supabase services (best-effort on managed Postgres)
+  psql_admin -v ON_ERROR_STOP=0 <<SQL || true
+DO \$\$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'postgres') THEN
+    CREATE ROLE postgres LOGIN PASSWORD '${PG_PASS_SQL}' CREATEDB CREATEROLE;
+  ELSE
+    BEGIN
+      ALTER ROLE postgres WITH LOGIN PASSWORD '${PG_PASS_SQL}';
+    EXCEPTION WHEN OTHERS THEN NULL;
+    END;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
+    CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD '${PG_PASS_SQL}';
+  ELSE
+    ALTER ROLE authenticator WITH LOGIN PASSWORD '${PG_PASS_SQL}';
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN
+    CREATE ROLE pgbouncer LOGIN PASSWORD '${PG_PASS_SQL}';
+  ELSE
+    ALTER ROLE pgbouncer WITH LOGIN PASSWORD '${PG_PASS_SQL}';
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_admin') THEN
+    CREATE ROLE supabase_admin LOGIN PASSWORD '${PG_PASS_SQL}' CREATEDB CREATEROLE BYPASSRLS;
+  ELSE
+    ALTER ROLE supabase_admin WITH LOGIN PASSWORD '${PG_PASS_SQL}' CREATEDB CREATEROLE;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN
+    CREATE ROLE supabase_auth_admin LOGIN PASSWORD '${PG_PASS_SQL}';
+  ELSE
+    ALTER ROLE supabase_auth_admin WITH LOGIN PASSWORD '${PG_PASS_SQL}';
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_storage_admin') THEN
+    CREATE ROLE supabase_storage_admin LOGIN PASSWORD '${PG_PASS_SQL}';
+  ELSE
+    ALTER ROLE supabase_storage_admin WITH LOGIN PASSWORD '${PG_PASS_SQL}';
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_functions_admin') THEN
+    CREATE ROLE supabase_functions_admin LOGIN PASSWORD '${PG_PASS_SQL}';
+  ELSE
+    ALTER ROLE supabase_functions_admin WITH LOGIN PASSWORD '${PG_PASS_SQL}';
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
+    CREATE ROLE anon NOLOGIN NOINHERIT;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated NOLOGIN NOINHERIT;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+    CREATE ROLE service_role NOLOGIN NOINHERIT BYPASSRLS;
+  END IF;
+END
+\$\$;
+
+GRANT ALL PRIVILEGES ON DATABASE "${PG_DB}" TO postgres;
+GRANT ALL PRIVILEGES ON DATABASE "${PG_DB}" TO supabase_admin;
+GRANT ALL PRIVILEGES ON DATABASE "${PG_DB}" TO authenticator;
+GRANT ALL PRIVILEGES ON DATABASE "${PG_DB}" TO supabase_auth_admin;
+GRANT ALL PRIVILEGES ON DATABASE "${PG_DB}" TO supabase_storage_admin;
+GRANT ALL ON SCHEMA public TO postgres, supabase_admin, authenticator, supabase_auth_admin, supabase_storage_admin, anon, authenticated, service_role;
+GRANT anon, authenticated, service_role TO authenticator;
+GRANT ALL ON SCHEMA public TO anon, authenticated, service_role;
+SQL
+
+  if ! psql_admin -tAc "SELECT 1 FROM pg_database WHERE datname = '_supabase'" 2>/dev/null | grep -q 1; then
+    psql_admin -c "CREATE DATABASE _supabase OWNER supabase_admin;" || true
+  fi
+
+  # Schemas that the local supabase/postgres image would create via init scripts
+  psql_admin -v ON_ERROR_STOP=0 <<SQL || true
+CREATE SCHEMA IF NOT EXISTS _realtime AUTHORIZATION supabase_admin;
+CREATE SCHEMA IF NOT EXISTS extensions AUTHORIZATION supabase_admin;
+SQL
+
+  PGPASSWORD="${PG_PASS}" psql \
+    "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=_supabase sslmode=require" \
+    -v ON_ERROR_STOP=0 <<SQL || true
+CREATE SCHEMA IF NOT EXISTS _analytics AUTHORIZATION supabase_admin;
+CREATE SCHEMA IF NOT EXISTS _supavisor AUTHORIZATION supabase_admin;
+SQL
+
+  if [ -n "${JWT_SECRET}" ]; then
+    psql_admin -v ON_ERROR_STOP=0 \
+      -c "ALTER DATABASE \"${PG_DB}\" SET \"app.settings.jwt_secret\" TO '${JWT_SECRET}';" || true
+    psql_admin -v ON_ERROR_STOP=0 \
+      -c "ALTER DATABASE \"${PG_DB}\" SET \"app.settings.jwt_exp\" TO '${JWT_EXPIRY}';" || true
+  fi
+
+  # Apply remaining bundled init SQL when possible (extensions like pg_net may be unavailable)
+  for sql in \
+    "${COMPOSE_DIR}/volumes/db/roles.sql" \
+    "${COMPOSE_DIR}/volumes/db/webhooks.sql"
+  do
+    if [ -f "${sql}" ]; then
+      echo "Applying $(basename "${sql}") to managed database (best-effort)"
+      PGPASSWORD="${PG_PASS}" POSTGRES_PASSWORD="${PG_PASS}" POSTGRES_USER=supabase_admin psql \
+        "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" \
+        -v ON_ERROR_STOP=0 -f "${sql}" || true
+    fi
+  done
+
+  # Enable SSL for services that connect via discrete DB host/port (not URL)
+  cat > "${COMPOSE_DIR}/docker-compose.dbaas.yml" <<'EOF'
+services:
+  realtime:
+    environment:
+      DB_SSL: "true"
+  meta:
+    environment:
+      PGSSLMODE: require
+  analytics:
+    environment:
+      PGSSLMODE: require
+EOF
+
+  # Persist credentials for MOTD / operators
+  if command -v jq >/dev/null 2>&1; then
+    PG_PASS_ENC=$(jq -nr --arg p "${PG_PASS}" '$p|@uri')
+  else
+    PG_PASS_ENC="${PG_PASS}"
+  fi
+  DATABASE_URL="postgresql://${PG_USER}:${PG_PASS_ENC}@${PG_HOST}:${PG_PORT}/${PG_DB}?sslmode=require"
+
+  cat >> /root/.digitalocean_passwords <<EOM
+SUPABASE_DBAAS=true
+POSTGRES_HOST=$(shell_quote "${PG_HOST}")
+POSTGRES_PORT=$(shell_quote "${PG_PORT}")
+POSTGRES_DB=$(shell_quote "${PG_DB}")
+POSTGRES_USER=$(shell_quote "${PG_USER}")
+POSTGRES_PASSWORD=$(shell_quote "${PG_PASS}")
+DATABASE_URL=$(shell_quote "${DATABASE_URL}")
+EOM
+
+  if ! grep -q '^DATABASE_URL=' /etc/environment 2>/dev/null; then
+    echo "DATABASE_URL=\"${DATABASE_URL}\"" >> /etc/environment
+  else
+    sed -i "/^DATABASE_URL=/d" /etc/environment
+    echo "DATABASE_URL=\"${DATABASE_URL}\"" >> /etc/environment
+  fi
+
+  echo "Supabase configured to use Managed PostgreSQL at ${PG_HOST}:${PG_PORT}/${PG_DB}"
 fi
 
-echo "Managed PostgreSQL credentials saved. Supabase continues to use the local db container."
+if [ "${using_dbaas}" = false ]; then
+  LOCAL_PG_PASS=$(read_env_var POSTGRES_PASSWORD)
+  LOCAL_PG_DB=$(read_env_var POSTGRES_DB)
+  LOCAL_PG_DB="${LOCAL_PG_DB:-postgres}"
+  cat >> /root/.digitalocean_passwords <<EOM
+SUPABASE_DBAAS=false
+POSTGRES_HOST='db'
+POSTGRES_PORT='5432'
+POSTGRES_DB=$(shell_quote "${LOCAL_PG_DB}")
+POSTGRES_PASSWORD=$(shell_quote "${LOCAL_PG_PASS}")
+EOM
+fi

--- a/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
+++ b/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Prepare DigitalOcean Managed PostgreSQL credentials when provided via
+# Marketplace predeploy (Add a Database).
+#
+# The Supabase stack keeps using its local `db` (supabase/postgres) container.
+# Managed DB credentials are validated, waited on, and saved for the user.
+
+set -u
+
+DBAAS_FILE="/root/.digitalocean_dbaas_credentials"
+DBAAS_WAIT_SECONDS="${DBAAS_WAIT_SECONDS:-300}"
+
+if [ ! -f "${DBAAS_FILE}" ]; then
+  cat >> /root/.digitalocean_passwords <<EOM
+SUPABASE_DBAAS=false
+EOM
+  exit 0
+fi
+
+if [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")" != "postgresql" ]; then
+  echo "Managed database protocol is not postgresql; skipping DBaaS setup."
+  cat >> /root/.digitalocean_passwords <<EOM
+SUPABASE_DBAAS=false
+EOM
+  exit 0
+fi
+
+PG_HOST=$(sed -n "s/^db_host=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+PG_PORT=$(sed -n "s/^db_port=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+PG_USER=$(sed -n "s/^db_username=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+PG_DB=$(sed -n "s/^db_database=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+PG_PASS=$(sed -n "s/^db_password=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")
+
+# URL-encode password for DATABASE_URL
+urlencode() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -nr --arg p "$1" '$p|@uri'
+  else
+    printf '%s' "$1"
+  fi
+}
+
+PG_PASS_ENC=$(urlencode "${PG_PASS}")
+DATABASE_URL="postgresql://${PG_USER}:${PG_PASS_ENC}@${PG_HOST}:${PG_PORT}/${PG_DB}?sslmode=require"
+
+# Single-quote a value for safe sourcing from MOTD / shell
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+write_dbaas_passwords() {
+  local ready="$1"
+  cat >> /root/.digitalocean_passwords <<EOM
+SUPABASE_DBAAS=true
+SUPABASE_DBAAS_READY=${ready}
+DB_HOST=$(shell_quote "${PG_HOST}")
+DB_PORT=$(shell_quote "${PG_PORT}")
+DB_DATABASE=$(shell_quote "${PG_DB}")
+DB_USERNAME=$(shell_quote "${PG_USER}")
+DB_PASSWORD=$(shell_quote "${PG_PASS}")
+DATABASE_URL=$(shell_quote "${DATABASE_URL}")
+EOM
+}
+
+echo -e "\nWaiting for your managed database to become available (up to ${DBAAS_WAIT_SECONDS}s)"
+elapsed=0
+until PGPASSWORD="${PG_PASS}" psql \
+  "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" \
+  -c 'SELECT 1' >/dev/null 2>&1; do
+  if [ "${elapsed}" -ge "${DBAAS_WAIT_SECONDS}" ]; then
+    echo -e "\nTimed out waiting for managed database. Credentials are still saved; check Trusted Sources and retry connectivity."
+    write_dbaas_passwords false
+    exit 0
+  fi
+  printf .
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+echo -e "\nManaged database available!\n"
+
+write_dbaas_passwords true
+
+# Persist DATABASE_URL for shells/apps (Marketplace predeploy convention)
+if ! grep -q '^DATABASE_URL=' /etc/environment 2>/dev/null; then
+  echo "DATABASE_URL=\"${DATABASE_URL}\"" >> /etc/environment
+else
+  sed -i "/^DATABASE_URL=/d" /etc/environment
+  echo "DATABASE_URL=\"${DATABASE_URL}\"" >> /etc/environment
+fi
+
+echo "Managed PostgreSQL credentials saved. Supabase continues to use the local db container."

--- a/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
+++ b/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
@@ -25,16 +25,60 @@ shell_quote() {
   printf "'"
 }
 
+# Write KEY=value for Docker Compose .env (single-quoted so # $ spaces are safe).
 update_env_var() {
   local key="$1"
   local value="$2"
   sed -i "/^${key}=/d" "${ENV_FILE}"
-  printf '%s=%s\n' "${key}" "${value}" >> "${ENV_FILE}"
+  printf '%s=%s\n' "${key}" "$(shell_quote "${value}")" >> "${ENV_FILE}"
 }
 
+# Read .env value; strip surrounding single quotes produced by update_env_var.
 read_env_var() {
   local key="$1"
-  sed -n "s/^${key}=//p" "${ENV_FILE}" | tail -n1
+  local v
+  v=$(sed -n "s/^${key}=//p" "${ENV_FILE}" | tail -n1)
+  case "${v}" in
+    \'*\')
+      v="${v#\'}"
+      v="${v%\'}"
+      v=$(printf '%s' "${v}" | sed "s/'\\\\''/'/g")
+      ;;
+  esac
+  printf '%s' "${v}"
+}
+
+# Idempotent upsert into /root/.digitalocean_passwords (value stored shell-quoted).
+upsert_password_var() {
+  local key="$1"
+  local value="$2"
+  local file="${3:-/root/.digitalocean_passwords}"
+  touch "${file}"
+  sed -i "/^${key}=/d" "${file}"
+  printf '%s=%s\n' "${key}" "$(shell_quote "${value}")" >> "${file}"
+}
+
+mark_dbaas_status() {
+  local status="$1"
+  local err="${2:-}"
+  upsert_password_var SUPABASE_DBAAS "${status}"
+  if [ -n "${err}" ]; then
+    upsert_password_var SUPABASE_DBAAS_ERROR "${err}"
+  else
+    sed -i '/^SUPABASE_DBAAS_ERROR=/d' /root/.digitalocean_passwords 2>/dev/null || true
+  fi
+}
+
+dbaas_die() {
+  echo "ERROR: $*" >&2
+  mark_dbaas_status failed "$*"
+  if [ -n "${PG_HOST:-}" ]; then
+    upsert_password_var POSTGRES_HOST "${PG_HOST}"
+    upsert_password_var POSTGRES_PORT "${PG_PORT:-}"
+    upsert_password_var POSTGRES_DB "${PG_DB:-}"
+    upsert_password_var POSTGRES_USER "${PG_USER:-}"
+  fi
+  exit 1
 }
 
 # Remove a single top-level Compose service by name (2-space indent).
@@ -79,12 +123,12 @@ remove_compose_service() {
   if grep -qE "^  ${service}:" "${tmp}"; then
     echo "ERROR: failed to remove Compose service '${service}' from ${file}" >&2
     rm -f "${tmp}"
-    exit 1
+    return 1
   fi
   if [ "${had_vector}" -eq 1 ] && ! grep -qE '^  vector:' "${tmp}"; then
     echo "ERROR: compose edit removed vector while stripping '${service}' — aborting" >&2
     rm -f "${tmp}"
-    exit 1
+    return 1
   fi
   mv "${tmp}" "${file}"
   echo "Removed local Compose service '${service}' (vector preserved if present)"
@@ -116,21 +160,16 @@ if [ -f "${DBAAS_FILE}" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DB
       echo "ERROR: Refusing to rewire Supabase to an unreachable database." >&2
       echo "ERROR: Add this Droplet's public IP under the database Trusted Sources," >&2
       echo "ERROR: then re-run: /var/lib/digitalocean/setup-dbaas.sh && cd /srv/supabase/supabase/docker && docker compose -f docker-compose.yml -f docker-compose.dbaas.yml up -d" >&2
-      cat >> /root/.digitalocean_passwords <<EOM
-SUPABASE_DBAAS=failed
-SUPABASE_DBAAS_ERROR='Timed out waiting for Managed Postgres — check Trusted Sources'
-POSTGRES_HOST=$(shell_quote "${PG_HOST}")
-POSTGRES_PORT=$(shell_quote "${PG_PORT}")
-POSTGRES_DB=$(shell_quote "${PG_DB}")
-POSTGRES_USER=$(shell_quote "${PG_USER}")
-EOM
-      exit 1
+      dbaas_die "Timed out waiting for Managed Postgres — check Trusted Sources"
     fi
     printf .
     sleep 2
     elapsed=$((elapsed + 2))
   done
   echo -e "\nManaged database available!\n"
+
+  # Any later failure in this DBaaS path marks MOTD as failed (idempotent upsert).
+  trap 'rc=$?; mark_dbaas_status failed "DBaaS setup aborted — see /var/log/one_click_setup.log"; [ -n "${PG_HOST:-}" ] && upsert_password_var POSTGRES_HOST "${PG_HOST}"; [ -n "${PG_PORT:-}" ] && upsert_password_var POSTGRES_PORT "${PG_PORT}"; [ -n "${PG_DB:-}" ] && upsert_password_var POSTGRES_DB "${PG_DB}"; [ -n "${PG_USER:-}" ] && upsert_password_var POSTGRES_USER "${PG_USER}"; exit "${rc}"' ERR
 
   # Point Supabase services at the managed Postgres instance
   update_env_var POSTGRES_HOST "${PG_HOST}"
@@ -151,7 +190,9 @@ EOM
   # Remove empty depends_on keys left behind
   perl -i -0pe 's/\n(    depends_on:)\n(    [a-z#])/\n$2/g' "${COMPOSE_FILE}"
 
-  remove_compose_service db "${COMPOSE_FILE}"
+  if ! remove_compose_service db "${COMPOSE_FILE}"; then
+    dbaas_die "Failed to remove local db service from compose while preserving vector"
+  fi
 
   # Require SSL for managed database connection strings in compose
   # Ecto uses ssl=true; libpq URLs use sslmode=require (apply ecto first)
@@ -284,8 +325,7 @@ SQL
   # jwt.sql equivalent. Custom GUCs like app.settings.* are often denied for doadmin
   # on Managed Postgres; Auth/Realtime still get JWT from container env — warn, don't abort.
   if [ -z "${JWT_SECRET}" ]; then
-    echo "ERROR: JWT_SECRET missing from ${ENV_FILE}; run generate-keys before setup-dbaas" >&2
-    exit 1
+    dbaas_die "JWT_SECRET missing from ${ENV_FILE}; run generate-keys before setup-dbaas"
   fi
   if ! psql_admin -v ON_ERROR_STOP=1 \
     -c "ALTER DATABASE \"${PG_DB}\" SET \"app.settings.jwt_secret\" TO '${JWT_SECRET_SQL}';" 2>/tmp/supabase-jwt-guc.err; then
@@ -303,24 +343,20 @@ SQL
   for role in supabase_admin authenticator supabase_auth_admin supabase_storage_admin \
               anon authenticated service_role pgbouncer; do
     if ! psql_admin -tAc "SELECT 1 FROM pg_roles WHERE rolname = '${role}'" | grep -q 1; then
-      echo "ERROR: required role missing after bootstrap: ${role}" >&2
-      exit 1
+      dbaas_die "required role missing after bootstrap: ${role}"
     fi
   done
   for schema in auth storage realtime _realtime graphql_public extensions; do
     if ! psql_admin -tAc "SELECT 1 FROM pg_namespace WHERE nspname = '${schema}'" | grep -q 1; then
-      echo "ERROR: required schema missing after bootstrap: ${schema}" >&2
-      exit 1
+      dbaas_die "required schema missing after bootstrap: ${schema}"
     fi
   done
   if ! psql_admin -tAc "SELECT 1 FROM pg_database WHERE datname = '_supabase'" | grep -q 1; then
-    echo "ERROR: database _supabase was not created" >&2
-    exit 1
+    dbaas_die "database _supabase was not created"
   fi
   for schema in _analytics _supavisor; do
     if ! psql_supabase_db -tAc "SELECT 1 FROM pg_namespace WHERE nspname = '${schema}'" | grep -q 1; then
-      echo "ERROR: required _supabase schema missing: ${schema}" >&2
-      exit 1
+      dbaas_die "required _supabase schema missing: ${schema}"
     fi
   done
 
@@ -350,17 +386,13 @@ SQL
   PREPARE="/var/lib/digitalocean/prepare-logflare-ssl.sh"
 
   if [ ! -x "${PREPARE}" ]; then
-    echo "ERROR: missing ${PREPARE}" >&2
-    exit 1
+    dbaas_die "missing ${PREPARE}"
   fi
   if ! "${PREPARE}" "${COMPOSE_DIR}"; then
-    echo "ERROR: Failed to prepare Logflare SSL patch for Managed Postgres." >&2
-    echo "ERROR: Refusing to mark DBaaS setup successful — analytics would block Studio/Kong." >&2
-    exit 1
+    dbaas_die "Failed to prepare Logflare SSL patch for Managed Postgres — analytics would block Studio/Kong"
   fi
   if [ ! -f "${RUNTIME_EXS}" ]; then
-    echo "ERROR: Logflare runtime.exs missing after prepare step." >&2
-    exit 1
+    dbaas_die "Logflare runtime.exs missing after prepare step"
   fi
 
   # Match top-level analytics service only (not nested depends_on: analytics:).
@@ -378,6 +410,8 @@ SQL
   # SSL / TLS for services that talk to Managed Postgres outside URL query params.
   # Cap per-service pools so the stack fits small Managed DB plans.
   # Studio must not wait on analytics healthy — otherwise Logflare issues hide Studio.
+  # Storage: TLS via compose DATABASE_URL ?sslmode=require (patched above) — do not use
+  # NODE_TLS_REJECT_UNAUTHORIZED (process-wide disable).
   cat > "${COMPOSE_DIR}/docker-compose.dbaas.yml" <<EOF
 services:
   realtime:
@@ -398,7 +432,7 @@ services:
       - ./volumes/analytics/runtime.exs:/opt/app/rel/logflare/releases/${LOGFLARE_VER}/runtime.exs:ro
   storage:
     environment:
-      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      PGSSLMODE: require
   auth:
     environment:
       GOTRUE_DB_SSLMODE: require
@@ -409,7 +443,7 @@ services:
         condition: service_started
 EOF
 
-  # Persist credentials for MOTD / operators
+  # Persist credentials for MOTD / operators (idempotent upserts)
   if command -v jq >/dev/null 2>&1; then
     PG_PASS_ENC=$(jq -nr --arg p "${PG_PASS}" '$p|@uri')
   else
@@ -417,23 +451,22 @@ EOF
   fi
   DATABASE_URL="postgresql://${PG_USER}:${PG_PASS_ENC}@${PG_HOST}:${PG_PORT}/${PG_DB}?sslmode=require"
 
-  cat >> /root/.digitalocean_passwords <<EOM
-SUPABASE_DBAAS=true
-POSTGRES_HOST=$(shell_quote "${PG_HOST}")
-POSTGRES_PORT=$(shell_quote "${PG_PORT}")
-POSTGRES_DB=$(shell_quote "${PG_DB}")
-POSTGRES_USER=$(shell_quote "${PG_USER}")
-POSTGRES_PASSWORD=$(shell_quote "${PG_PASS}")
-DATABASE_URL=$(shell_quote "${DATABASE_URL}")
-EOM
+  mark_dbaas_status true
+  upsert_password_var POSTGRES_HOST "${PG_HOST}"
+  upsert_password_var POSTGRES_PORT "${PG_PORT}"
+  upsert_password_var POSTGRES_DB "${PG_DB}"
+  upsert_password_var POSTGRES_USER "${PG_USER}"
+  upsert_password_var POSTGRES_PASSWORD "${PG_PASS}"
+  upsert_password_var DATABASE_URL "${DATABASE_URL}"
 
   if ! grep -q '^DATABASE_URL=' /etc/environment 2>/dev/null; then
-    echo "DATABASE_URL=\"${DATABASE_URL}\"" >> /etc/environment
+    echo "DATABASE_URL=$(shell_quote "${DATABASE_URL}")" >> /etc/environment
   else
     sed -i "/^DATABASE_URL=/d" /etc/environment
-    echo "DATABASE_URL=\"${DATABASE_URL}\"" >> /etc/environment
+    echo "DATABASE_URL=$(shell_quote "${DATABASE_URL}")" >> /etc/environment
   fi
 
+  trap - ERR
   echo "Supabase configured to use Managed PostgreSQL at ${PG_HOST}:${PG_PORT}/${PG_DB}"
 fi
 
@@ -441,11 +474,9 @@ if [ "${using_dbaas}" = false ]; then
   LOCAL_PG_PASS=$(read_env_var POSTGRES_PASSWORD)
   LOCAL_PG_DB=$(read_env_var POSTGRES_DB)
   LOCAL_PG_DB="${LOCAL_PG_DB:-postgres}"
-  cat >> /root/.digitalocean_passwords <<EOM
-SUPABASE_DBAAS=false
-POSTGRES_HOST='db'
-POSTGRES_PORT='5432'
-POSTGRES_DB=$(shell_quote "${LOCAL_PG_DB}")
-POSTGRES_PASSWORD=$(shell_quote "${LOCAL_PG_PASS}")
-EOM
+  mark_dbaas_status false
+  upsert_password_var POSTGRES_HOST "db"
+  upsert_password_var POSTGRES_PORT "5432"
+  upsert_password_var POSTGRES_DB "${LOCAL_PG_DB}"
+  upsert_password_var POSTGRES_PASSWORD "${LOCAL_PG_PASS}"
 fi

--- a/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
+++ b/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
@@ -5,7 +5,8 @@
 # When DBaaS credentials are present:
 #   - Point Supabase .env at Managed Postgres
 #   - Remove the local db (supabase/postgres) service from compose
-#   - Bootstrap roles/schemas needed by Supabase (best-effort)
+#   - Bootstrap roles/schemas (incl. auth/storage) needed by Supabase
+#   - Enable TLS for analytics/auth/storage/realtime against Managed Postgres
 # When absent, keep the local db container (default).
 
 set -uo pipefail
@@ -72,14 +73,24 @@ if [ -f "${DBAAS_FILE}" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DB
   update_env_var POSTGRES_DB "${PG_DB}"
   update_env_var POSTGRES_PASSWORD "${PG_PASS}"
 
+  # DO Managed Postgres allows ~25 connections per 1GB RAM, minus 3 reserved
+  # for maintenance. Stock Supabase defaults (POOLER_DEFAULT_POOL_SIZE=20 plus
+  # PostgREST/Auth/Logflare/…) exhaust a typical Marketplace 1GB DB and surface:
+  #   FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute
+  update_env_var POOLER_DEFAULT_POOL_SIZE "5"
+  update_env_var POOLER_MAX_CLIENT_CONN "50"
+  update_env_var POOLER_DB_POOL_SIZE "2"
+
   # Remove depends_on entries that require the local db container
   perl -i -0pe 's/\n[ \t]+db:\n[ \t]+# Disable this if you are using an external Postgres database\n[ \t]+condition: service_healthy//g' "${COMPOSE_FILE}"
   perl -i -0pe 's/\n[ \t]+db:\n[ \t]+condition: service_healthy//g' "${COMPOSE_FILE}"
   # Remove empty depends_on keys left behind
   perl -i -0pe 's/\n(    depends_on:)\n(    [a-z#])/\n$2/g' "${COMPOSE_FILE}"
 
-  # Drop the embedded db service; keep supavisor and the rest of the stack
-  perl -i -0pe 's/\n  # Comment out everything below this point if you are using an external Postgres database\n  db:.*?(?=\n  # Update the DATABASE_URL if you are using an external Postgres database)//s' "${COMPOSE_FILE}"
+  # Drop only the embedded db service; keep vector (log shipping) and everything after.
+  # Upstream places vector between db and the "# Update the DATABASE_URL…" marker — do not
+  # cut through that whole region or vector is deleted with db.
+  perl -i -0pe 's/\n  # Comment out everything below this point if you are using an external Postgres database\n  db:\n(?:.*\n)*?(?=\n  vector:)//' "${COMPOSE_FILE}"
 
   # Require SSL for managed database connection strings in compose
   # Ecto uses ssl=true; libpq URLs use sslmode=require (apply ecto first)
@@ -159,10 +170,21 @@ SQL
     psql_admin -c "CREATE DATABASE _supabase OWNER supabase_admin;" || true
   fi
 
-  # Schemas that the local supabase/postgres image would create via init scripts
+  # Schemas the local supabase/postgres image would create via init scripts.
+  # auth/storage are required before GoTrue/Storage can migrate on Managed Postgres.
   psql_admin -v ON_ERROR_STOP=0 <<SQL || true
 CREATE SCHEMA IF NOT EXISTS _realtime AUTHORIZATION supabase_admin;
 CREATE SCHEMA IF NOT EXISTS extensions AUTHORIZATION supabase_admin;
+CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_auth_admin;
+CREATE SCHEMA IF NOT EXISTS storage AUTHORIZATION supabase_storage_admin;
+CREATE SCHEMA IF NOT EXISTS graphql_public AUTHORIZATION supabase_admin;
+CREATE SCHEMA IF NOT EXISTS realtime AUTHORIZATION supabase_admin;
+GRANT ALL ON SCHEMA auth TO postgres, supabase_admin, supabase_auth_admin, authenticator;
+GRANT ALL ON SCHEMA storage TO postgres, supabase_admin, supabase_storage_admin, authenticator;
+GRANT ALL ON SCHEMA graphql_public TO postgres, supabase_admin, authenticator, anon, authenticated, service_role;
+GRANT ALL ON SCHEMA realtime TO postgres, supabase_admin, authenticator;
+GRANT ALL ON SCHEMA extensions TO postgres, supabase_admin, authenticator;
+GRANT ALL ON SCHEMA _realtime TO postgres, supabase_admin;
 SQL
 
   PGPASSWORD="${PG_PASS}" psql \
@@ -170,6 +192,8 @@ SQL
     -v ON_ERROR_STOP=0 <<SQL || true
 CREATE SCHEMA IF NOT EXISTS _analytics AUTHORIZATION supabase_admin;
 CREATE SCHEMA IF NOT EXISTS _supavisor AUTHORIZATION supabase_admin;
+GRANT ALL ON SCHEMA _analytics TO supabase_admin;
+GRANT ALL ON SCHEMA _supavisor TO supabase_admin;
 SQL
 
   if [ -n "${JWT_SECRET}" ]; then
@@ -192,8 +216,44 @@ SQL
     fi
   done
 
-  # Enable SSL for services that connect via discrete DB host/port (not URL)
-  cat > "${COMPOSE_DIR}/docker-compose.dbaas.yml" <<'EOF'
+  # Logflare only enables DB SSL when DB_SSL=true AND client cert PEMs exist.
+  # DO Managed Postgres uses server TLS without client certs.
+  # Prefer the Packer-baked patched runtime.exs; rebuild it if missing.
+  ANALYTICS_VOL="${COMPOSE_DIR}/volumes/analytics"
+  RUNTIME_EXS="${ANALYTICS_VOL}/runtime.exs"
+  VERSION_FILE="${ANALYTICS_VOL}/logflare_version"
+  PREPARE="/var/lib/digitalocean/prepare-logflare-ssl.sh"
+
+  if [ ! -x "${PREPARE}" ]; then
+    echo "ERROR: missing ${PREPARE}" >&2
+    exit 1
+  fi
+  if ! "${PREPARE}" "${COMPOSE_DIR}"; then
+    echo "ERROR: Failed to prepare Logflare SSL patch for Managed Postgres." >&2
+    echo "ERROR: Refusing to mark DBaaS setup successful — analytics would block Studio/Kong." >&2
+    exit 1
+  fi
+  if [ ! -f "${RUNTIME_EXS}" ]; then
+    echo "ERROR: Logflare runtime.exs missing after prepare step." >&2
+    exit 1
+  fi
+
+  # Match top-level analytics service only (not nested depends_on: analytics:).
+  LOGFLARE_IMAGE=$(awk '
+    /^[[:space:]]{2}analytics:[[:space:]]*$/ { f=1; next }
+    f && /^[[:space:]]{2}[a-zA-Z0-9_]+:/ { f=0 }
+    f && /^[[:space:]]+image:[[:space:]]*/ { print $2; exit }
+  ' "${COMPOSE_FILE}")
+  LOGFLARE_IMAGE="${LOGFLARE_IMAGE:-supabase/logflare:1.36.1}"
+  LOGFLARE_VER="${LOGFLARE_IMAGE##*:}"
+  if [ -f "${VERSION_FILE}" ]; then
+    LOGFLARE_VER=$(tr -d '[:space:]' < "${VERSION_FILE}")
+  fi
+
+  # SSL / TLS for services that talk to Managed Postgres outside URL query params.
+  # Cap per-service pools so the stack fits small Managed DB plans.
+  # Studio must not wait on analytics healthy — otherwise Logflare issues hide Studio.
+  cat > "${COMPOSE_DIR}/docker-compose.dbaas.yml" <<EOF
 services:
   realtime:
     environment:
@@ -201,9 +261,27 @@ services:
   meta:
     environment:
       PGSSLMODE: require
+  rest:
+    environment:
+      PGRST_DB_POOL: "5"
   analytics:
     environment:
+      DB_SSL: "true"
       PGSSLMODE: require
+      DB_POOL_SIZE: "3"
+    volumes:
+      - ./volumes/analytics/runtime.exs:/opt/app/rel/logflare/releases/${LOGFLARE_VER}/runtime.exs:ro
+  storage:
+    environment:
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+  auth:
+    environment:
+      GOTRUE_DB_SSLMODE: require
+      GOTRUE_DB_MAX_POOL_SIZE: "5"
+  studio:
+    depends_on:
+      analytics:
+        condition: service_started
 EOF
 
   # Persist credentials for MOTD / operators

--- a/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
+++ b/supabase-24-04/files/var/lib/digitalocean/setup-dbaas.sh
@@ -3,13 +3,15 @@
 # credentials are provided via Marketplace predeploy (Add a Database).
 #
 # When DBaaS credentials are present:
+#   - Wait until Managed Postgres is reachable (abort on timeout)
 #   - Point Supabase .env at Managed Postgres
-#   - Remove the local db (supabase/postgres) service from compose
-#   - Bootstrap roles/schemas (incl. auth/storage) needed by Supabase
+#   - Remove only the local db service from compose (keep vector)
+#   - Fail-fast bootstrap of required roles/schemas/_supabase
+#   - Apply local-parity init SQL where Managed PG allows
 #   - Enable TLS for analytics/auth/storage/realtime against Managed Postgres
 # When absent, keep the local db container (default).
 
-set -uo pipefail
+set -euo pipefail
 
 COMPOSE_DIR="/srv/supabase/supabase/docker"
 COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
@@ -35,6 +37,59 @@ read_env_var() {
   sed -n "s/^${key}=//p" "${ENV_FILE}" | tail -n1
 }
 
+# Remove a single top-level Compose service by name (2-space indent).
+# Safer than cutting between upstream comment markers (which also deleted vector).
+# Re-test whenever application_version / upstream docker-compose.yml layout changes.
+remove_compose_service() {
+  local service="$1"
+  local file="$2"
+  local tmp had_vector=0
+
+  if grep -qE "^  ${service}:" "${file}"; then
+    :
+  else
+    echo "NOTE: top-level service '${service}' not present in ${file}; nothing to remove"
+    return 0
+  fi
+  grep -qE '^  vector:' "${file}" && had_vector=1
+
+  tmp=$(mktemp)
+  awk -v svc="${service}" '
+    BEGIN { skip=0 }
+    /^  # Comment out everything below this point if you are using an external Postgres database$/ {
+      next
+    }
+    /^  [a-zA-Z0-9_]+:/ {
+      name=$1
+      sub(/:.*/, "", name)
+      if (name == svc) { skip=1; next }
+      skip=0
+      print
+      next
+    }
+    /^  #/ {
+      skip=0
+      print
+      next
+    }
+    skip { next }
+    { print }
+  ' "${file}" > "${tmp}"
+
+  if grep -qE "^  ${service}:" "${tmp}"; then
+    echo "ERROR: failed to remove Compose service '${service}' from ${file}" >&2
+    rm -f "${tmp}"
+    exit 1
+  fi
+  if [ "${had_vector}" -eq 1 ] && ! grep -qE '^  vector:' "${tmp}"; then
+    echo "ERROR: compose edit removed vector while stripping '${service}' — aborting" >&2
+    rm -f "${tmp}"
+    exit 1
+  fi
+  mv "${tmp}" "${file}"
+  echo "Removed local Compose service '${service}' (vector preserved if present)"
+}
+
 using_dbaas=false
 
 if [ -f "${DBAAS_FILE}" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DBAAS_FILE}")" = "postgresql" ]; then
@@ -49,23 +104,33 @@ if [ -f "${DBAAS_FILE}" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DB
   JWT_SECRET=$(read_env_var JWT_SECRET)
   JWT_EXPIRY=$(read_env_var JWT_EXPIRY)
   JWT_EXPIRY="${JWT_EXPIRY:-3600}"
+  JWT_SECRET_SQL=$(printf '%s' "${JWT_SECRET}" | sed "s/'/''/g")
 
   echo -e "\nWaiting for your managed database to become available (up to ${DBAAS_WAIT_SECONDS}s)"
   elapsed=0
   until PGPASSWORD="${PG_PASS}" psql \
-    "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" \
+    "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require connect_timeout=5" \
     -c 'SELECT 1' >/dev/null 2>&1; do
     if [ "${elapsed}" -ge "${DBAAS_WAIT_SECONDS}" ]; then
-      echo -e "\nTimed out waiting for managed database. Continuing with Managed Postgres config; check Trusted Sources if services fail to connect."
-      break
+      echo -e "\nERROR: Timed out waiting for Managed Postgres at ${PG_HOST}:${PG_PORT}." >&2
+      echo "ERROR: Refusing to rewire Supabase to an unreachable database." >&2
+      echo "ERROR: Add this Droplet's public IP under the database Trusted Sources," >&2
+      echo "ERROR: then re-run: /var/lib/digitalocean/setup-dbaas.sh && cd /srv/supabase/supabase/docker && docker compose -f docker-compose.yml -f docker-compose.dbaas.yml up -d" >&2
+      cat >> /root/.digitalocean_passwords <<EOM
+SUPABASE_DBAAS=failed
+SUPABASE_DBAAS_ERROR='Timed out waiting for Managed Postgres — check Trusted Sources'
+POSTGRES_HOST=$(shell_quote "${PG_HOST}")
+POSTGRES_PORT=$(shell_quote "${PG_PORT}")
+POSTGRES_DB=$(shell_quote "${PG_DB}")
+POSTGRES_USER=$(shell_quote "${PG_USER}")
+EOM
+      exit 1
     fi
     printf .
     sleep 2
     elapsed=$((elapsed + 2))
   done
-  if [ "${elapsed}" -lt "${DBAAS_WAIT_SECONDS}" ]; then
-    echo -e "\nManaged database available!\n"
-  fi
+  echo -e "\nManaged database available!\n"
 
   # Point Supabase services at the managed Postgres instance
   update_env_var POSTGRES_HOST "${PG_HOST}"
@@ -75,8 +140,7 @@ if [ -f "${DBAAS_FILE}" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DB
 
   # DO Managed Postgres allows ~25 connections per 1GB RAM, minus 3 reserved
   # for maintenance. Stock Supabase defaults (POOLER_DEFAULT_POOL_SIZE=20 plus
-  # PostgREST/Auth/Logflare/…) exhaust a typical Marketplace 1GB DB and surface:
-  #   FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute
+  # PostgREST/Auth/Logflare/…) exhaust a typical Marketplace 1GB DB.
   update_env_var POOLER_DEFAULT_POOL_SIZE "5"
   update_env_var POOLER_MAX_CLIENT_CONN "50"
   update_env_var POOLER_DB_POOL_SIZE "2"
@@ -87,10 +151,7 @@ if [ -f "${DBAAS_FILE}" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DB
   # Remove empty depends_on keys left behind
   perl -i -0pe 's/\n(    depends_on:)\n(    [a-z#])/\n$2/g' "${COMPOSE_FILE}"
 
-  # Drop only the embedded db service; keep vector (log shipping) and everything after.
-  # Upstream places vector between db and the "# Update the DATABASE_URL…" marker — do not
-  # cut through that whole region or vector is deleted with db.
-  perl -i -0pe 's/\n  # Comment out everything below this point if you are using an external Postgres database\n  db:\n(?:.*\n)*?(?=\n  vector:)//' "${COMPOSE_FILE}"
+  remove_compose_service db "${COMPOSE_FILE}"
 
   # Require SSL for managed database connection strings in compose
   # Ecto uses ssl=true; libpq URLs use sslmode=require (apply ecto first)
@@ -102,8 +163,15 @@ if [ -f "${DBAAS_FILE}" ] && [ "$(sed -n "s/^db_protocol=\"\(.*\)\"$/\1/p" "${DB
       "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" "$@"
   }
 
-  # Create roles expected by Supabase services (best-effort on managed Postgres)
-  psql_admin -v ON_ERROR_STOP=0 <<SQL || true
+  psql_supabase_db() {
+    PGPASSWORD="${PG_PASS}" psql \
+      "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=_supabase sslmode=require" "$@"
+  }
+
+  echo "Bootstrapping required Supabase roles (fail-fast)..."
+  # Create required login roles. BYPASSRLS is attempted but optional on Managed PG
+  # (doadmin may lack permission); role existence is mandatory.
+  psql_admin -v ON_ERROR_STOP=1 <<SQL
 DO \$\$
 BEGIN
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'postgres') THEN
@@ -111,39 +179,52 @@ BEGIN
   ELSE
     BEGIN
       ALTER ROLE postgres WITH LOGIN PASSWORD '${PG_PASS_SQL}';
-    EXCEPTION WHEN OTHERS THEN NULL;
+    EXCEPTION WHEN insufficient_privilege THEN
+      RAISE NOTICE 'skipping ALTER ROLE postgres (insufficient privilege)';
     END;
   END IF;
+
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
     CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD '${PG_PASS_SQL}';
   ELSE
     ALTER ROLE authenticator WITH LOGIN PASSWORD '${PG_PASS_SQL}';
   END IF;
+
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN
     CREATE ROLE pgbouncer LOGIN PASSWORD '${PG_PASS_SQL}';
   ELSE
     ALTER ROLE pgbouncer WITH LOGIN PASSWORD '${PG_PASS_SQL}';
   END IF;
+
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_admin') THEN
-    CREATE ROLE supabase_admin LOGIN PASSWORD '${PG_PASS_SQL}' CREATEDB CREATEROLE BYPASSRLS;
+    BEGIN
+      CREATE ROLE supabase_admin LOGIN PASSWORD '${PG_PASS_SQL}' CREATEDB CREATEROLE BYPASSRLS;
+    EXCEPTION WHEN OTHERS THEN
+      CREATE ROLE supabase_admin LOGIN PASSWORD '${PG_PASS_SQL}' CREATEDB CREATEROLE;
+      RAISE NOTICE 'created supabase_admin without BYPASSRLS: %', SQLERRM;
+    END;
   ELSE
     ALTER ROLE supabase_admin WITH LOGIN PASSWORD '${PG_PASS_SQL}' CREATEDB CREATEROLE;
   END IF;
+
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_auth_admin') THEN
     CREATE ROLE supabase_auth_admin LOGIN PASSWORD '${PG_PASS_SQL}';
   ELSE
     ALTER ROLE supabase_auth_admin WITH LOGIN PASSWORD '${PG_PASS_SQL}';
   END IF;
+
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_storage_admin') THEN
     CREATE ROLE supabase_storage_admin LOGIN PASSWORD '${PG_PASS_SQL}';
   ELSE
     ALTER ROLE supabase_storage_admin WITH LOGIN PASSWORD '${PG_PASS_SQL}';
   END IF;
+
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_functions_admin') THEN
     CREATE ROLE supabase_functions_admin LOGIN PASSWORD '${PG_PASS_SQL}';
   ELSE
     ALTER ROLE supabase_functions_admin WITH LOGIN PASSWORD '${PG_PASS_SQL}';
   END IF;
+
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
     CREATE ROLE anon NOLOGIN NOINHERIT;
   END IF;
@@ -151,7 +232,12 @@ BEGIN
     CREATE ROLE authenticated NOLOGIN NOINHERIT;
   END IF;
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
-    CREATE ROLE service_role NOLOGIN NOINHERIT BYPASSRLS;
+    BEGIN
+      CREATE ROLE service_role NOLOGIN NOINHERIT BYPASSRLS;
+    EXCEPTION WHEN OTHERS THEN
+      CREATE ROLE service_role NOLOGIN NOINHERIT;
+      RAISE NOTICE 'created service_role without BYPASSRLS: %', SQLERRM;
+    END;
   END IF;
 END
 \$\$;
@@ -166,13 +252,13 @@ GRANT anon, authenticated, service_role TO authenticator;
 GRANT ALL ON SCHEMA public TO anon, authenticated, service_role;
 SQL
 
-  if ! psql_admin -tAc "SELECT 1 FROM pg_database WHERE datname = '_supabase'" 2>/dev/null | grep -q 1; then
-    psql_admin -c "CREATE DATABASE _supabase OWNER supabase_admin;" || true
+  echo "Ensuring _supabase database exists..."
+  if ! psql_admin -tAc "SELECT 1 FROM pg_database WHERE datname = '_supabase'" | grep -q 1; then
+    psql_admin -v ON_ERROR_STOP=1 -c "CREATE DATABASE _supabase OWNER supabase_admin;"
   fi
 
-  # Schemas the local supabase/postgres image would create via init scripts.
-  # auth/storage are required before GoTrue/Storage can migrate on Managed Postgres.
-  psql_admin -v ON_ERROR_STOP=0 <<SQL || true
+  echo "Creating required schemas (auth/storage/realtime/…)..."
+  psql_admin -v ON_ERROR_STOP=1 <<SQL
 CREATE SCHEMA IF NOT EXISTS _realtime AUTHORIZATION supabase_admin;
 CREATE SCHEMA IF NOT EXISTS extensions AUTHORIZATION supabase_admin;
 CREATE SCHEMA IF NOT EXISTS auth AUTHORIZATION supabase_auth_admin;
@@ -187,38 +273,77 @@ GRANT ALL ON SCHEMA extensions TO postgres, supabase_admin, authenticator;
 GRANT ALL ON SCHEMA _realtime TO postgres, supabase_admin;
 SQL
 
-  PGPASSWORD="${PG_PASS}" psql \
-    "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=_supabase sslmode=require" \
-    -v ON_ERROR_STOP=0 <<SQL || true
+  # Local image init equivalents: logs.sql / pooler.sql (_analytics, _supavisor on _supabase)
+  psql_supabase_db -v ON_ERROR_STOP=1 <<SQL
 CREATE SCHEMA IF NOT EXISTS _analytics AUTHORIZATION supabase_admin;
 CREATE SCHEMA IF NOT EXISTS _supavisor AUTHORIZATION supabase_admin;
 GRANT ALL ON SCHEMA _analytics TO supabase_admin;
 GRANT ALL ON SCHEMA _supavisor TO supabase_admin;
 SQL
 
-  if [ -n "${JWT_SECRET}" ]; then
-    psql_admin -v ON_ERROR_STOP=0 \
-      -c "ALTER DATABASE \"${PG_DB}\" SET \"app.settings.jwt_secret\" TO '${JWT_SECRET}';" || true
-    psql_admin -v ON_ERROR_STOP=0 \
-      -c "ALTER DATABASE \"${PG_DB}\" SET \"app.settings.jwt_exp\" TO '${JWT_EXPIRY}';" || true
+  # jwt.sql equivalent. Custom GUCs like app.settings.* are often denied for doadmin
+  # on Managed Postgres; Auth/Realtime still get JWT from container env — warn, don't abort.
+  if [ -z "${JWT_SECRET}" ]; then
+    echo "ERROR: JWT_SECRET missing from ${ENV_FILE}; run generate-keys before setup-dbaas" >&2
+    exit 1
   fi
+  if ! psql_admin -v ON_ERROR_STOP=1 \
+    -c "ALTER DATABASE \"${PG_DB}\" SET \"app.settings.jwt_secret\" TO '${JWT_SECRET_SQL}';" 2>/tmp/supabase-jwt-guc.err; then
+    echo "WARNING: cannot set app.settings.jwt_secret on Managed Postgres (common for doadmin)." >&2
+    echo "WARNING: continuing — services use JWT_SECRET from .env. Detail: $(tr '\n' ' ' </tmp/supabase-jwt-guc.err)" >&2
+  fi
+  if ! psql_admin -v ON_ERROR_STOP=1 \
+    -c "ALTER DATABASE \"${PG_DB}\" SET \"app.settings.jwt_exp\" TO '${JWT_EXPIRY}';" 2>/tmp/supabase-jwt-guc.err; then
+    echo "WARNING: cannot set app.settings.jwt_exp on Managed Postgres; continuing." >&2
+  fi
+  rm -f /tmp/supabase-jwt-guc.err
 
-  # Apply remaining bundled init SQL when possible (extensions like pg_net may be unavailable)
-  for sql in \
-    "${COMPOSE_DIR}/volumes/db/roles.sql" \
-    "${COMPOSE_DIR}/volumes/db/webhooks.sql"
-  do
-    if [ -f "${sql}" ]; then
-      echo "Applying $(basename "${sql}") to managed database (best-effort)"
-      PGPASSWORD="${PG_PASS}" POSTGRES_PASSWORD="${PG_PASS}" POSTGRES_USER=supabase_admin psql \
-        "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" \
-        -v ON_ERROR_STOP=0 -f "${sql}" || true
+  # Verify required objects exist before continuing
+  echo "Verifying required roles and schemas..."
+  for role in supabase_admin authenticator supabase_auth_admin supabase_storage_admin \
+              anon authenticated service_role pgbouncer; do
+    if ! psql_admin -tAc "SELECT 1 FROM pg_roles WHERE rolname = '${role}'" | grep -q 1; then
+      echo "ERROR: required role missing after bootstrap: ${role}" >&2
+      exit 1
+    fi
+  done
+  for schema in auth storage realtime _realtime graphql_public extensions; do
+    if ! psql_admin -tAc "SELECT 1 FROM pg_namespace WHERE nspname = '${schema}'" | grep -q 1; then
+      echo "ERROR: required schema missing after bootstrap: ${schema}" >&2
+      exit 1
+    fi
+  done
+  if ! psql_admin -tAc "SELECT 1 FROM pg_database WHERE datname = '_supabase'" | grep -q 1; then
+    echo "ERROR: database _supabase was not created" >&2
+    exit 1
+  fi
+  for schema in _analytics _supavisor; do
+    if ! psql_supabase_db -tAc "SELECT 1 FROM pg_namespace WHERE nspname = '${schema}'" | grep -q 1; then
+      echo "ERROR: required _supabase schema missing: ${schema}" >&2
+      exit 1
     fi
   done
 
+  # roles.sql — sync passwords (local-parity; fail-fast)
+  if [ -f "${COMPOSE_DIR}/volumes/db/roles.sql" ]; then
+    echo "Applying roles.sql to managed database..."
+    PGPASSWORD="${PG_PASS}" POSTGRES_PASSWORD="${PG_PASS}" psql \
+      "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" \
+      -v ON_ERROR_STOP=1 -f "${COMPOSE_DIR}/volumes/db/roles.sql"
+  fi
+
+  # webhooks.sql needs pg_net (often unavailable on Managed PG) — best-effort with warning
+  if [ -f "${COMPOSE_DIR}/volumes/db/webhooks.sql" ]; then
+    echo "Applying webhooks.sql to managed database (best-effort; needs pg_net)..."
+    if ! PGPASSWORD="${PG_PASS}" POSTGRES_PASSWORD="${PG_PASS}" POSTGRES_USER=supabase_admin psql \
+      "host=${PG_HOST} port=${PG_PORT} user=${PG_USER} dbname=${PG_DB} sslmode=require" \
+      -v ON_ERROR_STOP=1 -f "${COMPOSE_DIR}/volumes/db/webhooks.sql"; then
+      echo "WARNING: webhooks.sql failed (pg_net or privileges). Database webhooks may be unavailable." >&2
+    fi
+  fi
+
   # Logflare only enables DB SSL when DB_SSL=true AND client cert PEMs exist.
   # DO Managed Postgres uses server TLS without client certs.
-  # Prefer the Packer-baked patched runtime.exs; rebuild it if missing.
   ANALYTICS_VOL="${COMPOSE_DIR}/volumes/analytics"
   RUNTIME_EXS="${ANALYTICS_VOL}/runtime.exs"
   VERSION_FILE="${ANALYTICS_VOL}/logflare_version"

--- a/supabase-24-04/listing.md
+++ b/supabase-24-04/listing.md
@@ -1,0 +1,112 @@
+# Supabase 1-Click Application
+
+Deploy self-hosted Supabase on Ubuntu 24.04 with Docker Compose and Nginx. Supabase provides Postgres-backed Auth, REST/Realtime APIs, Storage, and Studio. The Supabase stack uses its local `db` container. You can optionally attach a DigitalOcean Managed PostgreSQL database at create time for your own application data.
+
+## Included System Components
+
+- **Ubuntu 24.04 LTS**
+- **Docker Engine** and **Docker Compose plugin**
+- **Supabase** (pinned release from the image build, currently `v1.26.05`) — Studio, Kong, Auth, PostgREST, Realtime, Storage, and related services
+- **PostgreSQL** via the Supabase `db` container (`supabase/postgres`)
+- **Nginx** reverse proxy (ports 80/443 → Kong on `localhost:8000`)
+- **Certbot** (Snap) for optional custom-domain TLS
+- **UFW** — SSH, HTTP, and HTTPS
+- **postgresql-client** — used on first boot when a Managed Database is attached
+
+## System Requirements
+
+| Use Case | RAM | CPU | Storage |
+|----------|-----|-----|---------|
+| Minimum | 2 GB | 1 vCPU | 25 GB |
+| Recommended | 4 GB+ | 2 vCPU | 50 GB+ |
+
+## Getting Started
+
+### 1. Deploy the Droplet
+
+1. Select the Supabase 1-Click from the DigitalOcean Marketplace
+2. Choose a Droplet size (2 GB RAM minimum recommended)
+3. Optionally select **Add a Database** to provision Managed PostgreSQL (see below)
+4. Add your SSH key and create the Droplet
+
+### 2. Access Supabase
+
+1. Open `http://your-droplet-ip` in a browser (Nginx → Kong / Studio)
+2. SSH in for credentials:
+
+```bash
+ssh root@your-droplet-ip
+```
+
+Dashboard username and password are shown in the MOTD and stored in `/root/.digitalocean_passwords`.
+
+### 3. Optional domain / HTTPS
+
+Domain and TLS setup is manual (not prompted on every login). When ready, run:
+
+```bash
+/var/supabase/supabase-setup.sh
+```
+
+## Managing Supabase
+
+Supabase runs as Docker Compose services under `/srv/supabase/supabase/docker`.
+
+| Action | Command |
+|--------|---------|
+| Start | `cd /srv/supabase/supabase/docker && docker compose up -d` |
+| Stop | `cd /srv/supabase/supabase/docker && docker compose down` |
+| Restart | `cd /srv/supabase/supabase/docker && docker compose restart` |
+| Status | `cd /srv/supabase/supabase/docker && docker compose ps` |
+| Logs | `cd /srv/supabase/supabase/docker && docker compose logs -f` |
+| Update | Pin/bump `application_version` in a new image build, or follow [Supabase self-hosting update docs](https://supabase.com/docs/guides/self-hosting/docker) then `docker compose pull && docker compose up -d` |
+| Domain TLS | `/var/supabase/supabase-setup.sh` |
+
+Nginx: `systemctl {start|stop|restart|status} nginx`
+
+### Configuration paths
+
+- Supabase stack: `/srv/supabase/supabase/docker`
+- Env / secrets: `/srv/supabase/supabase/docker/.env`
+- Passwords: `/root/.digitalocean_passwords`
+- Managed DB credentials (when attached): `/root/.digitalocean_dbaas_credentials`
+- Domain / TLS helper: `/var/supabase/supabase-setup.sh`
+- Setup log: `/var/log/one_click_setup.log`
+
+## Using a DigitalOcean Managed Database (Optional)
+
+When creating the Droplet, select **Add a Database** to provision Managed PostgreSQL alongside Supabase.
+
+On first boot the Droplet:
+
+1. Waits for the managed cluster (up to a few minutes)
+2. Saves connection details and `DATABASE_URL` to `/root/.digitalocean_passwords` and `/etc/environment`
+3. Starts Supabase with its **local** `db` container (unchanged)
+
+Use the managed database for your own apps or tooling. Supabase services keep using the specialized local Postgres image.
+
+Add the Droplet IP under the database cluster’s **Trusted Sources** in the [control panel](https://cloud.digitalocean.com/databases) if connections time out.
+
+## Marketplace release note (Vendor Portal)
+
+Image code alone does **not** show **Add a Database** to customers. Before publishing or updating this 1-Click in the Marketplace:
+
+1. Open the [Vendor Portal](https://cloud.digitalocean.com/vendorportal)
+2. Edit the Supabase Droplet 1-Click
+3. Enable **PostgreSQL** under managed database / predeploy options
+4. Save so create-droplet offers **Add a Database**
+
+Without that checkbox, `/root/.digitalocean_dbaas_credentials` is never injected and DBaaS predeploy will not run.
+
+## Security notes
+
+- Change the Studio dashboard password after first login if needed (value in `/root/.digitalocean_passwords`)
+- Prefer restricting SSH (and optionally HTTP/HTTPS) with a Cloud Firewall
+- For production, configure a custom domain and TLS via `/var/supabase/supabase-setup.sh`
+- Rotate default JWT / API secrets in `/srv/supabase/supabase/docker/.env` for production use
+
+## Additional Resources
+
+- Marketplace: https://marketplace.digitalocean.com/apps/supabase
+- Supabase self-hosting: https://supabase.com/docs/guides/self-hosting/docker
+- Managed Databases: https://docs.digitalocean.com/products/databases/

--- a/supabase-24-04/listing.md
+++ b/supabase-24-04/listing.md
@@ -1,13 +1,13 @@
 # Supabase 1-Click Application
 
-Deploy self-hosted Supabase on Ubuntu 24.04 with Docker Compose and Nginx. Supabase provides Postgres-backed Auth, REST/Realtime APIs, Storage, and Studio. The Supabase stack uses its local `db` container. You can optionally attach a DigitalOcean Managed PostgreSQL database at create time for your own application data.
+Deploy self-hosted Supabase on Ubuntu 24.04 with Docker Compose and Nginx. Supabase provides Postgres-backed Auth, REST/Realtime APIs, Storage, and Studio. By default the stack uses its local `db` container; with **Add a Database**, Supabase is configured to use Managed PostgreSQL instead.
 
 ## Included System Components
 
 - **Ubuntu 24.04 LTS**
 - **Docker Engine** and **Docker Compose plugin**
 - **Supabase** (pinned release from the image build, currently `v1.26.05`) — Studio, Kong, Auth, PostgREST, Realtime, Storage, and related services
-- **PostgreSQL** via the Supabase `db` container (`supabase/postgres`)
+- **PostgreSQL** via the Supabase `db` container (`supabase/postgres`), or DigitalOcean Managed PostgreSQL when **Add a Database** is selected
 - **Nginx** reverse proxy (ports 80/443 → Kong on `localhost:8000`)
 - **Certbot** (Snap) for optional custom-domain TLS
 - **UFW** — SSH, HTTP, and HTTPS
@@ -54,7 +54,7 @@ Supabase runs as Docker Compose services under `/srv/supabase/supabase/docker`.
 
 | Action | Command |
 |--------|---------|
-| Start | `cd /srv/supabase/supabase/docker && docker compose up -d` |
+| Start | `cd /srv/supabase/supabase/docker && docker compose up -d` (add `-f docker-compose.dbaas.yml` when Managed DB is in use) |
 | Stop | `cd /srv/supabase/supabase/docker && docker compose down` |
 | Restart | `cd /srv/supabase/supabase/docker && docker compose restart` |
 | Status | `cd /srv/supabase/supabase/docker && docker compose ps` |
@@ -75,15 +75,14 @@ Nginx: `systemctl {start|stop|restart|status} nginx`
 
 ## Using a DigitalOcean Managed Database (Optional)
 
-When creating the Droplet, select **Add a Database** to provision Managed PostgreSQL alongside Supabase.
+When creating the Droplet, select **Add a Database** to provision Managed PostgreSQL for Supabase.
 
 On first boot the Droplet:
 
 1. Waits for the managed cluster (up to a few minutes)
-2. Saves connection details and `DATABASE_URL` to `/root/.digitalocean_passwords` and `/etc/environment`
-3. Starts Supabase with its **local** `db` container (unchanged)
-
-Use the managed database for your own apps or tooling. Supabase services keep using the specialized local Postgres image.
+2. Points Supabase at Managed Postgres and disables the local `db` container
+3. Bootstraps Supabase roles/schemas on the managed database (best-effort)
+4. Saves connection details to `/root/.digitalocean_passwords` and `DATABASE_URL` in `/etc/environment`
 
 Add the Droplet IP under the database cluster’s **Trusted Sources** in the [control panel](https://cloud.digitalocean.com/databases) if connections time out.
 

--- a/supabase-24-04/listing.md
+++ b/supabase-24-04/listing.md
@@ -81,10 +81,12 @@ On first boot the Droplet:
 
 1. Waits for the managed cluster (up to a few minutes)
 2. Points Supabase at Managed Postgres and disables the local `db` container
-3. Bootstraps Supabase roles/schemas on the managed database (best-effort)
+3. Bootstraps Supabase roles/schemas (`auth`, `storage`, `_supabase`, etc.) and TLS for analytics/auth/storage
 4. Saves connection details to `/root/.digitalocean_passwords` and `DATABASE_URL` in `/etc/environment`
 
 Add the Droplet IP under the database cluster’s **Trusted Sources** in the [control panel](https://cloud.digitalocean.com/databases) if connections time out.
+
+Prefer a **2GB+** Managed Database. Small plans (~25 connections/GB) can be exhausted by the Supabase stack; this 1-Click lowers pool sizes on DBaaS first boot. If you see `remaining connection slots are reserved…`, resize the DB or reduce `POOLER_DEFAULT_POOL_SIZE` in `/srv/supabase/supabase/docker/.env` and restart Compose.
 
 ## Marketplace release note (Vendor Portal)
 

--- a/supabase-24-04/listing.md
+++ b/supabase-24-04/listing.md
@@ -88,6 +88,8 @@ Add the Droplet IP under the database cluster’s **Trusted Sources** in the [co
 
 Prefer a **2GB+** Managed Database. Small plans (~25 connections/GB) can be exhausted by the Supabase stack; this 1-Click lowers pool sizes on DBaaS first boot. If you see `remaining connection slots are reserved…`, resize the DB or reduce `POOLER_DEFAULT_POOL_SIZE` in `/srv/supabase/supabase/docker/.env` and restart Compose.
 
+Storage talks to Managed Postgres over TLS via `DATABASE_URL?sslmode=require` (and `PGSSLMODE=require`); this image does **not** set `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+
 ## Marketplace release note (Vendor Portal)
 
 Image code alone does **not** show **Add a Database** to customers. Before publishing or updating this 1-Click in the Marketplace:

--- a/supabase-24-04/listing.md
+++ b/supabase-24-04/listing.md
@@ -79,12 +79,12 @@ When creating the Droplet, select **Add a Database** to provision Managed Postgr
 
 On first boot the Droplet:
 
-1. Waits for the managed cluster (up to a few minutes)
-2. Points Supabase at Managed Postgres and disables the local `db` container
-3. Bootstraps Supabase roles/schemas (`auth`, `storage`, `_supabase`, etc.) and TLS for analytics/auth/storage
+1. Waits for the managed cluster (up to a few minutes) and **aborts** if unreachable (e.g. Trusted Sources)
+2. Points Supabase at Managed Postgres and removes only the local `db` service (keeps `vector`)
+3. Fail-fast bootstraps required roles/schemas (`auth`, `storage`, `_supabase`, etc.) and TLS for analytics/auth/storage
 4. Saves connection details to `/root/.digitalocean_passwords` and `DATABASE_URL` in `/etc/environment`
 
-Add the Droplet IP under the database cluster’s **Trusted Sources** in the [control panel](https://cloud.digitalocean.com/databases) if connections time out.
+Add the Droplet IP under the database cluster’s **Trusted Sources** in the [control panel](https://cloud.digitalocean.com/databases). If the DB is unreachable on first boot, DBaaS setup aborts instead of starting a broken stack — see `/var/log/one_click_setup.log`, then re-run `/var/lib/digitalocean/setup-dbaas.sh` and `docker compose … up -d`.
 
 Prefer a **2GB+** Managed Database. Small plans (~25 connections/GB) can be exhausted by the Supabase stack; this 1-Click lowers pool sizes on DBaaS first boot. If you see `remaining connection slots are reserved…`, resize the DB or reduce `POOLER_DEFAULT_POOL_SIZE` in `/srv/supabase/supabase/docker/.env` and restart Compose.
 

--- a/supabase-24-04/scripts/011-supabase.sh
+++ b/supabase-24-04/scripts/011-supabase.sh
@@ -20,5 +20,10 @@ ln -sf /snap/bin/certbot /usr/bin/certbot
 
 chmod +x /var/supabase/supabase-setup.sh \
   /var/lib/digitalocean/setup-dbaas.sh \
+  /var/lib/digitalocean/prepare-logflare-ssl.sh \
   /var/lib/cloud/scripts/per-instance/001_onboot \
   /etc/update-motd.d/99-one-click
+
+# Bake Logflare Managed-DB SSL patch into the image so first boot does not depend
+# on a fragile docker pull during onboot.
+/var/lib/digitalocean/prepare-logflare-ssl.sh /srv/supabase/supabase/docker

--- a/supabase-24-04/scripts/011-supabase.sh
+++ b/supabase-24-04/scripts/011-supabase.sh
@@ -18,7 +18,10 @@ snap install core && snap refresh core
 snap install --classic certbot
 ln -sf /snap/bin/certbot /usr/bin/certbot
 
-chmod +x /var/supabase/supabase-setup.sh
+chmod +x /var/supabase/supabase-setup.sh \
+  /var/lib/digitalocean/setup-dbaas.sh \
+  /var/lib/cloud/scripts/per-instance/001_onboot \
+  /etc/update-motd.d/99-one-click
 
 grep -qxF '/var/supabase/supabase-setup.sh' /root/.bashrc || cat >> /root/.bashrc <<EOM
 /var/supabase/supabase-setup.sh

--- a/supabase-24-04/scripts/011-supabase.sh
+++ b/supabase-24-04/scripts/011-supabase.sh
@@ -22,7 +22,3 @@ chmod +x /var/supabase/supabase-setup.sh \
   /var/lib/digitalocean/setup-dbaas.sh \
   /var/lib/cloud/scripts/per-instance/001_onboot \
   /etc/update-motd.d/99-one-click
-
-grep -qxF '/var/supabase/supabase-setup.sh' /root/.bashrc || cat >> /root/.bashrc <<EOM
-/var/supabase/supabase-setup.sh
-EOM

--- a/supabase-24-04/template.json
+++ b/supabase-24-04/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "supabase-24-04-snapshot-{{timestamp}}",
-    "apt_packages": "ca-certificates curl jq git ufw dirmngr gnupg lsb-release debian-archive-keyring snapd nginx",
+    "apt_packages": "ca-certificates curl jq git ufw dirmngr gnupg lsb-release debian-archive-keyring snapd nginx postgresql-client",
     "application_name": "Supabase",
     "application_version": "v1.26.05"
   },


### PR DESCRIPTION
## Summary
- Enable Supabase 1-Click to use Marketplace PostgreSQL DBaaS predeploy.
- Add first-boot `setup-dbaas.sh` to wait for Managed PostgreSQL, validate connectivity, and save credentials / `DATABASE_URL` (Supabase stack still uses the local `db` container).
- Harden first-boot (`001_onboot`): setup logging, SSH unlock trap, passwords file, idempotent nginx enable.
- Update MOTD, README, and listing docs for optional Managed PostgreSQL; add `postgresql-client` for the readiness check.

## Test plan
- [x] Build/snapshot the Supabase 24.04 image from this branch
- [x] Create Droplet **without** Add a Database
  - [x] Supabase stack starts; Studio reachable at `http://<droplet-ip>`
  - [x] MOTD shows no managed DB;
- [x] Create Droplet **with** Managed PostgreSQL
  - [x] `/root/.digitalocean_dbaas_credentials` is present
  - [x] First-boot wait succeeds or times out cleanly (SSH still unlocks)
  - [x] Creds + `DATABASE_URL` written to `/root/.digitalocean_passwords` and `/etc/environment`
  - [x] MOTD shows managed DB host/port/user guidance
- [ ] Confirm Vendor Portal has PostgreSQL predeploy enabled on the Supabase listing before publish

## Links
[Jira](https://do-internal.atlassian.net/browse/MP-8489)