### PR TITLE
MP-8547: wire ollama Packer application_version for Autoupdate

### DIFF
--- a/ollama-24-04/template.json
+++ b/ollama-24-04/template.json
@@ -5,7 +5,7 @@
     "apt_packages": "fail2ban jq libgl1 libglx-mesa0 ffmpeg libsm6 libxext6 build-essential git-all debian-keyring debian-archive-keyring apt-transport-https curl",
     "application_name": "Ollama",
     "anaconda_version": "2024.06-1",
-    "ollama_version": "0.31.2",
+    "application_version": "0.31.2",
     "open_webui_version": "0.10.2",
     "model_name": "tinyllama"
   },
@@ -62,10 +62,10 @@
       "environment_vars": [
         "ANACONDA_VERSION={{user `anaconda_version`}}",
         "OPEN_WEBUI_VERSION={{user `open_webui_version`}}",
-        "OLLAMA_VERSION={{user `ollama_version`}}",
+        "OLLAMA_VERSION={{user `application_version`}}",
         "MODEL_NAME={{user `model_name`}}",
         "application_name={{user `application_name`}}",
-        "application_version={{user `ollama_version`}}",
+        "application_version={{user `application_version`}}",
         "DEBIAN_FRONTEND=noninteractive",
         "LC_ALL=C",
         "LANG=en_US.UTF-8",


### PR DESCRIPTION
### PR Description

- Marketplace Autoupdate always rebuilds with packer build -var application_version=<latest>. It cannot pass -var ollama_version=…, and internal/autoupdate/build.go is not in scope to change.

- Ollama’s 1-Click still declared Packer user var ollama_version. A cthulhu-only merge would clone this repo and keep installing the template default (0.31.2) instead of the fetched latest (e.g. 0.32.9).

- Rename ollama_version to application_version (default still "0.31.2") in ollama-24-04/template.json.

- Point the install provisioner at that var for both install and image tag: OLLAMA_VERSION={{user application_version}} (feeds 011-ollama.sh / ollama.com/install.sh) and application_version={{user application_version}} (feeds 020-application-tag.sh → /var/lib/digitalocean/application.info). Leave anaconda_version, open_webui_version, and model_name unchanged.

- This 1-Click change must land on droplet-1-clicks master before Ollama Autoupdate ships with is_enabled: true.

https://do-internal.atlassian.net/browse/MP-8547