### PR TITLE
Dynamic listing of models for Grok Build

### DIFF
--- a/grok-build-24-04/README.md
+++ b/grok-build-24-04/README.md
@@ -74,8 +74,8 @@ Grok Build supports any OpenAI-compatible provider through per-model entries in 
 
 - **Endpoint**: `https://inference.do-ai.run/v1`
 - **Auth**: Bearer token (model access key) read from the `MODEL_ACCESS_KEY` env var
-- **Default model**: `gpt-5-5` (GPT-5.5)
-- **Catalog**: GPT-5.x, Claude Opus/Sonnet, Kimi, MiniMax, GLM, Llama, Qwen, DeepSeek (see `config.toml`)
+- **Default model**: `openai-gpt-5.5` / alias `gpt-5-5` when that id is still in the live catalog
+- **Catalog**: loaded at runtime from `GET https://inference.do-ai.run/v1/models` (same helper as Hermes/OpenClaw)
 - **Intelligent Inference Router**: the `router` alias uses `model = "router:<name>"`
 
 ### Authentication priority
@@ -109,7 +109,7 @@ Grok resolves credentials per model as `model.api_key` > `model.env_key` > activ
 | Variable | Description |
 |----------|-------------|
 | `MODEL_ACCESS_KEY` | DigitalOcean model access key (default provider) |
-| `DO_INFERENCE_MODEL` | Optional default model alias (default `gpt-5-5`) |
+| `DO_INFERENCE_MODEL` | Optional default model id or alias (live catalog; prefers `openai-gpt-5.5`) |
 | `DO_INFERENCE_ROUTER` | Optional Intelligent Inference Router name (`router:<name>`) |
 | `XAI_API_KEY` | xAI API key (`xai-...`) for the xAI native provider |
 
@@ -120,13 +120,12 @@ Set these as droplet environment variables at create time (written to `/etc/envi
 On first SSH login (when nothing was pre-applied), the wizard:
 
 1. Prompts for a DigitalOcean model access key
-2. Presents a numbered list of DigitalOcean models to pick the default from — or `R` to use an Intelligent Inference Router (and prompts for its name)
-3. Saves the selection to `/opt/grok-build.env`, applies `MODEL_ACCESS_KEY`, and sets the default model/router in `config.toml`
-4. Tests the connection to `https://inference.do-ai.run/v1/models`
-5. If the model access key is skipped, offers xAI device-code sign-in or an xAI API key
-6. Self-removes from `.bashrc` after a successful setup
+2. Fetches the current chat-model list from `GET https://inference.do-ai.run/v1/models` and presents it (or `R` for the Intelligent Inference Router)
+3. Saves the selection to `/opt/grok-build.env`, applies `MODEL_ACCESS_KEY`, refreshes the DigitalOcean catalog in `config.toml`, and sets the default model/router
+4. If the model access key is skipped, offers xAI device-code sign-in or an xAI API key
+5. Self-removes from `.bashrc` after a successful setup
 
-The model menu aliases are kept in sync with `/root/.grok/config.toml`. The DigitalOcean catalog evolves; list the live set with `curl -s -H "Authorization: Bearer $MODEL_ACCESS_KEY" https://inference.do-ai.run/v1/models | jq -r '.data[].id'`.
+Invalid keys can be re-entered, or you can type a model id to continue without a live list. The DigitalOcean `[model.*]` entries in `config.toml` are replaced with the live set (existing aliases such as `gpt-5-5` are kept when that id is still available).
 
 ## Version Pinning
 

--- a/grok-build-24-04/files/etc/update-motd.d/99-one-click
+++ b/grok-build-24-04/files/etc/update-motd.d/99-one-click
@@ -11,16 +11,16 @@ Grok Build is xAI's terminal-based coding agent. Use natural language to plan,
 write, review, and refactor code. This droplet is pre-configured to run Grok
 Build on DigitalOcean Serverless Inference.
 
-PRE-CONFIGURED MODELS (via DigitalOcean Serverless Inference, default GPT-5.5):
-  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5,
-  gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
-  claude-haiku-4-5, deepseek-v4-pro, kimi-k2-6, minimax-m2-5, glm-5,
-  qwen3-coder-flash, llama-4-maverick, nemotron-3-super-120b, router
+MODELS (DigitalOcean Serverless Inference):
+  After you enter a model access key, the setup wizard loads the current
+  chat-model catalog from https://inference.do-ai.run/v1/models.
+  Option R uses the Intelligent Inference Router. Aliases live in
+  /root/.grok/config.toml and refresh when a key is applied.
 
 GETTING STARTED:
 
   1. On first login, the setup wizard prompts for your DigitalOcean model
-     access key and lets you pick a default model from a list. Create a key:
+     access key and loads the current model list. Create a key:
        https://cloud.digitalocean.com/model-studio/manage-keys  (Inference > Manage)
      With a model access key, Grok uses the API directly - no browser sign-in.
 

--- a/grok-build-24-04/files/opt/apply-inference-from-env.sh
+++ b/grok-build-24-04/files/opt/apply-inference-from-env.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 ENV_FILE="/opt/grok-build.env"
 KEY_PROFILED="/etc/profile.d/grok-build-key.sh"
 CONFIG_FILE="/root/.grok/config.toml"
+INFERENCE_MODELS_LIB="/var/lib/digitalocean/inference-models.sh"
+PREFERRED_INFERENCE_MODEL="openai-gpt-5.5"
 BASHRC="/root/.bashrc"
 BASHRC_BEGIN="# grok-build-24-04-key-env BEGIN"
 BASHRC_END="# grok-build-24-04-key-env END"
@@ -80,6 +82,170 @@ ensure_key_sourced_in_bashrc() {
     fi
 }
 
+# Refresh [model.*] entries between markers from the live catalog. Prints the
+# alias that should be set as [models].default for the chosen API id / alias.
+sync_inference_catalog() {
+    local chosen="$1"
+    local ids_file="$2"
+
+    python3 - "$CONFIG_FILE" "$chosen" "$ids_file" "$PREFERRED_INFERENCE_MODEL" <<'PY'
+import re
+import sys
+
+config_path, chosen, ids_path, preferred = sys.argv[1:5]
+begin = "# BEGIN digitalocean-inference-models"
+end = "# END digitalocean-inference-models"
+reserved = {"grok-build", "router"}
+
+def sanitize(model_id: str) -> str:
+    alias = model_id.replace(".", "-")
+    alias = re.sub(r"[^A-Za-z0-9_-]", "-", alias)
+    alias = re.sub(r"-{2,}", "-", alias).strip("-")
+    return alias or "model"
+
+def parse_blocks(text: str):
+    mapping = {}
+    current = None
+    fields = {}
+    for line in text.splitlines():
+        header = re.match(r"^\[model\.([^\]]+)\]\s*$", line)
+        if header:
+            if current and current not in reserved:
+                mapping[current] = fields
+            current = header.group(1)
+            fields = {}
+            continue
+        if current and re.match(r"^\[", line):
+            if current not in reserved:
+                mapping[current] = fields
+            current = None
+            fields = {}
+            continue
+        if current is None:
+            continue
+        match = re.match(r'^([A-Za-z0-9_]+)\s*=\s*"(.*)"\s*$', line)
+        if match:
+            fields[match.group(1)] = match.group(2)
+    if current and current not in reserved:
+        mapping[current] = fields
+    return mapping
+
+with open(config_path, encoding="utf-8") as fh:
+    text = fh.read()
+
+live_ids = []
+with open(ids_path, encoding="utf-8") as fh:
+    for line in fh:
+        model_id = line.strip()
+        if model_id:
+            live_ids.append(model_id)
+
+existing = parse_blocks(text)
+id_by_alias = {alias: fields.get("model", "") for alias, fields in existing.items()}
+alias_by_id = {}
+for alias, model_id in id_by_alias.items():
+    if model_id and model_id not in alias_by_id:
+        alias_by_id[model_id] = alias
+
+chosen_alias = "gpt-5-5"
+chosen_id = chosen.strip()
+if not chosen_id:
+    if preferred in live_ids:
+        chosen_id = preferred
+    elif live_ids:
+        chosen_id = live_ids[0]
+    elif "gpt-5-5" in id_by_alias:
+        chosen_id = id_by_alias["gpt-5-5"] or preferred
+    else:
+        chosen_id = preferred
+elif chosen_id in id_by_alias:
+    chosen_id = id_by_alias[chosen_id] or chosen_id
+
+ordered = []
+seen = set()
+for model_id in [chosen_id] + live_ids:
+    if model_id and model_id not in seen:
+        ordered.append(model_id)
+        seen.add(model_id)
+
+used_aliases = set()
+entries = []
+for model_id in ordered:
+    alias = alias_by_id.get(model_id) or sanitize(model_id)
+    base = alias
+    n = 2
+    while alias in used_aliases:
+        alias = f"{base}-{n}"
+        n += 1
+    used_aliases.add(alias)
+    prev = existing.get(alias, {})
+    name = prev.get("name") or f"{model_id} (DigitalOcean Inference)"
+    entries.append((alias, model_id, name))
+    if model_id == chosen_id:
+        chosen_alias = alias
+
+if not entries:
+    print("gpt-5-5", end="")
+    raise SystemExit(0)
+
+blocks = [
+    "# === DigitalOcean Serverless Inference models ===",
+    "# Refreshed from GET https://inference.do-ai.run/v1/models when a key is applied.",
+    "",
+]
+for alias, model_id, name in entries:
+    blocks.extend(
+        [
+            f"[model.{alias}]",
+            f'model = "{model_id}"',
+            'base_url = "https://inference.do-ai.run/v1"',
+            f'name = "{name}"',
+            'env_key = "MODEL_ACCESS_KEY"',
+            "",
+        ]
+    )
+new_region = "\n".join(blocks).rstrip() + "\n"
+
+if begin in text and end in text:
+    pre, rest = text.split(begin, 1)
+    _, post = rest.split(end, 1)
+    text = f"{pre}{begin}\n{new_region}{end}{post}"
+    with open(config_path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+print(chosen_alias, end="")
+PY
+}
+
+choose_inference_default() {
+    local requested="$1"
+    local chat_ids="$2"
+    local tmp alias
+
+    tmp="$(mktemp)"
+    if [ -n "$chat_ids" ]; then
+        printf '%s\n' "$chat_ids" >"$tmp"
+    else
+        : >"$tmp"
+    fi
+
+    if alias="$(sync_inference_catalog "$requested" "$tmp")"; then
+        rm -f "$tmp"
+        if [ -n "$alias" ]; then
+            printf '%s' "$alias"
+            return 0
+        fi
+    else
+        rm -f "$tmp"
+    fi
+
+    if [ -n "$requested" ]; then
+        printf '%s' "$requested"
+        return 0
+    fi
+    printf '%s' "gpt-5-5"
+}
+
 MODEL_ACCESS_KEY_VAL="$(read_value MODEL_ACCESS_KEY)"
 DO_INFERENCE_MODEL_VAL="$(read_value DO_INFERENCE_MODEL)"
 DO_INFERENCE_ROUTER_VAL="$(read_value DO_INFERENCE_ROUTER)"
@@ -88,15 +254,31 @@ XAI_API_KEY_VAL="$(read_value XAI_API_KEY)"
 if [ -n "$MODEL_ACCESS_KEY_VAL" ]; then
     write_profiled MODEL_ACCESS_KEY "$MODEL_ACCESS_KEY_VAL"
     ensure_key_sourced_in_bashrc
+
+    CHAT_IDS=""
+    if [ -f "$INFERENCE_MODELS_LIB" ]; then
+        # shellcheck source=/var/lib/digitalocean/inference-models.sh
+        . "$INFERENCE_MODELS_LIB"
+        CHAT_IDS="$(list_chat_inference_models "$MODEL_ACCESS_KEY_VAL" || true)"
+        if [ -z "$CHAT_IDS" ]; then
+            json="$(fetch_inference_models_json "$MODEL_ACCESS_KEY_VAL" || true)"
+            if [ -n "$json" ]; then
+                CHAT_IDS="$(printf '%s' "$json" | parse_inference_model_ids || true)"
+            fi
+        fi
+    fi
+
     if [ -n "$DO_INFERENCE_ROUTER_VAL" ]; then
+        choose_inference_default "$DO_INFERENCE_MODEL_VAL" "$CHAT_IDS" >/dev/null || true
         set_router_name "$DO_INFERENCE_ROUTER_VAL"
         set_default_model "router"
-    elif [ -n "$DO_INFERENCE_MODEL_VAL" ]; then
-        set_default_model "$DO_INFERENCE_MODEL_VAL"
-    else
-        set_default_model "gpt-5-5"
+        echo "DigitalOcean Serverless Inference configured (MODEL_ACCESS_KEY, router)."
+        exit 0
     fi
-    echo "DigitalOcean Serverless Inference configured (MODEL_ACCESS_KEY)."
+
+    DEFAULT_ALIAS="$(choose_inference_default "$DO_INFERENCE_MODEL_VAL" "$CHAT_IDS")"
+    set_default_model "$DEFAULT_ALIAS"
+    echo "DigitalOcean Serverless Inference configured (MODEL_ACCESS_KEY): ${DEFAULT_ALIAS}"
     exit 0
 fi
 

--- a/grok-build-24-04/files/opt/grok-build.env
+++ b/grok-build-24-04/files/opt/grok-build.env
@@ -3,9 +3,9 @@
 # DigitalOcean Serverless Inference (recommended):
 #   MODEL_ACCESS_KEY  Model access key (Inference > Manage
 #                        in the DigitalOcean control panel)
-#   DO_INFERENCE_MODEL   Default model alias from /root/.grok/config.toml, e.g.
-#                        gpt-5-5 (default), gpt-5-3-codex, claude-opus-4-8,
-#                        deepseek-v4-pro, kimi-k2-6, qwen3-coder-flash
+#   DO_INFERENCE_MODEL   Optional default model id or alias (e.g. openai-gpt-5.5
+#                        or gpt-5-5). If empty, apply uses openai-gpt-5.5 when
+#                        it is still in the live catalog, else the first chat model.
 #   DO_INFERENCE_ROUTER  Optional. Name of a DigitalOcean Intelligent Inference
 #                        Router attached to MODEL_ACCESS_KEY (in the control
 #                        panel). If set, requests route through "router:<name>"
@@ -21,6 +21,6 @@
 # Otherwise run the wizard on first SSH login: /opt/setup-grok-build.sh
 
 MODEL_ACCESS_KEY=
-DO_INFERENCE_MODEL=gpt-5-5
+DO_INFERENCE_MODEL=
 DO_INFERENCE_ROUTER=
 XAI_API_KEY=

--- a/grok-build-24-04/files/opt/setup-grok-build.sh
+++ b/grok-build-24-04/files/opt/setup-grok-build.sh
@@ -15,6 +15,8 @@ fi
 SETUP_MARKER="/root/.grok_build_setup_complete"
 ENV_FILE="/opt/grok-build.env"
 CONFIG_FILE="/root/.grok/config.toml"
+INFERENCE_MODELS_LIB="/var/lib/digitalocean/inference-models.sh"
+PREFERRED_INFERENCE_MODEL="openai-gpt-5.5"
 
 # The .bashrc hook invokes this with --autostart on login. In that mode, skip
 # silently if setup is already complete or a key is configured from the
@@ -67,8 +69,8 @@ echo "========================================================================"
 echo ""
 echo "This droplet is pre-configured to run Grok Build on DigitalOcean Serverless"
 echo "Inference (https://inference.do-ai.run/v1). A single DigitalOcean model"
-echo "access key unlocks GPT-5.5 (default), Claude, Llama, Kimi, GLM,"
-echo "DeepSeek, Qwen, MiniMax and more, plus the Intelligent Inference Router."
+echo "access key unlocks the current Serverless Inference catalog, plus the"
+echo "Intelligent Inference Router."
 echo ""
 echo "To create a DigitalOcean model access key:"
 echo "  1. Go to https://cloud.digitalocean.com/model-studio/manage-keys"
@@ -82,66 +84,127 @@ read -rsp "Enter your DigitalOcean model access key (or press Enter for xAI opti
 echo ""
 [ -n "${old_histfile:-}" ] && export HISTFILE="$old_histfile"
 
-# DigitalOcean Serverless Inference model menu (alias -> label): a short list of the latest,
-# most popular coding models. The full catalog lives in /root/.grok/config.toml
-# and can be selected any time with /model or -m <alias>.
-MENU_ALIASES=(
-  gpt-5-5 gpt-5-3-codex claude-opus-4-8 claude-sonnet-4-6
-  deepseek-v4-pro kimi-k2-6 qwen3-coder-flash glm-5
-)
-MENU_LABELS=(
-  "GPT-5.5 (default)" "GPT-5.3 Codex" "Claude Opus 4.8" "Claude Sonnet 4.6"
-  "DeepSeek V4 Pro" "Kimi K2.6" "Qwen3 Coder Flash" "GLM-5"
-)
-
 if [ -n "$MODEL_ACCESS_KEY" ]; then
+  if [ ! -f "$INFERENCE_MODELS_LIB" ]; then
+    echo "ERROR: missing $INFERENCE_MODELS_LIB" >&2
+    exit 1
+  fi
+  # shellcheck source=/var/lib/digitalocean/inference-models.sh
+  . "$INFERENCE_MODELS_LIB"
+
   save_env_kv MODEL_ACCESS_KEY "$MODEL_ACCESS_KEY"
 
   echo ""
-  echo "Choose a default model (you can switch later with /model or -m <alias>):"
-  echo ""
-  for i in "${!MENU_ALIASES[@]}"; do
-    printf "  %2d) %-22s (%s)\n" "$((i + 1))" "${MENU_LABELS[$i]}" "${MENU_ALIASES[$i]}"
-  done
-  echo "   R) DigitalOcean Intelligent Inference Router (auto-picks the best model)"
-  echo ""
-  read -rp "Selection [1-${#MENU_ALIASES[@]} / R, or Enter for GPT-5.5]: " SEL
+  echo "Fetching available models from DigitalOcean Serverless Inference..."
 
-  if [ "$SEL" = "R" ] || [ "$SEL" = "r" ]; then
-    echo ""
-    echo "Create a router under Inference > Routers, then enter its name."
-    read -rp "Router name: " ROUTER_NAME
-    if [ -n "$ROUTER_NAME" ]; then
-      save_env_kv DO_INFERENCE_ROUTER "$ROUTER_NAME"
+  json=""
+  chat_ids=""
+  CHOSEN=""
+  ROUTER_NAME=""
+  while true; do
+    if json="$(fetch_inference_models_json "$MODEL_ACCESS_KEY")"; then
+      chat_ids="$(printf '%s' "$json" | parse_inference_model_ids | filter_chat_inference_models)"
+      if [ -z "$chat_ids" ]; then
+        chat_ids="$(printf '%s' "$json" | parse_inference_model_ids)"
+      fi
+      if [ -n "$chat_ids" ]; then
+        if printf '%s\n' "$chat_ids" | grep -Fxq "$PREFERRED_INFERENCE_MODEL"; then
+          rest="$(printf '%s\n' "$chat_ids" | grep -Fxv "$PREFERRED_INFERENCE_MODEL")"
+          chat_ids="$(printf '%s\n%s\n' "$PREFERRED_INFERENCE_MODEL" "$rest")"
+        fi
+        break
+      fi
+      echo "The serverless inference API returned no models for this key."
     else
-      echo "No router name entered; keeping the GPT-5.5 default."
-      save_env_kv DO_INFERENCE_MODEL "gpt-5-5"
+      status="${INFERENCE_MODELS_HTTP_STATUS:-000}"
+      if [ "$status" = "401" ] || [ "$status" = "403" ]; then
+        echo "That key was rejected (HTTP ${status})."
+      else
+        echo "Could not list models from https://inference.do-ai.run/v1/models (HTTP ${status})."
+      fi
     fi
-  elif [ -n "$SEL" ] && [ "$SEL" -ge 1 ] 2>/dev/null && [ "$SEL" -le "${#MENU_ALIASES[@]}" ] 2>/dev/null; then
-    CHOSEN="${MENU_ALIASES[$((SEL - 1))]}"
+
+    echo ""
+    echo "You can re-enter the key, type a model id to use this key anyway,"
+    echo "or press Enter to keep trying options."
+    old_histfile="${HISTFILE-}"
+    unset HISTFILE
+    read -rsp "Re-enter your model access key (or press Enter to keep the current key): " NEW_KEY
+    echo ""
+    [ -n "${old_histfile:-}" ] && export HISTFILE="$old_histfile"
+    if [ -n "${NEW_KEY}" ]; then
+      MODEL_ACCESS_KEY="$NEW_KEY"
+      save_env_kv MODEL_ACCESS_KEY "$MODEL_ACCESS_KEY"
+      continue
+    fi
+
+    echo ""
+    echo "Enter a DigitalOcean model id, R for the Intelligent Inference Router,"
+    echo "or press Enter to try listing models again."
+    read -rp "Model id / R: " MANUAL_SEL
+    if [ "$MANUAL_SEL" = "R" ] || [ "$MANUAL_SEL" = "r" ]; then
+      echo ""
+      echo "Create a router under Inference > Routers, then enter its name."
+      read -rp "Router name: " ROUTER_NAME
+      if [ -n "$ROUTER_NAME" ]; then
+        chat_ids=""
+        break
+      fi
+      echo "No router name entered."
+    elif [ -n "$MANUAL_SEL" ]; then
+      CHOSEN="$MANUAL_SEL"
+      chat_ids=""
+      break
+    fi
+  done
+
+  if [ -n "$chat_ids" ]; then
+    default_model="$(printf '%s\n' "$chat_ids" | pick_default_inference_model)"
+    echo ""
+    echo "Choose a default model (you can switch later with /model or -m <alias>):"
+    echo ""
+    i=1
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      printf "  %2d) %s\n" "$i" "$line"
+      i=$((i + 1))
+    done <<<"$chat_ids"
+    echo "   R) DigitalOcean Intelligent Inference Router (auto-picks the best model)"
+    echo ""
+    count=$((i - 1))
+    read -rp "Selection [1-${count} / R, or Enter for ${default_model}]: " SEL
+
+    if [ "$SEL" = "R" ] || [ "$SEL" = "r" ]; then
+      echo ""
+      echo "Create a router under Inference > Routers, then enter its name."
+      read -rp "Router name: " ROUTER_NAME
+      if [ -z "$ROUTER_NAME" ]; then
+        echo "No router name entered; keeping ${default_model}."
+        CHOSEN="$default_model"
+      fi
+    elif [ -z "$SEL" ]; then
+      CHOSEN="$default_model"
+    elif CHOSEN="$(printf '%s\n' "$chat_ids" | resolve_inference_model_choice "$SEL")"; then
+      :
+    elif [[ "$SEL" =~ ^[0-9]+$ ]]; then
+      echo "Invalid selection; using ${default_model}."
+      CHOSEN="$default_model"
+    else
+      CHOSEN="$SEL"
+    fi
+  fi
+
+  if [ -n "$ROUTER_NAME" ]; then
+    save_env_kv DO_INFERENCE_ROUTER "$ROUTER_NAME"
+    echo "Default set to Intelligent Inference Router (router:${ROUTER_NAME})."
+  else
     save_env_kv DO_INFERENCE_MODEL "$CHOSEN"
     save_env_kv DO_INFERENCE_ROUTER ""
     echo "Default model set to: $CHOSEN"
-  else
-    save_env_kv DO_INFERENCE_MODEL "gpt-5-5"
-    save_env_kv DO_INFERENCE_ROUTER ""
-    echo "Default model set to: gpt-5-5 (GPT-5.5)"
   fi
 
-  /opt/apply-inference-from-env.sh
   export MODEL_ACCESS_KEY="$MODEL_ACCESS_KEY"
-
-  echo ""
-  echo "Testing connection to DigitalOcean Serverless Inference..."
-  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-    -H "Authorization: Bearer ${MODEL_ACCESS_KEY}" \
-    https://inference.do-ai.run/v1/models 2>/dev/null)
-  if [ "$HTTP_STATUS" = "200" ]; then
-    echo "Connection successful! Your key is valid."
-  else
-    echo "Warning: received HTTP $HTTP_STATUS from the DigitalOcean inference API."
-    echo "Your key was saved. If it's wrong, re-run: /opt/setup-grok-build.sh"
-  fi
+  /opt/apply-inference-from-env.sh
   finish
 fi
 

--- a/grok-build-24-04/files/root/.grok/config.toml
+++ b/grok-build-24-04/files/root/.grok/config.toml
@@ -7,7 +7,7 @@
 #
 # Provide the key via the droplet environment (MODEL_ACCESS_KEY), /opt/grok-build.env,
 # or the first-login setup wizard (/opt/setup-grok-build.sh). The wizard also
-# lets you pick the default model from a list. Switch any time in the TUI with
+# loads the live catalog after you enter a key. Switch any time in the TUI with
 # /model, or headlessly with: grok -p "..." -m <alias>
 #
 # The default model is set by /opt/apply-inference-from-env.sh from
@@ -29,7 +29,12 @@ base_url = "https://api.x.ai/v1"
 name = "Grok Build 0.1 (xAI)"
 env_key = "XAI_API_KEY"
 
-# === DigitalOcean Serverless Inference: OpenAI models ===
+# BEGIN digitalocean-inference-models
+# === DigitalOcean Serverless Inference models ===
+# Seeded catalog; refreshed from GET https://inference.do-ai.run/v1/models
+# when a model access key is applied.
+
+# --- OpenAI models ---
 
 [model.gpt-5-5]
 model = "openai-gpt-5.5"
@@ -67,7 +72,7 @@ base_url = "https://inference.do-ai.run/v1"
 name = "GPT-4.1 (DigitalOcean Inference)"
 env_key = "MODEL_ACCESS_KEY"
 
-# === DigitalOcean Serverless Inference: Anthropic models ===
+# --- Anthropic models ---
 
 [model.claude-opus-4-8]
 model = "anthropic-claude-opus-4.8"
@@ -99,7 +104,7 @@ base_url = "https://inference.do-ai.run/v1"
 name = "Claude Haiku 4.5 (DigitalOcean Inference)"
 env_key = "MODEL_ACCESS_KEY"
 
-# === DigitalOcean Serverless Inference: open / DO-hosted models ===
+# --- Open / DO-hosted models ---
 
 [model.deepseek-v4-pro]
 model = "deepseek-v4-pro"
@@ -154,6 +159,8 @@ model = "nvidia-nemotron-3-super-120b"
 base_url = "https://inference.do-ai.run/v1"
 name = "NVIDIA Nemotron 3 Super 120B (DigitalOcean Inference)"
 env_key = "MODEL_ACCESS_KEY"
+
+# END digitalocean-inference-models
 
 # === DigitalOcean Intelligent Inference Router ===
 # Create a router in the DigitalOcean control panel (Inference > Routers) and

--- a/grok-build-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/grok-build-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -17,6 +17,7 @@ systemctl restart ssh
 mkdir -p /root/.grok
 
 chmod +x /opt/apply-inference-from-env.sh
+chmod +x /var/lib/digitalocean/inference-models.sh
 
 CONFIGURED=0
 if /opt/apply-inference-from-env.sh; then
@@ -52,17 +53,12 @@ DigitalOcean Serverless Inference (https://inference.do-ai.run/v1).
 Authentication was configured automatically from the droplet environment
 (MODEL_ACCESS_KEY / XAI_API_KEY) or /opt/grok-build.env.
 
-PRE-CONFIGURED MODELS (DigitalOcean Serverless Inference, default GPT-5.5):
+MODELS (DigitalOcean Serverless Inference):
 
-  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5,
-  gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
-  claude-haiku-4-5, deepseek-v4-pro, deepseek-4-flash, kimi-k2-6,
-  minimax-m2-5, glm-5, qwen3-coder-flash, qwen3-5, llama-4-maverick,
-  nemotron-3-super-120b, router
-
-  List the live catalog:
-    curl -s -H "Authorization: Bearer $MODEL_ACCESS_KEY" \
-      https://inference.do-ai.run/v1/models | jq -r '.data[].id'
+  The current chat-model catalog is loaded from
+  https://inference.do-ai.run/v1/models when a model access key is applied.
+  Default is openai-gpt-5.5 (alias gpt-5-5) when that id is still listed.
+  Switch with /model or: grok -p "..." -m <alias>
 
 NEXT STEPS:
 
@@ -102,19 +98,16 @@ Grok Build 1-Click Droplet - Getting Started
 Grok Build is xAI's terminal-based coding agent, pre-configured to run on
 DigitalOcean Serverless Inference (https://inference.do-ai.run/v1).
 
-PRE-CONFIGURED MODELS (DigitalOcean Serverless Inference, default GPT-5.5):
+MODELS (DigitalOcean Serverless Inference):
 
-  gpt-5-5 (default), gpt-5-4, gpt-5-3-codex, gpt-5-2, gpt-5,
-  gpt-4-1, claude-opus-4-8, claude-opus-4-6, claude-sonnet-4-6,
-  claude-haiku-4-5, deepseek-v4-pro, deepseek-4-flash, kimi-k2-6,
-  minimax-m2-5, glm-5, qwen3-coder-flash, qwen3-5, llama-4-maverick,
-  nemotron-3-super-120b, router
+  The setup wizard loads the current chat-model catalog after you enter
+  a model access key (or pick R for the Intelligent Inference Router).
 
 NEXT STEPS:
 
 1. Authenticate. The setup wizard runs automatically on first login,
-   prompts for a DigitalOcean model access key, and lets you pick
-   a default model from a list (or a router). Create a key at:
+   prompts for a DigitalOcean model access key, and loads the current
+   model list (or a router). Create a key at:
      https://cloud.digitalocean.com/model-studio/manage-keys
      (Inference > Manage)
 

--- a/grok-build-24-04/listing.md
+++ b/grok-build-24-04/listing.md
@@ -38,7 +38,7 @@ Grok Build is lightweight; most compute happens at the inference service.
 - **Grok Build** – xAI terminal coding agent (version 0.2.51)
 - **DigitalOcean Serverless Inference** – Pre-configured inference provider
 - **Git** – Version control
-- **curl**, **jq**, **unzip** – Utilities
+- **curl**, **jq**, **python3**, **unzip** – Utilities
 - **UFW Firewall** – SSH only (rate-limited)
 
 ## Getting Started
@@ -85,11 +85,13 @@ grok -p "Explain this codebase"
 grok -p "Review this diff" --output-format json --always-approve
 ```
 
-The default model is **GPT-5.5** (`gpt-5-5` via DigitalOcean Serverless Inference). Switch with `/model` in the TUI or `-m <alias>` headlessly.
+The default model is **GPT-5.5** (`openai-gpt-5.5` / alias `gpt-5-5`) when that id is still in the live DigitalOcean catalog. Switch with `/model` in the TUI or `-m <alias>` headlessly.
 
-## Pre-Configured Models
+## Models
 
-All models below are available via DigitalOcean Serverless Inference with just a model access key. The setup wizard lets you pick the default from this list (or a router). Switch any time with the alias via `-m` or `/model`; configuration lives in `/root/.grok/config.toml`.
+The setup wizard loads the current chat-model list at runtime from `GET https://inference.do-ai.run/v1/models` after you enter a model access key (same helper as Hermes/OpenClaw). New models appear and deprecated ones drop off. Pick `R` for the Intelligent Inference Router.
+
+The table below is the **seeded** catalog in `/root/.grok/config.toml`. Applying a key refreshes those DigitalOcean entries from the live list and keeps existing aliases when the model id is still available. Switch any time with `-m` or `/model`.
 
 | Alias | Model | ID |
 |-------|-------|----|
@@ -122,7 +124,7 @@ curl -s -H "Authorization: Bearer $MODEL_ACCESS_KEY" \
   https://inference.do-ai.run/v1/models | jq -r '.data[].id'
 ```
 
-To use a model that isn't pre-configured, add a `[model.<alias>]` block to `/root/.grok/config.toml` (copy an existing DigitalOcean entry and change `model` to the catalog ID).
+Re-run `/opt/apply-inference-from-env.sh` (or the setup wizard) after new models ship — the DigitalOcean catalog in `config.toml` is rebuilt from the live list. To add a provider that is not on Serverless Inference, add a `[model.<alias>]` block (see the commented examples at the bottom of that file).
 
 ## Intelligent Inference Router
 

--- a/grok-build-24-04/scripts/010-grok-build.sh
+++ b/grok-build-24-04/scripts/010-grok-build.sh
@@ -54,6 +54,7 @@ chmod +x /opt/setup-grok-build.sh
 chmod +x /opt/update-grok-build.sh
 chmod +x /opt/grok-login.sh
 chmod +x /opt/apply-inference-from-env.sh
+chmod +x /var/lib/digitalocean/inference-models.sh
 chmod 600 /opt/grok-build.env
 chmod +x /etc/update-motd.d/99-one-click
 chmod +x /var/lib/cloud/scripts/per-instance/001_onboot

--- a/grok-build-24-04/template.json
+++ b/grok-build-24-04/template.json
@@ -2,7 +2,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "grok-build-24-04-snapshot-{{timestamp}}",
-    "apt_packages": "apt-transport-https ca-certificates curl software-properties-common git jq unzip ufw",
+    "apt_packages": "apt-transport-https ca-certificates curl software-properties-common git jq python3 unzip ufw",
     "application_name": "Grok Build",
     "application_version": "0.2.51"
   },


### PR DESCRIPTION
## Summary

- Load Grok Build’s setup-wizard model list at runtime from `GET https://inference.do-ai.run/v1/models` (same helper as Hermes/OpenClaw), so new models appear and deprecated ones drop off.
- After a key is applied, refresh the DigitalOcean `[model.*]` entries in `/root/.grok/config.toml` from that live catalog. Existing aliases (e.g. `gpt-5-5`) are kept when the id is still available; xAI (`grok-build`) and the Intelligent Inference Router are unchanged.
- Keep option `R` / `DO_INFERENCE_ROUTER`. Enter prefers `openai-gpt-5.5` when it is still listed.

## Test plan

- [ ] First login: enter a model access key → wizard shows the live chat-model list (not the old hardcoded menu)
- [ ] Pick a model → it becomes the default in `config.toml` and the DigitalOcean catalog is replaced with the live set
- [ ] Pick `R`, enter a router name → default is the `router` alias (`router:<name>`)
- [ ] Set `MODEL_ACCESS_KEY` (and optional `DO_INFERENCE_MODEL` / `DO_INFERENCE_ROUTER`) at droplet create → wizard is skipped and the catalog still refreshes
- [ ] Invalid key → can re-enter the key or type a model id