### PR TITLE
MP-8522 : Stop injecting --token into openclaw agents commands

### DIFF
--- a/openclaw-24-04/files/opt/openclaw-cli.sh
+++ b/openclaw-24-04/files/opt/openclaw-cli.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Run OpenClaw CLI as the openclaw user (arguments preserved and shell-safe).
 # Injects --token from /opt/openclaw.env only for gateway RPC commands (devices,
-# tui, status, …). Subcommands like `skills` do not accept --token.
+# tui, status, agent, …). Local subcommands like `skills` and `agents` (add/list
+# /bind/delete) do not accept --token.
 
 OPENCLAW_BIN=${OPENCLAW_BIN:-/usr/bin/openclaw}
 
@@ -23,7 +24,7 @@ read_gateway_token_from_env() {
 # openclaw subcommands that talk to the gateway and accept --token
 openclaw_cli_accepts_gateway_token() {
     case "${1:-}" in
-        devices|tui|status|cron|gateway|health|logs|agent|agents|sessions|browser)
+        devices|tui|status|cron|gateway|health|logs|agent|sessions|browser)
             return 0
             ;;
     esac

--- a/openclaw-24-04/tests/test-openclaw-cli.sh
+++ b/openclaw-24-04/tests/test-openclaw-cli.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Unit tests for /opt/openclaw-cli.sh gateway-token injection allowlist.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLI="$SCRIPT_DIR/../files/opt/openclaw-cli.sh"
+
+if [ ! -f "$CLI" ]; then
+    echo "FAIL: missing $CLI"
+    exit 1
+fi
+
+eval "$(sed -n '/^openclaw_cli_accepts_gateway_token()/,/^}/p' "$CLI")"
+
+FAILURES=0
+
+assert_accepts_token() {
+    local cmd="$1"
+    if openclaw_cli_accepts_gateway_token "$cmd"; then
+        echo "OK: $cmd receives --token"
+    else
+        echo "FAIL: $cmd should receive --token"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_rejects_token() {
+    local cmd="$1"
+    if openclaw_cli_accepts_gateway_token "$cmd"; then
+        echo "FAIL: $cmd should not receive --token"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "OK: $cmd does not receive --token"
+    fi
+}
+
+echo "=== openclaw-cli.sh token allowlist ==="
+
+# Gateway RPC commands still need the injected token.
+assert_accepts_token agent
+assert_accepts_token devices
+assert_accepts_token tui
+assert_accepts_token status
+assert_accepts_token gateway
+
+# agents is local config management (add/list/bind/delete); --token is rejected.
+assert_rejects_token agents
+assert_rejects_token skills
+assert_rejects_token configure
+assert_rejects_token onboard
+
+if [ "$FAILURES" -ne 0 ]; then
+    echo
+    echo "$FAILURES assertion(s) failed"
+    exit 1
+fi
+
+echo
+echo "All assertions passed"


### PR DESCRIPTION
## Summary

`openclaw agents add` fails on the OpenClaw 1-Click because `/opt/openclaw-cli.sh` injects `--token` into `agents` commands. `agents` is local config management and rejects that flag.

This removes `agents` from the token allowlist. Gateway RPC commands (`agent`, `devices`, `tui`, …) still get `--token`.


## Test plan

- [ ] `bash openclaw-24-04/tests/test-openclaw-cli.sh`
- [ ] On a rebuilt image, `openclaw agents add <name>` succeeds
- [ ] `openclaw devices list` / `openclaw tui` still authenticate with the gateway token