### PR TITLE
MP-8761 openhands 1 click application replace deprecated models

### DIFF
--- a/openhands-24-04/README.md
+++ b/openhands-24-04/README.md
@@ -54,7 +54,8 @@ make build-openhands-24-04
 
 ## What Gets Installed
 
-- **OpenHands Agent Canvas** (`@openhands/agent-canvas`, version from `application_version` in `template.json`)
+- **OpenHands Agent Canvas** (`@openhands/agent-canvas@1.16.0`, from `application_version` in `template.json`)
+- **Chromium** (`chromium-browser`) for agent browser tooling
 - **Node.js 22** and **uv** (agent-server / automation via uvx)
 - **Caddy** – reverse proxy on ports 80/443 to `127.0.0.1:8000` with shortlived TLS by IP
 - **UFW** – SSH (rate-limited), HTTP, HTTPS

--- a/openhands-24-04/files/etc/setup_wizard.sh
+++ b/openhands-24-04/files/etc/setup_wizard.sh
@@ -74,7 +74,7 @@ Configure Serverless Inference so OpenHands can call models via a single model a
 Create a key at: https://cloud.digitalocean.com/gen-ai
   (API Keys > Model Access Keys)
 
-Examples: minimax-m2.5 (default), kimi-k2.5, glm-5, llama3.3-70b-instruct
+Examples: minimax-m2.5 (default), kimi-k3, glm-5.3, llama3.3-70b-instruct
 
 You can also skip and set any provider later in Settings > LLM.
 

--- a/openhands-24-04/files/opt/openhands.env
+++ b/openhands-24-04/files/opt/openhands.env
@@ -17,7 +17,7 @@ OH_SECRET_KEY=PLACEHOLDER_WILL_BE_REPLACED_ON_FIRST_BOOT
 
 # Pre-configured inference via Serverless Inference (optional):
 #   MODEL_ACCESS_KEY    Model access key (Inference > Manage in the control panel)
-#   INFERENCE_MODEL     Model id, e.g. minimax-m2.5, kimi-k2.5, glm-5
+#   INFERENCE_MODEL     Model id, e.g. minimax-m2.5, kimi-k3, glm-5.3
 #                       (stored as openai/<id> with serverless inference base URL; default minimax-m2.5)
 # On first boot, 001_onboot reads /etc/environment first, then /opt/openhands.env.
 # If MODEL_ACCESS_KEY is set in either place, Serverless Inference is configured and

--- a/openhands-24-04/files/opt/update-openhands.sh
+++ b/openhands-24-04/files/opt/update-openhands.sh
@@ -3,16 +3,7 @@
 
 set -euo pipefail
 
-APP_VERSION="latest"
-if [ -f /opt/openhands.env ]; then
-  APP_VERSION_VALUE=$(grep -E '^OPENHANDS_VERSION=' /opt/openhands.env | tail -n 1 | cut -d= -f2-)
-  if [ -n "$APP_VERSION_VALUE" ]; then
-    APP_VERSION="$APP_VERSION_VALUE"
-  fi
-fi
-case "$APP_VERSION" in *'$'*) APP_VERSION="latest" ;; esac
-
-TARGET="${1:-$APP_VERSION}"
+TARGET="${1:-latest}"
 if [ "$TARGET" = "Latest" ] || [ "$TARGET" = "latest" ]; then
   TARGET="latest"
 fi

--- a/openhands-24-04/listing.md
+++ b/openhands-24-04/listing.md
@@ -32,7 +32,8 @@ OpenHands Agent Canvas runs the agent server on the host. Prefer at least 4 GB R
 ## Included System Components
 
 - **Ubuntu 24.04 LTS**
-- **OpenHands Agent Canvas** (version pinned in the image build)
+- **OpenHands Agent Canvas** (version pinned in the image build; currently 1.16.0)
+- **Chromium** (`chromium-browser`) for agent browser tooling
 - **Node.js 22** and **uv**
 - **Caddy** reverse proxy (ports 80/443 → Agent Canvas on localhost:8000)
 - **UFW** and **fail2ban**

--- a/openhands-24-04/scripts/010-openhands.sh
+++ b/openhands-24-04/scripts/010-openhands.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-APP_VERSION="${application_version:-1.4.0}"
+APP_VERSION="${application_version:-1.16.0}"
 OPENHANDS_USER=openhands
 OPENHANDS_HOME=/home/openhands
 
@@ -10,6 +10,9 @@ ufw allow 80/tcp comment 'HTTP'
 ufw allow 443/tcp comment 'HTTPS'
 ufw limit ssh/tcp
 ufw --force enable
+
+# Chromium (browser tooling for agents); also in template apt_packages
+apt-get install -y chromium-browser
 
 # Node.js 22 (required by Agent Canvas)
 curl -fsSL https://deb.nodesource.com/setup_22.x | bash -

--- a/openhands-24-04/template.json
+++ b/openhands-24-04/template.json
@@ -2,9 +2,9 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "openhands-24-04-snapshot-{{timestamp}}",
-    "apt_packages": "procps file apt-transport-https ca-certificates curl software-properties-common git build-essential jq unzip gnupg fail2ban ufw",
+    "apt_packages": "procps file apt-transport-https ca-certificates curl software-properties-common git build-essential jq unzip gnupg fail2ban ufw chromium-browser",
     "application_name": "OpenHands",
-    "application_version": "1.4.0"
+    "application_version": "1.16.0"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [


### PR DESCRIPTION
[MP-8761](https://do-internal.atlassian.net/browse/MP-8761) — OpenHands 1-Click updates

- Replaced deprecated Serverless Inference model examples: kimi-k2.5 → kimi-k3, glm-5 → glm-5.3
- Added chromium-browser to image install (apt_packages + setup script)
- Bumped Agent Canvas pin from 1.4.0 to 1.16.0 (@openhands/agent-canvas)
- Updated /opt/update-openhands.sh to default to @latest instead of reinstalling the env pin
- Refreshed README/listing to reflect Chromium and the new Agent Canvas version

[MP-8761]: https://do-internal.atlassian.net/browse/MP-8761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ