### PR TITLE
MP-8506 Create buzz.xyz Droplet 1-Click

### DIFF
--- a/buzz-24-04/README.md
+++ b/buzz-24-04/README.md
@@ -1,0 +1,74 @@
+# Buzz 1-Click Droplet Builder
+
+Packer builder for a DigitalOcean Marketplace 1-Click that runs [Buzz](https://buzz.xyz/) (Block's open-source humans + agents workspace) on Ubuntu 24.04.
+
+Upstream self-host path: official Docker Compose bundle from [`block/buzz` `deploy/compose`](https://github.com/block/buzz/tree/main/deploy/compose), with host Caddy for shortlived TLS (Marketplace pattern) instead of `compose.caddy.yml`.
+
+## Directory Structure
+
+```
+buzz-24-04/
+├── template.json
+├── README.md
+├── listing.md
+├── scripts/
+│   └── 010-buzz.sh
+└── files/
+    ├── etc/
+    │   ├── caddy/
+    │   │   ├── Caddyfile.tmp
+    │   │   └── Caddyfile.domain.tmp
+    │   ├── systemd/system/buzz.service
+    │   └── update-motd.d/99-one-click
+    ├── opt/
+    │   ├── buzz/
+    │   │   ├── compose.yml
+    │   │   ├── env.template   # copied to .env at install time
+    │   │   └── run.sh
+    │   ├── start|stop|restart|status|update-buzz.sh
+    │   └── setup-buzz-domain.sh
+    └── var/lib/cloud/scripts/per-instance/001_onboot
+```
+
+## Build Requirements
+
+1. Packer with the DigitalOcean plugin (see repo root `README.md`)
+2. `DIGITALOCEAN_API_TOKEN` with write access
+
+```bash
+export DIGITALOCEAN_API_TOKEN="your_api_token_here"
+```
+
+## Validate and Build
+
+From the `droplet-1-clicks` repo root:
+
+```bash
+make validate-buzz-24-04
+make build-buzz-24-04
+```
+
+## What Gets Installed
+
+- Buzz relay image `ghcr.io/block/buzz:<application_version>` (pinned in `template.json`)
+- Postgres 17.10, Redis 7.4.10, MinIO (compose sidecars; path-style S3 addressing)
+- Docker CE + Compose plugin
+- Caddy → `127.0.0.1:3000` with Let's Encrypt shortlived TLS by IP
+- UFW (SSH + HTTP/HTTPS), fail2ban
+
+## First Boot
+
+1. Unlock SSH (remove Packer `ForceCommand`)
+2. Generate owner + relay Nostr keys via `buzz-admin generate-key`
+3. Fill `/opt/buzz/.env` secrets and set `RELAY_URL` / CORS to the droplet IP
+4. Install Caddyfile for the public IP
+5. `systemctl start buzz` + `caddy`
+6. Write `/root/buzz_credentials.txt` and `/root/buzz_info.txt`
+
+## Version Pinning
+
+Edit `application_version` in `template.json` (relay semver, e.g. `0.2.0`). The install script sets `BUZZ_IMAGE=ghcr.io/block/buzz:<version>` and pre-pulls that tag.
+
+## License
+
+Builder files follow the droplet-1-clicks repository license. Buzz itself is Apache-2.0.

--- a/buzz-24-04/README.md
+++ b/buzz-24-04/README.md
@@ -59,11 +59,12 @@ make build-buzz-24-04
 ## First Boot
 
 1. Unlock SSH (remove Packer `ForceCommand`)
-2. Generate owner + relay Nostr keys via `buzz-admin generate-key`
-3. Fill `/opt/buzz/.env` secrets and set `RELAY_URL` / CORS to the droplet IP
-4. Install Caddyfile for the public IP
-5. `systemctl start buzz` + `caddy`
-6. Write `/root/buzz_credentials.txt` and `/root/buzz_info.txt`
+2. Generate owner + relay Nostr keys via `buzz-admin generate-key` (hex for `.env`)
+3. Encode the same owner keypair as `nsec1` / `npub` for Desktop-friendly credentials
+4. Fill `/opt/buzz/.env` secrets and set `RELAY_URL` / CORS to the droplet IP
+5. Install Caddyfile for the public IP
+6. `systemctl start buzz` + `caddy`
+7. Write `/root/buzz_credentials.txt` (hex + `nsec1`/`npub`) and `/root/buzz_info.txt`
 
 ## Version Pinning
 

--- a/buzz-24-04/files/etc/caddy/Caddyfile.domain.tmp
+++ b/buzz-24-04/files/etc/caddy/Caddyfile.domain.tmp
@@ -1,0 +1,10 @@
+PLACEHOLDER_DOMAIN {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+    reverse_proxy 127.0.0.1:3000
+    header X-DO-MARKETPLACE "buzz"
+}

--- a/buzz-24-04/files/etc/caddy/Caddyfile.tmp
+++ b/buzz-24-04/files/etc/caddy/Caddyfile.tmp
@@ -1,0 +1,10 @@
+PLACEHOLDER_DOMAIN {
+    tls {
+        issuer acme {
+            dir https://acme-v02.api.letsencrypt.org/directory
+            profile shortlived
+        }
+    }
+    reverse_proxy localhost:3000
+    header X-DO-MARKETPLACE "buzz"
+}

--- a/buzz-24-04/files/etc/systemd/system/buzz.service
+++ b/buzz-24-04/files/etc/systemd/system/buzz.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Buzz — self-hosted humans + agents workspace relay
+Documentation=https://github.com/block/buzz
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/buzz
+ExecStart=/opt/start-buzz.sh
+ExecStop=/opt/stop-buzz.sh
+TimeoutStartSec=300
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/buzz-24-04/files/etc/update-motd.d/99-one-click
+++ b/buzz-24-04/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Configured as part of the DigitalOcean 1-Click Image build process
+
+pub=$(curl -fsS --retry 3 --retry-connrefused --max-time 3 \
+  http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)
+myip="${pub:-$(hostname -I | awk '{print$1}')}"
+
+owner_pub=$(grep -E '^RELAY_OWNER_PUBKEY=' /opt/buzz/.env 2>/dev/null | cut -d= -f2-)
+creds=/root/buzz_credentials.txt
+
+cat <<EOF
+********************************************************************************
+
+Welcome to DigitalOcean's One-Click Buzz Droplet.
+
+Buzz is a self-hostable workspace where humans and AI agents share rooms on a
+relay you own (https://buzz.xyz / https://github.com/block/buzz).
+
+🌐 Access:
+  Web UI:     https://$myip
+  Relay URL:  wss://$myip
+
+  Credentials: $creds
+  Owner pubkey: ${owner_pub:-see credentials file}
+
+📝 First steps:
+  1. Open the Web UI (or point the Buzz desktop app at wss://$myip)
+  2. Import / use the owner secret key from $creds to claim the relay
+  3. Optionally attach a domain: /opt/setup-buzz-domain.sh
+  4. Add members: /opt/buzz/run.sh add-member <npub-or-hex>
+
+🔧 Management:
+  Start:    /opt/start-buzz.sh
+  Stop:     /opt/stop-buzz.sh
+  Restart:  /opt/restart-buzz.sh
+  Status:   /opt/status-buzz.sh
+  Update:   /opt/update-buzz.sh [version]
+  Domain:   /opt/setup-buzz-domain.sh
+  Logs:     /opt/buzz/run.sh logs
+
+  systemctl {start|stop|restart|status} buzz
+  systemctl {start|stop|restart|status} caddy
+
+📚 Docs: https://github.com/block/buzz
+🔗 Site: https://buzz.xyz/
+
+********************************************************************************
+To delete this message of the day: rm -rf $(readlink -f ${0})
+EOF

--- a/buzz-24-04/files/etc/update-motd.d/99-one-click
+++ b/buzz-24-04/files/etc/update-motd.d/99-one-click
@@ -26,8 +26,8 @@ relay you own (https://buzz.xyz / https://github.com/block/buzz).
 
 📝 First steps:
   1. Download Buzz Desktop: https://github.com/block/buzz/releases (or https://buzz.xyz/)
-  2. Import the owner secret key from $creds (Identity / import key in the desktop app)
-  3. Add this relay: wss://$myip
+  2. Open $creds and copy the nsec1 owner secret (Desktop rejects hex)
+  3. In Desktop: Use an existing key → paste nsec1 → Join a Community: wss://$myip
   4. Optionally attach a domain: /opt/setup-buzz-domain.sh
   5. Add members: /opt/buzz/run.sh add-member <npub-or-hex>
 

--- a/buzz-24-04/files/etc/update-motd.d/99-one-click
+++ b/buzz-24-04/files/etc/update-motd.d/99-one-click
@@ -25,10 +25,14 @@ relay you own (https://buzz.xyz / https://github.com/block/buzz).
   Owner pubkey: ${owner_pub:-see credentials file}
 
 📝 First steps:
-  1. Open the Web UI (or point the Buzz desktop app at wss://$myip)
-  2. Import / use the owner secret key from $creds to claim the relay
-  3. Optionally attach a domain: /opt/setup-buzz-domain.sh
-  4. Add members: /opt/buzz/run.sh add-member <npub-or-hex>
+  1. Download Buzz Desktop: https://github.com/block/buzz/releases (or https://buzz.xyz/)
+  2. Import the owner secret key from $creds (Identity / import key in the desktop app)
+  3. Add this relay: wss://$myip
+  4. Optionally attach a domain: /opt/setup-buzz-domain.sh
+  5. Add members: /opt/buzz/run.sh add-member <npub-or-hex>
+
+  Note: The browser page at https://$myip is a read-only relay landing page.
+  Claiming ownership and chatting happen in Buzz Desktop, not in that web UI.
 
 🔧 Management:
   Start:    /opt/start-buzz.sh

--- a/buzz-24-04/files/opt/buzz/compose.yml
+++ b/buzz-24-04/files/opt/buzz/compose.yml
@@ -1,0 +1,142 @@
+name: buzz-prod
+
+services:
+  relay:
+    image: ${BUZZ_IMAGE:-ghcr.io/block/buzz:0.2.0}
+    env_file:
+      - .env
+    environment:
+      BUZZ_BIND_ADDR: 0.0.0.0:3000
+      BUZZ_HEALTH_PORT: "8080"
+      BUZZ_METRICS_PORT: "9102"
+      DATABASE_URL: postgres://${POSTGRES_USER:-buzz}:${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-buzz}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?set REDIS_PASSWORD}@redis:6379
+      BUZZ_S3_ENDPOINT: http://minio:9000
+      # Docker DNS resolves `minio`, not arbitrary `<bucket>.minio` hosts.
+      BUZZ_S3_ADDRESSING_STYLE: path
+      BUZZ_S3_ACCESS_KEY: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
+      BUZZ_S3_SECRET_KEY: ${BUZZ_S3_SECRET_KEY:?set BUZZ_S3_SECRET_KEY}
+      BUZZ_S3_BUCKET: ${BUZZ_S3_BUCKET:-buzz-media}
+      BUZZ_GIT_REPO_PATH: /data/git
+      BUZZ_AUTO_MIGRATE: ${BUZZ_AUTO_MIGRATE:-false}
+      BUZZ_GIT_CONFORMANCE_PROBE: ${BUZZ_GIT_CONFORMANCE_PROBE:-true}
+    # Bind to loopback only — Caddy on the host terminates TLS and proxies here.
+    ports:
+      - "127.0.0.1:${BUZZ_HTTP_PORT:-3000}:3000"
+    volumes:
+      - buzz-git-data:/data/git
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "bash -ec 'exec 3<>/dev/tcp/127.0.0.1/8080; printf \"GET /_readiness HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\nConnection: close\\r\\n\\r\\n\" >&3; grep -q \"200 OK\" <&3'",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 12
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
+  postgres:
+    image: postgres:17.10-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-buzz}
+      POSTGRES_USER: ${POSTGRES_USER:-buzz}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - buzz-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
+  redis:
+    image: redis:7.4.10-alpine
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD:?set REDIS_PASSWORD}"]
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?set REDIS_PASSWORD}
+    volumes:
+      - buzz-redis-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$${REDIS_PASSWORD}\" ping | grep -q PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${BUZZ_S3_SECRET_KEY:?set BUZZ_S3_SECRET_KEY}
+    volumes:
+      - buzz-minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - buzz-net
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      BUZZ_S3_ACCESS_KEY: ${BUZZ_S3_ACCESS_KEY:?set BUZZ_S3_ACCESS_KEY}
+      BUZZ_S3_SECRET_KEY: ${BUZZ_S3_SECRET_KEY:?set BUZZ_S3_SECRET_KEY}
+      BUZZ_S3_BUCKET: ${BUZZ_S3_BUCKET:-buzz-media}
+    entrypoint: >
+      /bin/sh -euc '
+        mc alias set local http://minio:9000 "$${BUZZ_S3_ACCESS_KEY}" "$${BUZZ_S3_SECRET_KEY}"
+        mc mb --ignore-existing "local/$${BUZZ_S3_BUCKET}"
+        mc anonymous set none "local/$${BUZZ_S3_BUCKET}"
+      '
+    restart: "no"
+    networks:
+      - buzz-net
+
+volumes:
+  buzz-postgres-data:
+    labels:
+      com.buzz.volume: postgres
+  buzz-redis-data:
+    labels:
+      com.buzz.volume: redis
+  buzz-minio-data:
+    labels:
+      com.buzz.volume: minio
+  buzz-git-data:
+    labels:
+      com.buzz.volume: git
+
+networks:
+  buzz-net:
+    driver: bridge
+    labels:
+      com.buzz.network: production

--- a/buzz-24-04/files/opt/buzz/env.template
+++ b/buzz-24-04/files/opt/buzz/env.template
@@ -1,5 +1,5 @@
 # Buzz production Docker Compose environment.
-# Secrets with PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT are filled by 001_onboot.
+# Secrets marked for first-boot replacement are filled by 001_onboot.
 
 # Pinned relay image (application_version from Packer template).
 BUZZ_IMAGE=ghcr.io/block/buzz:0.2.0

--- a/buzz-24-04/files/opt/buzz/env.template
+++ b/buzz-24-04/files/opt/buzz/env.template
@@ -1,0 +1,39 @@
+# Buzz production Docker Compose environment.
+# Secrets with PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT are filled by 001_onboot.
+
+# Pinned relay image (application_version from Packer template).
+BUZZ_IMAGE=ghcr.io/block/buzz:0.2.0
+
+# Public host — rewritten on first boot to the droplet IP (or custom domain).
+BUZZ_DOMAIN=PLACEHOLDER_DOMAIN
+RELAY_URL=wss://PLACEHOLDER_DOMAIN
+BUZZ_MEDIA_BASE_URL=https://PLACEHOLDER_DOMAIN/media
+BUZZ_MEDIA_SERVER_DOMAIN=PLACEHOLDER_DOMAIN
+BUZZ_CORS_ORIGINS=https://PLACEHOLDER_DOMAIN
+
+# Closed relay: only the owner (and added members) can use the workspace.
+BUZZ_REQUIRE_AUTH_TOKEN=true
+BUZZ_REQUIRE_RELAY_MEMBERSHIP=true
+BUZZ_ALLOW_NIP_OA_AUTH=true
+BUZZ_AUTO_MIGRATE=true
+BUZZ_GIT_CONFORMANCE_PROBE=true
+RUST_LOG=buzz_relay=info,buzz_db=info,buzz_auth=info,buzz_pubsub=info,tower_http=info
+
+# Owner identity (64-char hex). Filled on first boot.
+RELAY_OWNER_PUBKEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+
+# Stable secrets. Generated once on first boot — back these up.
+BUZZ_RELAY_PRIVATE_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+BUZZ_GIT_HOOK_HMAC_SECRET=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+POSTGRES_DB=buzz
+POSTGRES_USER=buzz
+POSTGRES_PASSWORD=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+REDIS_PASSWORD=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+BUZZ_S3_ACCESS_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+BUZZ_S3_SECRET_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
+BUZZ_S3_BUCKET=buzz-media
+# Bundled MinIO uses path-style URLs (also set in compose.yml environment).
+BUZZ_S3_ADDRESSING_STYLE=path
+
+# Loopback publish port (Caddy proxies here).
+BUZZ_HTTP_PORT=3000

--- a/buzz-24-04/files/opt/buzz/run.sh
+++ b/buzz-24-04/files/opt/buzz/run.sh
@@ -15,7 +15,8 @@ require_env() {
     echo "Missing /opt/buzz/.env" >&2
     exit 1
   fi
-  if grep -Eq 'PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|PLACEHOLDER_DOMAIN|CHANGE_ME' .env; then
+  # Ignore comments — Packer/docs lines must not trip this check.
+  if grep -vE '^\s*#' .env | grep -Eq 'PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|PLACEHOLDER_DOMAIN|CHANGE_ME'; then
     echo "/opt/buzz/.env still contains placeholders. Wait for first-boot init or finish setup." >&2
     exit 1
   fi

--- a/buzz-24-04/files/opt/buzz/run.sh
+++ b/buzz-24-04/files/opt/buzz/run.sh
@@ -27,7 +27,7 @@ backup_hint() {
 Back up these before upgrades and on a regular schedule:
 
 - /opt/buzz/.env (BUZZ_RELAY_PRIVATE_KEY, DB/Redis/S3 secrets, BUZZ_GIT_HOOK_HMAC_SECRET)
-- /root/buzz_credentials.txt (owner secret key for RELAY_OWNER_PUBKEY)
+- /root/buzz_credentials.txt (owner nsec1 + hex for RELAY_OWNER_PUBKEY)
 - Postgres data volume (buzz-postgres-data)
 - MinIO/S3 bucket contents (media + git objects)
 - buzz-git-data volume

--- a/buzz-24-04/files/opt/buzz/run.sh
+++ b/buzz-24-04/files/opt/buzz/run.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+COMPOSE_FILES=(-f compose.yml)
+
+compose() {
+  docker compose --env-file .env "${COMPOSE_FILES[@]}" "$@"
+}
+
+require_env() {
+  if [[ ! -f .env ]]; then
+    echo "Missing /opt/buzz/.env" >&2
+    exit 1
+  fi
+  if grep -Eq 'PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT|PLACEHOLDER_DOMAIN|CHANGE_ME' .env; then
+    echo "/opt/buzz/.env still contains placeholders. Wait for first-boot init or finish setup." >&2
+    exit 1
+  fi
+}
+
+backup_hint() {
+  cat <<'MSG'
+Back up these before upgrades and on a regular schedule:
+
+- /opt/buzz/.env (BUZZ_RELAY_PRIVATE_KEY, DB/Redis/S3 secrets, BUZZ_GIT_HOOK_HMAC_SECRET)
+- /root/buzz_credentials.txt (owner secret key for RELAY_OWNER_PUBKEY)
+- Postgres data volume (buzz-postgres-data)
+- MinIO/S3 bucket contents (media + git objects)
+- buzz-git-data volume
+
+Keep Postgres + object/git state snapshots from the same maintenance window.
+MSG
+}
+
+case "${1:-help}" in
+  start|up)
+    require_env
+    compose up -d --wait
+    ;;
+  stop|down)
+    compose down
+    ;;
+  restart)
+    require_env
+    compose up -d --wait --force-recreate relay
+    ;;
+  pull)
+    require_env
+    compose pull
+    ;;
+  upgrade)
+    require_env
+    compose pull
+    compose up -d --wait
+    backup_hint
+    ;;
+  logs)
+    shift || true
+    compose logs -f "${@:-relay}"
+    ;;
+  status|ps)
+    compose ps
+    ;;
+  config)
+    require_env
+    compose config
+    ;;
+  backup-hint)
+    backup_hint
+    ;;
+  add-member)
+    compose exec relay /usr/local/bin/buzz-admin add-member --pubkey "${2:?Usage: ./run.sh add-member <npub-or-hex> [--role member|admin]}" "${@:3}"
+    ;;
+  remove-member)
+    compose exec relay /usr/local/bin/buzz-admin remove-member --pubkey "${2:?Usage: ./run.sh remove-member <npub-or-hex> [--role member|admin]}" "${@:3}"
+    ;;
+  list-members)
+    compose exec relay /usr/local/bin/buzz-admin list-members
+    ;;
+  help|-h|--help)
+    cat <<'MSG'
+Usage: /opt/buzz/run.sh <command>
+
+Commands:
+  start         Start Buzz (docker compose up -d --wait)
+  stop          Stop containers (volumes preserved)
+  restart       Recreate the relay after env/image changes
+  pull          Pull configured images
+  upgrade       Pull and restart, then print backup reminders
+  logs [svc]    Follow logs (default: relay)
+  status        Show compose service status
+  config        Render merged compose config
+  backup-hint   Print the production backup checklist
+
+  add-member <npub-or-hex> [--role member|admin]
+  remove-member <npub-or-hex> [--role member|admin]
+  list-members
+MSG
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    echo "Run /opt/buzz/run.sh help" >&2
+    exit 1
+    ;;
+esac

--- a/buzz-24-04/files/opt/restart-buzz.sh
+++ b/buzz-24-04/files/opt/restart-buzz.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+exec /opt/buzz/run.sh restart

--- a/buzz-24-04/files/opt/setup-buzz-domain.sh
+++ b/buzz-24-04/files/opt/setup-buzz-domain.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+PORT=3000
+BIND_IP=127.0.0.1
+ENV_FILE=/opt/buzz/.env
+DOMAIN_TMP=/etc/caddy/Caddyfile.domain.tmp
+
+if [ ! -f "${DOMAIN_TMP}" ]; then
+  echo "Error: ${DOMAIN_TMP} not found"
+  exit 1
+fi
+
+read -rp "Enter the domain you pointed at this droplet (e.g. buzz.example.com): " DOMAIN
+if [ -z "${DOMAIN}" ]; then
+  echo "Domain cannot be empty."
+  exit 1
+fi
+
+read -rp "Enter an email for Let's Encrypt notifications (optional): " EMAIL
+
+sed "s/PLACEHOLDER_DOMAIN/${DOMAIN}/" "${DOMAIN_TMP}" > /etc/caddy/Caddyfile
+
+if [ -n "$EMAIL" ]; then
+  sed -i "1iemail ${EMAIL}" /etc/caddy/Caddyfile
+fi
+
+# Keep relay public URLs in sync with the custom domain.
+sed -i "s|^BUZZ_DOMAIN=.*|BUZZ_DOMAIN=${DOMAIN}|" "$ENV_FILE"
+sed -i "s|^RELAY_URL=.*|RELAY_URL=wss://${DOMAIN}|" "$ENV_FILE"
+sed -i "s|^BUZZ_MEDIA_BASE_URL=.*|BUZZ_MEDIA_BASE_URL=https://${DOMAIN}/media|" "$ENV_FILE"
+sed -i "s|^BUZZ_MEDIA_SERVER_DOMAIN=.*|BUZZ_MEDIA_SERVER_DOMAIN=${DOMAIN}|" "$ENV_FILE"
+sed -i "s|^BUZZ_CORS_ORIGINS=.*|BUZZ_CORS_ORIGINS=https://${DOMAIN}|" "$ENV_FILE"
+
+systemctl enable caddy
+systemctl restart caddy
+systemctl restart buzz
+
+echo "Caddy is now proxying https://${DOMAIN} to ${BIND_IP}:${PORT}."
+echo "Relay URL updated to wss://${DOMAIN}."
+echo "Ensure DNS A/AAAA for ${DOMAIN} points at this droplet and ports 80/443 are open."

--- a/buzz-24-04/files/opt/start-buzz.sh
+++ b/buzz-24-04/files/opt/start-buzz.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+exec /opt/buzz/run.sh start

--- a/buzz-24-04/files/opt/status-buzz.sh
+++ b/buzz-24-04/files/opt/status-buzz.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+exec /opt/buzz/run.sh status

--- a/buzz-24-04/files/opt/stop-buzz.sh
+++ b/buzz-24-04/files/opt/stop-buzz.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+exec /opt/buzz/run.sh stop

--- a/buzz-24-04/files/opt/update-buzz.sh
+++ b/buzz-24-04/files/opt/update-buzz.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+ENV_FILE=/opt/buzz/.env
+TARGET="${1:-}"
+
+if [ -n "$TARGET" ]; then
+  case "$TARGET" in
+    *:*) IMAGE="$TARGET" ;;
+    *) IMAGE="ghcr.io/block/buzz:${TARGET#v}" ;;
+  esac
+  echo "Pinning BUZZ_IMAGE=${IMAGE}"
+  sed -i "s|^BUZZ_IMAGE=.*|BUZZ_IMAGE=${IMAGE}|" "$ENV_FILE"
+fi
+
+echo "Updating Buzz images and restarting stack..."
+/opt/buzz/run.sh upgrade
+echo "Done. Check status with: /opt/status-buzz.sh"

--- a/buzz-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/buzz-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,154 @@
+#!/bin/bash
+set -euo pipefail
+
+ENV_FILE=/opt/buzz/.env
+CREDS_FILE=/root/buzz_credentials.txt
+INFO_FILE=/root/buzz_info.txt
+
+meta() { curl -fsS --retry 10 --retry-connrefused --max-time 2 "$1"; }
+DROPLET_PUBLIC_IP="$(meta http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address 2>/dev/null || true)"
+DROPLET_PRIVATE_IP="$(hostname -I | awk '{print $1}')"
+DROPLET_IP="${DROPLET_PUBLIC_IP:-$DROPLET_PRIVATE_IP}"
+
+generate_keypair() {
+  local image out
+  image="$(grep -E '^BUZZ_IMAGE=' "$ENV_FILE" | cut -d= -f2-)"
+  out="$(docker run --rm --entrypoint /usr/local/bin/buzz-admin "$image" generate-key)"
+  OWNER_PUB="$(printf '%s\n' "$out" | awk '/^Public key:/{print $3}')"
+  OWNER_SEC="$(printf '%s\n' "$out" | awk '/^Secret key:/{print $3}')"
+  if [ -z "${OWNER_PUB:-}" ] || [ -z "${OWNER_SEC:-}" ]; then
+    echo "ERROR: failed to parse buzz-admin generate-key output:" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+
+# Generate unique secrets + owner keypair once per droplet
+if grep -q "PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT" "$ENV_FILE" 2>/dev/null; then
+  echo "Generating Buzz secrets and owner keypair..."
+
+  generate_keypair
+  RELAY_KEY_OUT="$(docker run --rm --entrypoint /usr/local/bin/buzz-admin \
+    "$(grep -E '^BUZZ_IMAGE=' "$ENV_FILE" | cut -d= -f2-)" generate-key)"
+  RELAY_SEC="$(printf '%s\n' "$RELAY_KEY_OUT" | awk '/^Secret key:/{print $3}')"
+
+  POSTGRES_PASSWORD="$(openssl rand -base64 32 | tr -d '=+/' | cut -c1-32)"
+  REDIS_PASSWORD="$(openssl rand -base64 32 | tr -d '=+/' | cut -c1-32)"
+  GIT_HMAC="$(openssl rand -hex 32)"
+  S3_ACCESS="$(openssl rand -hex 12)"
+  S3_SECRET="$(openssl rand -hex 32)"
+
+  sed -i "s|^RELAY_OWNER_PUBKEY=.*|RELAY_OWNER_PUBKEY=${OWNER_PUB}|" "$ENV_FILE"
+  sed -i "s|^BUZZ_RELAY_PRIVATE_KEY=.*|BUZZ_RELAY_PRIVATE_KEY=${RELAY_SEC}|" "$ENV_FILE"
+  sed -i "s|^BUZZ_GIT_HOOK_HMAC_SECRET=.*|BUZZ_GIT_HOOK_HMAC_SECRET=${GIT_HMAC}|" "$ENV_FILE"
+  sed -i "s|^POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${POSTGRES_PASSWORD}|" "$ENV_FILE"
+  sed -i "s|^REDIS_PASSWORD=.*|REDIS_PASSWORD=${REDIS_PASSWORD}|" "$ENV_FILE"
+  sed -i "s|^BUZZ_S3_ACCESS_KEY=.*|BUZZ_S3_ACCESS_KEY=${S3_ACCESS}|" "$ENV_FILE"
+  sed -i "s|^BUZZ_S3_SECRET_KEY=.*|BUZZ_S3_SECRET_KEY=${S3_SECRET}|" "$ENV_FILE"
+
+  umask 077
+  cat > "$CREDS_FILE" << EOF
+Buzz 1-Click credentials (keep private)
+=======================================
+Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+Owner public key (RELAY_OWNER_PUBKEY):
+  ${OWNER_PUB}
+
+Owner secret key (import this identity to claim the relay):
+  ${OWNER_SEC}
+
+Relay URL:
+  wss://${DROPLET_IP}
+
+Web UI:
+  https://${DROPLET_IP}
+
+Env file:
+  ${ENV_FILE}
+EOF
+  chmod 600 "$CREDS_FILE"
+  chmod 600 "$ENV_FILE"
+  echo "Credentials written to ${CREDS_FILE}"
+fi
+
+# Point public URLs at this droplet's IP (domain helper rewrites later)
+if grep -q "PLACEHOLDER_DOMAIN" "$ENV_FILE" 2>/dev/null; then
+  echo "Configuring Buzz public URLs for ${DROPLET_IP}..."
+  sed -i "s|PLACEHOLDER_DOMAIN|${DROPLET_IP}|g" "$ENV_FILE"
+fi
+
+# Install Caddyfile and substitute droplet IP for shortlived TLS
+if [ -f /etc/caddy/Caddyfile.tmp ]; then
+  mv /etc/caddy/Caddyfile.tmp /etc/caddy/Caddyfile
+fi
+if grep -q "PLACEHOLDER_DOMAIN" /etc/caddy/Caddyfile 2>/dev/null; then
+  echo "Configuring Caddy with droplet IP address..."
+  sed -i "s/PLACEHOLDER_DOMAIN/${DROPLET_IP}/" /etc/caddy/Caddyfile
+  systemctl enable caddy
+fi
+
+# Remove the ssh force logout command
+sed -e '/Match User root/d' \
+    -e '/.*ForceCommand.*droplet.*/d' \
+    -i /etc/ssh/sshd_config
+
+OWNER_PUB="$(grep -E '^RELAY_OWNER_PUBKEY=' "$ENV_FILE" | cut -d= -f2-)"
+
+cat > "$INFO_FILE" << EOF
+================================================================================
+Buzz 1-Click Droplet - Getting Started
+================================================================================
+
+Buzz is a self-hostable workspace for humans and AI agents on a relay you own.
+
+ACCESS:
+  Web UI:     https://${DROPLET_IP}
+  Relay URL:  wss://${DROPLET_IP}
+
+OWNER IDENTITY:
+  Public key:  ${OWNER_PUB}
+  Secret key:  see ${CREDS_FILE}
+
+  Import the owner secret key in the Buzz desktop/web client to administer
+  this closed relay. Add other members with:
+    /opt/buzz/run.sh add-member <npub-or-hex>
+
+MANAGEMENT:
+  Start:     /opt/start-buzz.sh
+  Stop:      /opt/stop-buzz.sh
+  Restart:   /opt/restart-buzz.sh
+  Status:    /opt/status-buzz.sh
+  Update:    /opt/update-buzz.sh [version]
+  Domain:    /opt/setup-buzz-domain.sh
+  Logs:      /opt/buzz/run.sh logs
+  Backup:    /opt/buzz/run.sh backup-hint
+
+  systemctl {start|stop|restart|status} buzz
+  systemctl {start|stop|restart|status} caddy
+
+PATHS:
+  Stack:     /opt/buzz
+  Env:       /opt/buzz/.env
+  Creds:     ${CREDS_FILE}
+
+SECURITY:
+  The relay runs in closed membership mode. Port 3000 is bound to localhost;
+  only HTTPS (80/443 via Caddy) is public. Keep ${CREDS_FILE} and .env private.
+
+DOCS:
+  https://github.com/block/buzz
+  https://buzz.xyz/
+
+================================================================================
+EOF
+chmod 600 "$INFO_FILE"
+
+systemctl restart ssh
+systemctl enable buzz
+# start-buzz.sh runs `docker compose up -d --wait`, so this blocks until healthy.
+systemctl restart buzz
+systemctl restart caddy
+
+echo "Buzz first-boot initialization complete!"
+echo "Access info saved to ${INFO_FILE}"

--- a/buzz-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/buzz-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -23,6 +23,51 @@ generate_keypair() {
   fi
 }
 
+# Encode 32-byte hex as NIP-19 bech32 (nsec1… / npub1…). Same keypair, Desktop-friendly form.
+hex_to_bech32() {
+  local hrp="$1" hex="$2"
+  HEX_KEY="$hex" HRP="$hrp" python3 - <<'PY'
+import os, sys
+
+hex_key = os.environ["HEX_KEY"].strip().lower()
+hrp = os.environ["HRP"]
+if len(hex_key) != 64 or any(c not in "0123456789abcdef" for c in hex_key):
+    sys.exit(f"invalid 64-char hex for {hrp}: {hex_key!r}")
+
+CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+GEN = [0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3]
+
+def polymod(values):
+    chk = 1
+    for v in values:
+        b = chk >> 25
+        chk = ((chk & 0x1FFFFFF) << 5) ^ v
+        for i in range(5):
+            chk ^= GEN[i] if ((b >> i) & 1) else 0
+    return chk
+
+def convertbits(data, frombits, tobits):
+    acc = bits = 0
+    out = []
+    maxv = (1 << tobits) - 1
+    for value in data:
+        acc = (acc << frombits) | value
+        bits += frombits
+        while bits >= tobits:
+            bits -= tobits
+            out.append((acc >> bits) & maxv)
+    if bits:
+        out.append((acc << (tobits - bits)) & maxv)
+    return out
+
+data = convertbits(list(bytes.fromhex(hex_key)), 8, 5)
+values = [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp] + data
+mod = polymod(values + [0, 0, 0, 0, 0, 0]) ^ 1
+checksum = [(mod >> 5 * (5 - i)) & 31 for i in range(6)]
+print(hrp + "1" + "".join(CHARSET[d] for d in data + checksum))
+PY
+}
+
 # Generate unique secrets + owner keypair once per droplet
 if grep -q "PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT" "$ENV_FILE" 2>/dev/null; then
   echo "Generating Buzz secrets and owner keypair..."
@@ -31,6 +76,10 @@ if grep -q "PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT" "$ENV_FILE" 2>/dev/null;
   RELAY_KEY_OUT="$(docker run --rm --entrypoint /usr/local/bin/buzz-admin \
     "$(grep -E '^BUZZ_IMAGE=' "$ENV_FILE" | cut -d= -f2-)" generate-key)"
   RELAY_SEC="$(printf '%s\n' "$RELAY_KEY_OUT" | awk '/^Secret key:/{print $3}')"
+
+  # Desktop "Use an existing key" accepts nsec1 only; relay .env keeps hex.
+  OWNER_NSEC="$(hex_to_bech32 nsec "$OWNER_SEC")"
+  OWNER_NPUB="$(hex_to_bech32 npub "$OWNER_PUB")"
 
   POSTGRES_PASSWORD="$(openssl rand -base64 32 | tr -d '=+/' | cut -c1-32)"
   REDIS_PASSWORD="$(openssl rand -base64 32 | tr -d '=+/' | cut -c1-32)"
@@ -52,10 +101,16 @@ Buzz 1-Click credentials (keep private)
 =======================================
 Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-Owner public key (RELAY_OWNER_PUBKEY):
+Owner public key (RELAY_OWNER_PUBKEY / hex — used by the relay):
   ${OWNER_PUB}
 
-Owner secret key (import this identity to claim the relay):
+Owner public key (npub — same key, Bech32):
+  ${OWNER_NPUB}
+
+Owner secret for Buzz Desktop (nsec1 — paste into "Use an existing key"):
+  ${OWNER_NSEC}
+
+Owner secret (hex — same key; for CLI / advanced use; Desktop rejects hex):
   ${OWNER_SEC}
 
 Relay URL:
@@ -110,13 +165,14 @@ ACCESS:
   Relay URL:  wss://${DROPLET_IP}
 
 OWNER IDENTITY:
-  Public key:  ${OWNER_PUB}
-  Secret key:  see ${CREDS_FILE}
+  Public key (hex):  ${OWNER_PUB}
+  Desktop secret:    see ${CREDS_FILE} (nsec1 line — Desktop rejects hex)
 
-  Download Buzz Desktop (https://github.com/block/buzz/releases), import the
-  owner secret key, then Join a Community with wss://${DROPLET_IP}.
-  The browser page at https://${DROPLET_IP} is a landing page only — key
-  import and chat are in the desktop app. Add other members with:
+  Download Buzz Desktop (https://github.com/block/buzz/releases), choose
+  "Use an existing key", paste the nsec1 from ${CREDS_FILE}, then Join a
+  Community with wss://${DROPLET_IP}. The browser page at
+  https://${DROPLET_IP} is a landing page only — key import and chat are in
+  the desktop app. Add other members with:
     /opt/buzz/run.sh add-member <npub-or-hex>
 
 MANAGEMENT:

--- a/buzz-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/buzz-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -78,15 +78,18 @@ if grep -q "PLACEHOLDER_DOMAIN" "$ENV_FILE" 2>/dev/null; then
   sed -i "s|PLACEHOLDER_DOMAIN|${DROPLET_IP}|g" "$ENV_FILE"
 fi
 
-# Install Caddyfile and substitute droplet IP for shortlived TLS
+# Install Caddyfile and substitute droplet IP for shortlived TLS.
+# Reload Caddy immediately: it may already be running with the package default
+# (congrats page) from enable-at-build, before this per-instance script runs.
 if [ -f /etc/caddy/Caddyfile.tmp ]; then
   mv /etc/caddy/Caddyfile.tmp /etc/caddy/Caddyfile
 fi
 if grep -q "PLACEHOLDER_DOMAIN" /etc/caddy/Caddyfile 2>/dev/null; then
   echo "Configuring Caddy with droplet IP address..."
   sed -i "s/PLACEHOLDER_DOMAIN/${DROPLET_IP}/" /etc/caddy/Caddyfile
-  systemctl enable caddy
 fi
+systemctl enable caddy
+systemctl restart caddy
 
 # Remove the ssh force logout command
 sed -e '/Match User root/d' \
@@ -110,8 +113,10 @@ OWNER IDENTITY:
   Public key:  ${OWNER_PUB}
   Secret key:  see ${CREDS_FILE}
 
-  Import the owner secret key in the Buzz desktop/web client to administer
-  this closed relay. Add other members with:
+  Download Buzz Desktop (https://github.com/block/buzz/releases), import the
+  owner secret key, then Join a Community with wss://${DROPLET_IP}.
+  The browser page at https://${DROPLET_IP} is a landing page only — key
+  import and chat are in the desktop app. Add other members with:
     /opt/buzz/run.sh add-member <npub-or-hex>
 
 MANAGEMENT:
@@ -148,7 +153,6 @@ systemctl restart ssh
 systemctl enable buzz
 # start-buzz.sh runs `docker compose up -d --wait`, so this blocks until healthy.
 systemctl restart buzz
-systemctl restart caddy
 
 echo "Buzz first-boot initialization complete!"
 echo "Access info saved to ${INFO_FILE}"

--- a/buzz-24-04/listing.md
+++ b/buzz-24-04/listing.md
@@ -30,9 +30,9 @@ This 1-Click defaults to a **2 vCPU / 4 GB** Droplet.
 ## Getting Started
 
 1. **Create the Droplet** from this 1-Click, attach an SSH key, and wait for first-boot init (SSH is locked until `001_onboot` finishes).
-2. **Read credentials**: `/root/buzz_credentials.txt` (also shown in the MOTD) — note the **owner secret key** and Relay URL `wss://YOUR_DROPLET_IP`.
+2. **Read credentials**: `/root/buzz_credentials.txt` (also shown in the MOTD) — copy the **`nsec1` owner secret** (for Desktop) and Relay URL `wss://YOUR_DROPLET_IP`. Hex forms are also listed for the relay/CLI; Buzz Desktop only accepts `nsec1`.
 3. **Install [Buzz Desktop](https://github.com/block/buzz/releases)** (macOS / Windows / Linux). The browser page at `https://YOUR_DROPLET_IP` is only a relay landing page; it does **not** offer key import or chat.
-4. **Claim the relay** in Buzz Desktop: import the owner secret key, then add/connect to `wss://YOUR_DROPLET_IP`.
+4. **Claim the relay** in Buzz Desktop: **Use an existing key**, paste the `nsec1` from credentials, then Join a Community with `wss://YOUR_DROPLET_IP`.
 5. **Optional domain**: point DNS at the Droplet, then run `/opt/setup-buzz-domain.sh`.
 
 The relay starts in **closed membership mode**. Random visitors cannot join until you add them.
@@ -77,7 +77,7 @@ Member management:
 
 - Port **3000** is bound to **localhost only**; public access is via Caddy on **80/443**.
 - Secrets are generated on **first boot** (not baked into the snapshot).
-- Back up `.env`, the owner secret key, Postgres, and MinIO volumes together before upgrades.
+- Back up `.env`, `/root/buzz_credentials.txt` (owner `nsec1`/hex), Postgres, and MinIO volumes together before upgrades.
 
 ## Software License
 

--- a/buzz-24-04/listing.md
+++ b/buzz-24-04/listing.md
@@ -1,0 +1,84 @@
+# Buzz 1-Click Application
+
+Deploy [Buzz](https://buzz.xyz/) — a free, open-source collaboration platform from Block where humans and AI agents share the same rooms on a relay you own.
+
+## What is Buzz?
+
+Buzz is a self-hostable workspace built on a Nostr-style event relay. Channels, threads, media, git events, workflows, and agent activity live in one signed event log. Use the web UI served by the relay, or connect the [Buzz desktop app](https://github.com/block/buzz/releases) to `wss://your-droplet`.
+
+## Included System Components
+
+- **Ubuntu 24.04 LTS**
+- **Buzz Relay** `ghcr.io/block/buzz:0.2.0` (WebSocket + REST + bundled web UI)
+- **PostgreSQL 17.10** — event store
+- **Redis 7.4.10** — pub/sub and presence
+- **MinIO** — S3-compatible media / object storage
+- **Docker Engine + Compose** — orchestrates the stack under `/opt/buzz`
+- **Caddy** — HTTPS on 80/443 with Let's Encrypt shortlived certificates; proxies to `127.0.0.1:3000`
+- **UFW** — SSH (rate-limited), HTTP, HTTPS
+- **fail2ban**
+
+## System Requirements
+
+| Workload | RAM | CPU | Disk |
+|----------|-----|-----|------|
+| Minimum (small team) | 4 GB | 2 vCPU | 50 GB |
+| Recommended | 8 GB | 4 vCPU | 100 GB+ |
+
+This 1-Click defaults to a **2 vCPU / 4 GB** Droplet.
+
+## Getting Started
+
+1. **Create the Droplet** from this 1-Click, attach an SSH key, and wait for first-boot init (SSH is locked until `001_onboot` finishes).
+2. **Open the UI**: `https://YOUR_DROPLET_IP`
+3. **Claim the relay**: read `/root/buzz_credentials.txt` (also shown in the MOTD). Import the **owner secret key** into the Buzz client so you authenticate as `RELAY_OWNER_PUBKEY`.
+4. **Connect desktop clients** to `wss://YOUR_DROPLET_IP` (or your custom domain after step 5).
+5. **Optional domain**: point DNS at the Droplet, then run `/opt/setup-buzz-domain.sh`.
+
+The relay starts in **closed membership mode**. Random visitors cannot join until you add them.
+
+## Start / Stop / Restart / Update
+
+```bash
+/opt/start-buzz.sh
+/opt/stop-buzz.sh
+/opt/restart-buzz.sh
+/opt/status-buzz.sh
+/opt/update-buzz.sh            # pull pinned image and recreate
+/opt/update-buzz.sh 0.2.0      # pin a specific relay tag
+```
+
+Or with systemd:
+
+```bash
+systemctl start|stop|restart|status buzz
+systemctl status caddy
+```
+
+Member management:
+
+```bash
+/opt/buzz/run.sh add-member <npub-or-hex>
+/opt/buzz/run.sh list-members
+/opt/buzz/run.sh logs
+/opt/buzz/run.sh backup-hint
+```
+
+## Important Paths
+
+| Path | Purpose |
+|------|---------|
+| `/opt/buzz/` | Compose stack + `run.sh` |
+| `/opt/buzz/.env` | Secrets and public URL settings |
+| `/root/buzz_credentials.txt` | Owner keypair + access URLs |
+| `/root/buzz_info.txt` | First-boot getting-started summary |
+
+## Security Notes
+
+- Port **3000** is bound to **localhost only**; public access is via Caddy on **80/443**.
+- Secrets are generated on **first boot** (not baked into the snapshot).
+- Back up `.env`, the owner secret key, Postgres, and MinIO volumes together before upgrades.
+
+## Software License
+
+Buzz is Apache-2.0. See https://github.com/block/buzz.

--- a/buzz-24-04/listing.md
+++ b/buzz-24-04/listing.md
@@ -4,7 +4,7 @@ Deploy [Buzz](https://buzz.xyz/) — a free, open-source collaboration platform 
 
 ## What is Buzz?
 
-Buzz is a self-hostable workspace built on a Nostr-style event relay. Channels, threads, media, git events, workflows, and agent activity live in one signed event log. Use the web UI served by the relay, or connect the [Buzz desktop app](https://github.com/block/buzz/releases) to `wss://your-droplet`.
+Buzz is a self-hostable workspace built on a Nostr-style event relay. Channels, threads, media, git events, workflows, and agent activity live in one signed event log. Connect the [Buzz desktop app](https://github.com/block/buzz/releases) to `wss://your-droplet` (the HTTPS page on the Droplet is a relay landing page only).
 
 ## Included System Components
 
@@ -30,9 +30,9 @@ This 1-Click defaults to a **2 vCPU / 4 GB** Droplet.
 ## Getting Started
 
 1. **Create the Droplet** from this 1-Click, attach an SSH key, and wait for first-boot init (SSH is locked until `001_onboot` finishes).
-2. **Open the UI**: `https://YOUR_DROPLET_IP`
-3. **Claim the relay**: read `/root/buzz_credentials.txt` (also shown in the MOTD). Import the **owner secret key** into the Buzz client so you authenticate as `RELAY_OWNER_PUBKEY`.
-4. **Connect desktop clients** to `wss://YOUR_DROPLET_IP` (or your custom domain after step 5).
+2. **Read credentials**: `/root/buzz_credentials.txt` (also shown in the MOTD) — note the **owner secret key** and Relay URL `wss://YOUR_DROPLET_IP`.
+3. **Install [Buzz Desktop](https://github.com/block/buzz/releases)** (macOS / Windows / Linux). The browser page at `https://YOUR_DROPLET_IP` is only a relay landing page; it does **not** offer key import or chat.
+4. **Claim the relay** in Buzz Desktop: import the owner secret key, then add/connect to `wss://YOUR_DROPLET_IP`.
 5. **Optional domain**: point DNS at the Droplet, then run `/opt/setup-buzz-domain.sh`.
 
 The relay starts in **closed membership mode**. Random visitors cannot join until you add them.

--- a/buzz-24-04/scripts/010-buzz.sh
+++ b/buzz-24-04/scripts/010-buzz.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_VERSION="${application_version:-0.2.0}"
+BUZZ_IMAGE="ghcr.io/block/buzz:${APP_VERSION}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Docker Engine (Compose plugin required by upstream deploy/compose)
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+  > /etc/apt/sources.list.d/docker.list
+
+apt-get update -qq
+apt-get install -y -qq \
+  docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+mkdir -p /etc/docker
+cat > /etc/docker/daemon.json <<EOF
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+EOF
+
+systemctl enable docker
+systemctl restart docker
+
+docker --version
+docker compose version
+
+# Caddy reverse proxy (host TLS; relay stays on loopback :3000)
+curl -1sLf "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" \
+  | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main" \
+  > /etc/apt/sources.list.d/caddy-stable.list
+apt-get update -y
+apt-get install -y caddy
+mkdir -p /var/log/caddy
+chown -R caddy:caddy /var/log/caddy
+
+# Materialize .env from the non-hidden Packer template (Packer may skip dotfiles)
+if [ -f /opt/buzz/env.template ]; then
+  cp /opt/buzz/env.template /opt/buzz/.env
+fi
+if [ -f /opt/buzz/.env ]; then
+  sed -i "s|^BUZZ_IMAGE=.*|BUZZ_IMAGE=${BUZZ_IMAGE}|" /opt/buzz/.env
+  chmod 600 /opt/buzz/.env
+fi
+
+# Pre-pull images so first boot is faster (sidecar tags match compose.yml pins)
+echo "Pulling Buzz stack images (relay ${APP_VERSION})..."
+docker pull "${BUZZ_IMAGE}"
+docker pull postgres:17.10-alpine
+docker pull redis:7.4.10-alpine
+docker pull minio/minio:RELEASE.2025-09-07T16-13-09Z
+docker pull minio/mc:RELEASE.2025-08-13T08-35-41Z
+
+systemctl enable fail2ban
+systemctl restart fail2ban
+
+# Helper scripts and MOTD
+chmod +x /opt/buzz/run.sh
+chmod +x /opt/start-buzz.sh
+chmod +x /opt/stop-buzz.sh
+chmod +x /opt/restart-buzz.sh
+chmod +x /opt/status-buzz.sh
+chmod +x /opt/update-buzz.sh
+chmod +x /opt/setup-buzz-domain.sh
+chmod +x /etc/update-motd.d/99-one-click
+chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+
+systemctl daemon-reload
+systemctl enable buzz
+systemctl enable caddy
+
+echo "Buzz ${APP_VERSION} installation complete."
+echo "Stack will start on first boot after secrets are generated."

--- a/buzz-24-04/template.json
+++ b/buzz-24-04/template.json
@@ -1,0 +1,82 @@
+{
+  "variables": {
+    "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
+    "image_name": "buzz-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "procps file apt-transport-https ca-certificates curl software-properties-common git jq unzip openssl ufw gnupg fail2ban",
+    "application_name": "Buzz",
+    "application_version": "0.2.0"
+  },
+  "sensitive-variables": ["do_api_token"],
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_api_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-2vcpu-4gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "cloud-init status --wait"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "common/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "file",
+      "source": "buzz-24-04/files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "buzz-24-04/files/opt/",
+      "destination": "/opt/"
+    },
+    {
+      "type": "file",
+      "source": "buzz-24-04/files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt -qqy update",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' full-upgrade",
+        "apt -qqy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "buzz-24-04/scripts/010-buzz.sh",
+        "common/scripts/014-ufw-http.sh",
+        "common/scripts/018-force-ssh-logout.sh",
+        "common/scripts/020-application-tag.sh",
+        "common/scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}

--- a/buzz-24-04/template.json
+++ b/buzz-24-04/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "buzz-24-04-snapshot-{{timestamp}}",
-    "apt_packages": "procps file apt-transport-https ca-certificates curl software-properties-common git jq unzip openssl ufw gnupg fail2ban",
+    "apt_packages": "procps file apt-transport-https ca-certificates curl software-properties-common git jq unzip openssl ufw gnupg fail2ban python3",
     "application_name": "Buzz",
     "application_version": "0.2.0"
   },


### PR DESCRIPTION
## Summary

- [JIRA](https://do-internal.atlassian.net/browse/MP-8506) — **MP-8506**
- Add a new **Buzz** (`buzz.xyz`) Droplet 1-Click on Ubuntu 24.04 under `buzz-24-04/`
- Deploy the official Docker Compose stack (relay + Postgres + Redis + MinIO) with host **Caddy** shortlived TLS; bind the relay to localhost and expose only 80/443
- Generate per-droplet secrets and owner keypair on first boot; run the relay in closed membership mode
- Include MOTD, systemd unit, start/stop/restart/status/update helpers, and a domain setup helper backed by a shipped `Caddyfile.domain.tmp`

## Test plan

- [ ] Create a Droplet from the snapshot; confirm SSH unlocks after `001_onboot`
- [ ] Open `https://<droplet-ip>`; import owner secret key from `/root/buzz_credentials.txt`
- [ ] Confirm port 3000 is not public; only 22/80/443 via UFW
- [ ] Exercise `/opt/start-buzz.sh`, `/opt/stop-buzz.sh`, `/opt/restart-buzz.sh`, `/opt/status-buzz.sh`
- [ ] Buzz Desktop: import owner `nsec1` from `/root/buzz_credentials.txt`, join `wss://<droplet-ip>`, send a message in a channel
- [ ] Non-member identity is denied; after `/opt/buzz/run.sh add-member <npub-or-hex>`, that identity can join; verify with `list-members` (and optional `remove-member`)