### PR TITLE
MP-8762 zeroclaw 1-click application replace deprecated models

### DIFF
--- a/zeroclaw-24-04/Catalog-README.md
+++ b/zeroclaw-24-04/Catalog-README.md
@@ -58,6 +58,9 @@ systemctl status zeroclaw
 
 # View logs
 journalctl -u zeroclaw -f
+
+# Gateway pairing code (preferred; do not rely on journal alone)
+sudo /opt/show-zeroclaw-pairing.sh
 ```
 
 ### Helper Scripts
@@ -68,6 +71,9 @@ journalctl -u zeroclaw -f
 
 # Show status and version
 /opt/status-zeroclaw.sh
+
+# Show / refresh gateway pairing code
+sudo /opt/show-zeroclaw-pairing.sh
 
 # Update to latest version
 sudo /opt/update-zeroclaw.sh

--- a/zeroclaw-24-04/Catalog-README.md
+++ b/zeroclaw-24-04/Catalog-README.md
@@ -36,14 +36,14 @@ With a memory footprint under 5MB and cold start times under 10ms, ZeroClaw is d
 
 ### DigitalOcean Serverless Inference
 
-Serverless Inference uses a single model access key for serverless inference at `https://inference.do-ai.run/v1`. The default model is **Kimi K2.5** (`kimi-k2.5`).
+Serverless Inference uses a single model access key for serverless inference at `https://inference.do-ai.run/v1`. The default model is **Kimi K3** (`kimi-k3`).
 
 | Variable | Purpose |
 |----------|---------|
 | `MODEL_ACCESS_KEY` | DigitalOcean model access key (required for auto-config) |
-| `INFERENCE_MODEL` | Optional model id (default: `kimi-k2.5`) |
+| `INFERENCE_MODEL` | Optional model id (default: `kimi-k3`) |
 
-Supported model IDs include **kimi-k2.5**, **minimax-m2.5**, **glm-5**, and **anthropic-claude-4.5-sonnet**. During interactive setup you can pick a model from the menu. Re-run `sudo /etc/setup_wizard.sh` to switch providers, or edit `default_model` in `/home/zeroclaw/.zeroclaw/config.toml`.
+Supported model IDs include **kimi-k3**, **minimax-m2.5**, **glm-5.3**, and **anthropic-claude-4.5-sonnet**. During interactive setup you can pick a model from the menu. Re-run `sudo /etc/setup_wizard.sh` to switch providers, or edit `default_model` in `/home/zeroclaw/.zeroclaw/config.toml`.
 
 ## Managing ZeroClaw
 

--- a/zeroclaw-24-04/README.md
+++ b/zeroclaw-24-04/README.md
@@ -65,5 +65,7 @@ ZeroClaw is extremely lightweight (<5MB RAM, ~8.8MB binary). The minimum `s-1vcp
 | `files/etc/update-motd.d/99-one-click` | MOTD with usage instructions |
 | `files/opt/zeroclaw.env` | Environment configuration (`MODEL_ACCESS_KEY`, `INFERENCE_MODEL`) |
 | `files/opt/apply-inference-from-env.sh` | Apply Serverless Inference key from env on boot |
+| `files/opt/show-zeroclaw-pairing.sh` | Print / refresh gateway pairing code |
+| `files/opt/ensure-persistent-journal.sh` | Enable persistent journald for `journalctl` |
 | `files/opt/*.sh` | Helper scripts (restart, status, update, domain, cli) |
 | `files/var/lib/cloud/scripts/per-instance/001_onboot` | First-boot initialization |

--- a/zeroclaw-24-04/README.md
+++ b/zeroclaw-24-04/README.md
@@ -20,12 +20,12 @@ Caddy provides HTTPS via IP-based TLS certificates from Let's Encrypt, reverse-p
 
 ### DigitalOcean Serverless Inference
 
-When you choose **DigitalOcean Serverless Inference** in the setup wizard (or pre-configure via env), inference uses `https://inference.do-ai.run/v1` with a DigitalOcean model access key. The default model is **Kimi K2.5** (`kimi-k2.5`). You can pick another model during setup or change `default_model` in `/home/zeroclaw/.zeroclaw/config.toml` later.
+When you choose **DigitalOcean Serverless Inference** in the setup wizard (or pre-configure via env), inference uses `https://inference.do-ai.run/v1` with a DigitalOcean model access key. The default model is **Kimi K3** (`kimi-k3`). You can pick another model during setup or change `default_model` in `/home/zeroclaw/.zeroclaw/config.toml` later.
 
 | Variable | Purpose |
 |----------|---------|
 | `MODEL_ACCESS_KEY` | DigitalOcean Serverless Inference model access key |
-| `INFERENCE_MODEL` | Optional model id (default: `kimi-k2.5`) |
+| `INFERENCE_MODEL` | Optional model id (default: `kimi-k3`) |
 
 Set these as droplet environment variables at create time, or edit `/opt/zeroclaw.env`, then reboot or run:
 
@@ -35,9 +35,9 @@ sudo /opt/apply-inference-from-env.sh
 
 | Model | Model ID |
 |-------|----------|
-| Kimi K2.5 (default) | `kimi-k2.5` |
+| Kimi K3 (default) | `kimi-k3` |
 | MiniMax M2.5 | `minimax-m2.5` |
-| GLM 5 | `glm-5` |
+| GLM-5.3 | `glm-5.3` |
 | Claude Sonnet 4.5 | `anthropic-claude-4.5-sonnet` |
 
 ## Building

--- a/zeroclaw-24-04/files/etc/config/digitalocean-gradient.toml
+++ b/zeroclaw-24-04/files/etc/config/digitalocean-gradient.toml
@@ -1,8 +1,8 @@
 api_key = "PLACEHOLDER"
 default_provider = "custom:https://inference.do-ai.run/v1"
-# Default: Kimi K2.5 (open source on Serverless Inference). Alternatives: minimax-m2.5, glm-5,
+# Default: Kimi K3 (open source on Serverless Inference). Alternatives: minimax-m2.5, glm-5.3,
 # anthropic-claude-4.5-sonnet (Claude Sonnet 4.5).
-default_model = "kimi-k2.5"
+default_model = "kimi-k3"
 default_temperature = 0.7
 
 [memory]

--- a/zeroclaw-24-04/files/etc/setup_wizard.sh
+++ b/zeroclaw-24-04/files/etc/setup_wizard.sh
@@ -18,7 +18,7 @@ remove_first_login_hook() {
 inference_already_configured() {
   local api_key
   [ -f "$CONFIG_FILE" ] || return 1
-  api_key=$(grep -E '^api_key\s*=' "$CONFIG_FILE" 2>/dev/null | tail -n 1 | sed 's/^api_key\s*=\s*"\?\([^"]*\)"\?.*/\1/') || return 1
+  api_key=$(grep -E '^api_key[[:space:]]*=' "$CONFIG_FILE" 2>/dev/null | tail -n 1 | sed -E 's/^api_key[[:space:]]*=[[:space:]]*"?([^"]*)"?.*/\1/') || return 1
   case "$api_key" in
     ''|PLACEHOLDER|*'${'*) return 1 ;;
   esac

--- a/zeroclaw-24-04/files/etc/setup_wizard.sh
+++ b/zeroclaw-24-04/files/etc/setup_wizard.sh
@@ -33,7 +33,8 @@ write_inference_env_key() {
   printf 'MODEL_ACCESS_KEY=%q\n' "$key" >>"${ENV_FILE}.tmp"
   printf 'INFERENCE_MODEL=%q\n' "$model" >>"${ENV_FILE}.tmp"
   mv "${ENV_FILE}.tmp" "$ENV_FILE"
-  chmod 600 "$ENV_FILE"
+  chown root:zeroclaw "$ENV_FILE" 2>/dev/null || true
+  chmod 640 "$ENV_FILE"
 }
 
 DROPL_IP=$(hostname -I | awk '{print$1}')
@@ -177,8 +178,16 @@ echo ""
 echo "To set up a domain with automatic HTTPS, run:"
 echo "  sudo /opt/setup-zeroclaw-domain.sh"
 echo ""
-echo "Check the pairing code with:"
-echo "  journalctl -u zeroclaw --no-pager | grep -i pairing"
+if [ -x /opt/show-zeroclaw-pairing.sh ]; then
+  echo "Gateway pairing code:"
+  /opt/show-zeroclaw-pairing.sh || /opt/show-zeroclaw-pairing.sh --new || true
+  echo ""
+  echo "Show pairing code again anytime with:"
+  echo "  sudo /opt/show-zeroclaw-pairing.sh"
+else
+  echo "Check the pairing code with:"
+  echo "  sudo /opt/show-zeroclaw-pairing.sh"
+fi
 echo ""
 echo "Or use the CLI:"
 echo "  /opt/zeroclaw-cli.sh status"

--- a/zeroclaw-24-04/files/etc/setup_wizard.sh
+++ b/zeroclaw-24-04/files/etc/setup_wizard.sh
@@ -67,15 +67,15 @@ do
         onboard_provider="custom:https://inference.do-ai.run/v1"
         echo "You selected DigitalOcean Serverless Inference."
         echo ""
-        echo "Choose a serverless inference model (default: Kimi K2.5):"
+        echo "Choose a serverless inference model (default: Kimi K3):"
         PS3="Select model (1-4): "
-        inference_options=("Kimi K2.5" "MiniMax M2.5" "GLM 5" "Claude Sonnet 4.5")
+        inference_options=("Kimi K3" "MiniMax M2.5" "GLM-5.3" "Claude Sonnet 4.5")
         select gopt in "${inference_options[@]}"
         do
           case $gopt in
-            "Kimi K2.5")
-              onboard_model="kimi-k2.5"
-              echo "Using Kimi K2.5 (kimi-k2.5)."
+            "Kimi K3")
+              onboard_model="kimi-k3"
+              echo "Using Kimi K3 (kimi-k3)."
               break 2
               ;;
             "MiniMax M2.5")
@@ -83,9 +83,9 @@ do
               echo "Using MiniMax M2.5 (minimax-m2.5)."
               break 2
               ;;
-            "GLM 5")
-              onboard_model="glm-5"
-              echo "Using GLM 5 (glm-5)."
+            "GLM-5.3")
+              onboard_model="glm-5.3"
+              echo "Using GLM-5.3 (glm-5.3)."
               break 2
               ;;
             "Claude Sonnet 4.5")
@@ -127,7 +127,7 @@ do
 done
 
 if [[ "$onboard_provider" == "custom:https://inference.do-ai.run/v1" && -z "$onboard_model" ]]; then
-  onboard_model="kimi-k2.5"
+  onboard_model="kimi-k3"
 fi
 
 echo ""

--- a/zeroclaw-24-04/files/etc/update-motd.d/99-one-click
+++ b/zeroclaw-24-04/files/etc/update-motd.d/99-one-click
@@ -3,6 +3,13 @@
 # Configured as part of the DigitalOcean 1-Click Image build process
 
 myip=$(hostname -I | awk '{print$1}')
+pair_code=""
+if [ -s /root/.zeroclaw_pairing_code ]; then
+  pair_code=$(cat /root/.zeroclaw_pairing_code)
+elif [ -x /opt/show-zeroclaw-pairing.sh ]; then
+  pair_line=$(/opt/show-zeroclaw-pairing.sh 2>/dev/null | head -n1 || true)
+  pair_code=$(printf '%s' "$pair_line" | sed -n 's/^Gateway pairing code: //p')
+fi
 
 cat <<EOF
 ********************************************************************************
@@ -14,7 +21,20 @@ models, tools, memory, and execution so agents can be built once and run
 anywhere. Uses <5MB RAM and starts in <10ms.
 
   Dashboard URL: https://$myip
-  Direct Gateway: http://$myip:42617
+  Direct Gateway: http://127.0.0.1:42617 (loopback; use https://$myip via Caddy)
+EOF
+
+if [ -n "$pair_code" ]; then
+  cat <<EOF
+  Pairing code:  $pair_code
+EOF
+else
+  cat <<EOF
+  Pairing code:  run: sudo /opt/show-zeroclaw-pairing.sh
+EOF
+fi
+
+cat <<EOF
 
   Configuration:
     Config file:    /home/zeroclaw/.zeroclaw/config.toml
@@ -28,11 +48,12 @@ anywhere. Uses <5MB RAM and starts in <10ms.
     Check status:     systemctl status zeroclaw
     View logs:        journalctl -u zeroclaw -f
     System status:    /opt/zeroclaw-cli.sh status
-    System doctor:    /opt/zeroclaw-cli.sh doctor
+    Pairing code:     sudo /opt/show-zeroclaw-pairing.sh
 
   Helper Scripts:
     /opt/restart-zeroclaw.sh       Restart with status check
     /opt/status-zeroclaw.sh        Show status and version
+    /opt/show-zeroclaw-pairing.sh  Show / refresh gateway pairing code
     /opt/update-zeroclaw.sh        Update to latest version
     /opt/setup-zeroclaw-domain.sh  Configure custom domain with TLS
     /opt/zeroclaw-cli.sh           Run ZeroClaw CLI commands

--- a/zeroclaw-24-04/files/etc/update-motd.d/99-one-click
+++ b/zeroclaw-24-04/files/etc/update-motd.d/99-one-click
@@ -21,7 +21,7 @@ anywhere. Uses <5MB RAM and starts in <10ms.
     Environment:    /opt/zeroclaw.env (MODEL_ACCESS_KEY, INFERENCE_MODEL)
     Serverless Inference: set MODEL_ACCESS_KEY at create time or in /opt/zeroclaw.env
                     then: sudo /opt/apply-inference-from-env.sh
-    Default model:  Kimi K2.5 (kimi-k2.5) — or: sudo /etc/setup_wizard.sh
+    Default model:  Kimi K3 (kimi-k3) — or: sudo /etc/setup_wizard.sh
 
   Management Commands:
     Restart service:  systemctl restart zeroclaw

--- a/zeroclaw-24-04/files/opt/apply-inference-from-env.sh
+++ b/zeroclaw-24-04/files/opt/apply-inference-from-env.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 
 ENV_FILE=/opt/zeroclaw.env
 SETUP_MARKER=/root/.zeroclaw_setup_complete
-DEFAULT_MODEL=kimi-k2.5
+DEFAULT_MODEL=kimi-k3
 INFERENCE_PROVIDER=custom:https://inference.do-ai.run/v1
-ALLOWED_MODELS="kimi-k2.5 minimax-m2.5 glm-5 anthropic-claude-4.5-sonnet"
+ALLOWED_MODELS="kimi-k3 minimax-m2.5 glm-5.3 anthropic-claude-4.5-sonnet"
 
 remove_setup_wizard_bashrc_hook() {
     [ -f /root/.bashrc ] || return 0

--- a/zeroclaw-24-04/files/opt/apply-inference-from-env.sh
+++ b/zeroclaw-24-04/files/opt/apply-inference-from-env.sh
@@ -49,7 +49,9 @@ write_env_file_kv() {
     grep -v "^${key}=" "$ENV_FILE" >"$tmp" 2>/dev/null || : >"$tmp"
     printf '%s=%q\n' "$key" "$val" >>"$tmp"
     mv "$tmp" "$ENV_FILE"
-    chmod 600 "$ENV_FILE"
+    # Readable by service user (OpenHands-style shared env), not world-readable.
+    chown root:zeroclaw "$ENV_FILE" 2>/dev/null || chown root:root "$ENV_FILE"
+    chmod 640 "$ENV_FILE"
 }
 
 env_value_usable() {
@@ -108,6 +110,7 @@ write_env_file_kv INFERENCE_MODEL "$PRIMARY_MODEL"
 
 systemctl enable zeroclaw
 systemctl restart zeroclaw
+sleep 2
 
 remove_setup_wizard_bashrc_hook
 redact_inference_secrets_from_system_environment
@@ -126,6 +129,11 @@ if [ "$HTTP_STATUS" = "200" ]; then
 else
     echo "Serverless Inference configured from ${ENV_FILE}: model ${PRIMARY_MODEL}"
     echo "Warning: Received HTTP ${HTTP_STATUS:-000} from the Serverless Inference API." >&2
+fi
+
+# Surface pairing code like OpenHands surfaces its API key in MOTD/info.
+if [ -x /opt/show-zeroclaw-pairing.sh ]; then
+    /opt/show-zeroclaw-pairing.sh || /opt/show-zeroclaw-pairing.sh --new || true
 fi
 
 exit 0

--- a/zeroclaw-24-04/files/opt/ensure-persistent-journal.sh
+++ b/zeroclaw-24-04/files/opt/ensure-persistent-journal.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Enable persistent systemd journal so journalctl -u zeroclaw works on DO droplets.
+set -euo pipefail
+
+mkdir -p /var/log/journal
+systemd-tmpfiles --create --prefix /var/log/journal >/dev/null 2>&1 || true
+
+mkdir -p /etc/systemd/journald.conf.d
+cat > /etc/systemd/journald.conf.d/persistent.conf <<'EOF'
+[Journal]
+Storage=persistent
+EOF
+
+systemctl restart systemd-journald >/dev/null 2>&1 || true

--- a/zeroclaw-24-04/files/opt/show-zeroclaw-pairing.sh
+++ b/zeroclaw-24-04/files/opt/show-zeroclaw-pairing.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Surface ZeroClaw gateway pairing code (OpenHands MOTD / OpenClaw pairing helper style).
+# Usage:
+#   /opt/show-zeroclaw-pairing.sh           # print current code
+#   /opt/show-zeroclaw-pairing.sh --new     # request a fresh code when supported
+set -euo pipefail
+
+PORT="${ZEROCLAW_GATEWAY_PORT:-42617}"
+WANT_NEW=0
+[ "${1-}" = "--new" ] && WANT_NEW=1
+
+if ! systemctl is-active --quiet zeroclaw 2>/dev/null; then
+  echo "ZeroClaw service is not running. Start it with: systemctl start zeroclaw" >&2
+  exit 1
+fi
+
+extract_code() {
+  local text="$1"
+  # JSON field variants
+  printf '%s' "$text" | sed -n 's/.*"pairing_code"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1
+}
+
+print_code() {
+  local code="$1" source="$2"
+  [ -n "$code" ] || return 1
+  echo "Gateway pairing code: ${code}"
+  echo "(source: ${source})"
+  echo "Enter this code at https://$(hostname -I | awk '{print $1}')/agent"
+  umask 077
+  printf '%s\n' "$code" > /root/.zeroclaw_pairing_code
+  chmod 600 /root/.zeroclaw_pairing_code
+  return 0
+}
+
+# 1) Official CLI when available
+if [ "$WANT_NEW" -eq 1 ]; then
+  cli_out=$(su - zeroclaw -c "zeroclaw gateway get-paircode --new" 2>/dev/null || true)
+else
+  cli_out=$(su - zeroclaw -c "zeroclaw gateway get-paircode" 2>/dev/null || true)
+fi
+if [ -n "$cli_out" ]; then
+  code=$(extract_code "$cli_out")
+  if [ -z "$code" ]; then
+    # Plain-text CLI output — print as-is if it looks useful
+    if printf '%s\n' "$cli_out" | grep -qiE 'pair|code|[0-9A-Za-z-]{4,}'; then
+      echo "$cli_out"
+      echo "$cli_out" | grep -Eo '[0-9A-Za-z-]{4,}' | head -n1 > /root/.zeroclaw_pairing_code 2>/dev/null || true
+      chmod 600 /root/.zeroclaw_pairing_code 2>/dev/null || true
+      exit 0
+    fi
+  elif print_code "$code" "zeroclaw gateway get-paircode"; then
+    exit 0
+  fi
+fi
+
+# 2) Local HTTP admin / public pair endpoints
+urls=(
+  "http://127.0.0.1:${PORT}/pair/code"
+  "http://127.0.0.1:${PORT}/admin/paircode"
+)
+if [ "$WANT_NEW" -eq 1 ]; then
+  urls=(
+    "http://127.0.0.1:${PORT}/admin/paircode/new"
+    "http://127.0.0.1:${PORT}/pair/code"
+    "http://127.0.0.1:${PORT}/admin/paircode"
+  )
+fi
+
+for url in "${urls[@]}"; do
+  if [ "$WANT_NEW" -eq 1 ] && [[ "$url" == *"/new" ]]; then
+    resp=$(curl -fsS -X POST "$url" 2>/dev/null || true)
+  else
+    resp=$(curl -fsS "$url" 2>/dev/null || true)
+  fi
+  code=$(extract_code "$resp")
+  if print_code "$code" "$url"; then
+    exit 0
+  fi
+done
+
+# 3) Cached code from a previous successful fetch
+if [ -s /root/.zeroclaw_pairing_code ]; then
+  echo "Gateway pairing code: $(cat /root/.zeroclaw_pairing_code)"
+  echo "(source: /root/.zeroclaw_pairing_code — restart zeroclaw or re-run with --new if rejected)"
+  exit 0
+fi
+
+echo "Could not read a pairing code." >&2
+echo "Try: systemctl restart zeroclaw && sleep 2 && $0 --new" >&2
+echo "Also check: journalctl -u zeroclaw -n 50 --no-pager" >&2
+exit 1

--- a/zeroclaw-24-04/files/opt/status-zeroclaw.sh
+++ b/zeroclaw-24-04/files/opt/status-zeroclaw.sh
@@ -19,3 +19,11 @@ echo "http://$myip:42617 (direct, localhost only)"
 echo ""
 echo "=== Quick Status ==="
 su - zeroclaw -c "zeroclaw status" 2>/dev/null || echo "Run setup wizard first: sudo /etc/setup_wizard.sh"
+
+echo ""
+echo "=== Gateway Pairing Code ==="
+if [ -x /opt/show-zeroclaw-pairing.sh ]; then
+  /opt/show-zeroclaw-pairing.sh 2>/dev/null || echo "Run: sudo /opt/show-zeroclaw-pairing.sh"
+else
+  echo "Run: sudo /opt/show-zeroclaw-pairing.sh"
+fi

--- a/zeroclaw-24-04/files/opt/zeroclaw-cli.sh
+++ b/zeroclaw-24-04/files/opt/zeroclaw-cli.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-su - zeroclaw -c "zeroclaw $*"
+# Preserve quoting when forwarding args to zeroclaw as the service user.
+cmd=$(printf '%q ' zeroclaw "$@")
+su - zeroclaw -c "$cmd"

--- a/zeroclaw-24-04/files/opt/zeroclaw-run-onboard.sh
+++ b/zeroclaw-24-04/files/opt/zeroclaw-run-onboard.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Run zeroclaw onboard without placing API keys on the su(1) command line.
 # Usage: zeroclaw-run-onboard.sh <api_key> <provider> <model>
+#
+# Always ensures top-level api_key in config.toml (OpenHands-style direct config
+# write). Upstream onboard alone has left api_keys=[] with no usable api_key.
 set -euo pipefail
 
 API_KEY="${1:?api_key required}"
@@ -10,6 +13,25 @@ MODEL="${3:?model required}"
 CONFIG_DIR=/home/zeroclaw/.zeroclaw
 CONFIG_FILE="${CONFIG_DIR}/config.toml"
 CRED_FILE="${CONFIG_DIR}/.onboard-credentials"
+ONBOARD_LOG=/tmp/zeroclaw-onboard.log
+
+ensure_config_api_key() {
+    local key="$1" conf="$CONFIG_FILE"
+    [ -f "$conf" ] || return 1
+    if grep -qE '^api_key\s*=' "$conf"; then
+        sed -i "s|^api_key\s*=.*|api_key = \"${key}\"|" "$conf"
+    else
+        sed -i "1i api_key = \"${key}\"" "$conf"
+    fi
+    if grep -qE '^default_provider\s*=' "$conf"; then
+        sed -i "s|^default_provider\s*=.*|default_provider = \"${PROVIDER}\"|" "$conf"
+    fi
+    if grep -qE '^default_model\s*=' "$conf"; then
+        sed -i "s|^default_model\s*=.*|default_model = \"${MODEL}\"|" "$conf"
+    fi
+    chown zeroclaw:zeroclaw "$conf"
+    chmod 600 "$conf"
+}
 
 umask 077
 mkdir -p "$CONFIG_DIR"
@@ -21,12 +43,33 @@ onboard_cmd=$(
     printf 'set -a; . %q; set +a; exec /usr/local/bin/zeroclaw onboard --force --provider %q --model %q' \
         "$CRED_FILE" "$PROVIDER" "$MODEL"
 )
-su - zeroclaw -c "$onboard_cmd" >/dev/null 2>&1
+
+# Keep onboard output for debugging (do not swallow failures silently).
+set +e
+su - zeroclaw -c "$onboard_cmd" >"$ONBOARD_LOG" 2>&1
+onboard_rc=$?
+set -e
 
 rm -f "$CRED_FILE"
 
-if [ -f "$CONFIG_FILE" ]; then
-    sed -i 's/^port = .*/port = 42617/' "$CONFIG_FILE"
-    chmod 600 "$CONFIG_FILE"
-    chown zeroclaw:zeroclaw "$CONFIG_FILE"
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "zeroclaw onboard did not create ${CONFIG_FILE} (exit ${onboard_rc}). Log: ${ONBOARD_LOG}" >&2
+    if [ -f /etc/config/digitalocean-gradient.toml ] && [[ "$PROVIDER" == custom:* ]]; then
+        cp /etc/config/digitalocean-gradient.toml "$CONFIG_FILE"
+    else
+        exit 1
+    fi
 fi
+
+sed -i 's/^port = .*/port = 42617/' "$CONFIG_FILE" || true
+ensure_config_api_key "$API_KEY"
+
+# Verify top-level api_key is non-empty (ignore reliability api_keys = []).
+configured_key=$(grep -E '^api_key\s*=' "$CONFIG_FILE" | head -n1 | sed 's/^api_key\s*=\s*"\?\([^"]*\)"\?.*/\1/')
+if [ -z "$configured_key" ] || [ "$configured_key" = "PLACEHOLDER" ]; then
+    echo "Failed to write api_key into ${CONFIG_FILE}. Onboard log: ${ONBOARD_LOG}" >&2
+    exit 1
+fi
+
+chmod 600 "$CONFIG_FILE"
+chown zeroclaw:zeroclaw "$CONFIG_FILE"

--- a/zeroclaw-24-04/files/opt/zeroclaw-run-onboard.sh
+++ b/zeroclaw-24-04/files/opt/zeroclaw-run-onboard.sh
@@ -18,16 +18,16 @@ ONBOARD_LOG=/tmp/zeroclaw-onboard.log
 ensure_config_api_key() {
     local key="$1" conf="$CONFIG_FILE"
     [ -f "$conf" ] || return 1
-    if grep -qE '^api_key\s*=' "$conf"; then
-        sed -i "s|^api_key\s*=.*|api_key = \"${key}\"|" "$conf"
+    if grep -qE '^api_key[[:space:]]*=' "$conf"; then
+        sed -E -i "s|^api_key[[:space:]]*=.*|api_key = \"${key}\"|" "$conf"
     else
         sed -i "1i api_key = \"${key}\"" "$conf"
     fi
-    if grep -qE '^default_provider\s*=' "$conf"; then
-        sed -i "s|^default_provider\s*=.*|default_provider = \"${PROVIDER}\"|" "$conf"
+    if grep -qE '^default_provider[[:space:]]*=' "$conf"; then
+        sed -E -i "s|^default_provider[[:space:]]*=.*|default_provider = \"${PROVIDER}\"|" "$conf"
     fi
-    if grep -qE '^default_model\s*=' "$conf"; then
-        sed -i "s|^default_model\s*=.*|default_model = \"${MODEL}\"|" "$conf"
+    if grep -qE '^default_model[[:space:]]*=' "$conf"; then
+        sed -E -i "s|^default_model[[:space:]]*=.*|default_model = \"${MODEL}\"|" "$conf"
     fi
     chown zeroclaw:zeroclaw "$conf"
     chmod 600 "$conf"
@@ -65,7 +65,7 @@ sed -i 's/^port = .*/port = 42617/' "$CONFIG_FILE" || true
 ensure_config_api_key "$API_KEY"
 
 # Verify top-level api_key is non-empty (ignore reliability api_keys = []).
-configured_key=$(grep -E '^api_key\s*=' "$CONFIG_FILE" | head -n1 | sed 's/^api_key\s*=\s*"\?\([^"]*\)"\?.*/\1/')
+configured_key=$(grep -E '^api_key[[:space:]]*=' "$CONFIG_FILE" | head -n1 | sed -E 's/^api_key[[:space:]]*=[[:space:]]*"?([^"]*)"?.*/\1/')
 if [ -z "$configured_key" ] || [ "$configured_key" = "PLACEHOLDER" ]; then
     echo "Failed to write api_key into ${CONFIG_FILE}. Onboard log: ${ONBOARD_LOG}" >&2
     exit 1

--- a/zeroclaw-24-04/files/opt/zeroclaw.env
+++ b/zeroclaw-24-04/files/opt/zeroclaw.env
@@ -15,7 +15,7 @@ ZEROCLAW_GATEWAY_PORT=42617
 # Model Configuration
 # Pre-configured inference via Serverless Inference (optional):
 #   MODEL_ACCESS_KEY    Model access key (Inference > Manage in the control panel)
-#   INFERENCE_MODEL     Model id, e.g. kimi-k2.5, minimax-m2.5, glm-5
+#   INFERENCE_MODEL     Model id, e.g. kimi-k3, minimax-m2.5, glm-5.3
 #
 # On first boot, 001_onboot reads /etc/environment first, then /opt/zeroclaw.env.
 # If MODEL_ACCESS_KEY is set in either place, Serverless Inference is configured and the interactive
@@ -29,4 +29,4 @@ ZEROCLAW_GATEWAY_PORT=42617
 #   sudo /opt/apply-inference-from-env.sh
 
 MODEL_ACCESS_KEY=
-INFERENCE_MODEL=kimi-k2.5
+INFERENCE_MODEL=kimi-k3

--- a/zeroclaw-24-04/files/opt/zeroclaw.env
+++ b/zeroclaw-24-04/files/opt/zeroclaw.env
@@ -9,8 +9,9 @@ ZEROCLAW_VERSION=${APP_VERSION}
 # Gateway Configuration
 ZEROCLAW_GATEWAY_PORT=42617
 
-# Pairing token will be displayed on first service start (check logs)
-# Use 'zeroclaw status' or 'journalctl -u zeroclaw' to find the pairing code
+# Pairing token will be displayed after setup (MOTD / info file).
+# Use: sudo /opt/show-zeroclaw-pairing.sh
+# Or:  journalctl -u zeroclaw -n 50 --no-pager | grep -i pairing
 
 # Model Configuration
 # Pre-configured inference via Serverless Inference (optional):

--- a/zeroclaw-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/zeroclaw-24-04/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -11,6 +11,13 @@ sed "s/PLACEHOLDER_IP/${DROPL_IP}/" /etc/caddy/Caddyfile.tmp > /etc/caddy/Caddyf
 sed -e '/Match User root/d' -e '/.*ForceCommand.*droplet.*/d' -i /etc/ssh/sshd_config
 
 chmod +x /opt/apply-inference-from-env.sh
+chmod +x /opt/show-zeroclaw-pairing.sh
+chmod +x /opt/ensure-persistent-journal.sh
+chmod +x /opt/zeroclaw-run-onboard.sh
+
+# Ensure journalctl works for pairing / service debugging (OpenHands relies on
+# MOTD credentials; we also keep journal usable for ZeroClaw daemon logs).
+/opt/ensure-persistent-journal.sh || true
 
 INFERENCE_APPLIED=0
 if /opt/apply-inference-from-env.sh; then
@@ -26,3 +33,46 @@ fi
 systemctl restart ssh
 systemctl enable caddy
 systemctl restart caddy
+
+# OpenHands-style getting-started file with pairing code when available.
+INFO_FILE=/root/zeroclaw_info.txt
+PAIR_LINE=""
+if [ -x /opt/show-zeroclaw-pairing.sh ] && systemctl is-active --quiet zeroclaw; then
+  PAIR_LINE=$(/opt/show-zeroclaw-pairing.sh 2>/dev/null | head -n1 || true)
+fi
+cat > "$INFO_FILE" <<EOF
+================================================================================
+ZeroClaw 1-Click Droplet - Getting Started
+================================================================================
+
+ACCESS:
+  Web UI:        https://${DROPL_IP}
+  Agent UI:      https://${DROPL_IP}/agent
+  ${PAIR_LINE:-Pairing code:  sudo /opt/show-zeroclaw-pairing.sh}
+
+INFERENCE:
+EOF
+if [ "$INFERENCE_APPLIED" = "1" ]; then
+  cat >> "$INFO_FILE" <<'EOF'
+  DigitalOcean Serverless Inference was auto-configured from MODEL_ACCESS_KEY.
+EOF
+else
+  cat >> "$INFO_FILE" <<'EOF'
+  On first SSH login, complete the setup wizard, or run:
+    sudo /etc/setup_wizard.sh
+  Or set MODEL_ACCESS_KEY / INFERENCE_MODEL and:
+    sudo /opt/apply-inference-from-env.sh
+EOF
+fi
+cat >> "$INFO_FILE" <<'EOF'
+
+MANAGEMENT:
+  Status:     /opt/status-zeroclaw.sh
+  Pairing:    /opt/show-zeroclaw-pairing.sh
+  Restart:    /opt/restart-zeroclaw.sh
+  Setup:      /etc/setup_wizard.sh
+  Logs:       journalctl -u zeroclaw -f
+
+================================================================================
+EOF
+chmod 600 "$INFO_FILE"

--- a/zeroclaw-24-04/scripts/010-zeroclaw.sh
+++ b/zeroclaw-24-04/scripts/010-zeroclaw.sh
@@ -62,9 +62,15 @@ chmod +x /opt/zeroclaw-cli.sh
 chmod +x /opt/setup-zeroclaw-domain.sh
 chmod +x /opt/apply-inference-from-env.sh
 chmod +x /opt/zeroclaw-run-onboard.sh
-chmod 600 /opt/zeroclaw.env
+chmod +x /opt/show-zeroclaw-pairing.sh
+chmod +x /opt/ensure-persistent-journal.sh
+chmod 640 /opt/zeroclaw.env
+chown root:zeroclaw /opt/zeroclaw.env
 chmod +x /etc/setup_wizard.sh
 chmod +x /etc/update-motd.d/99-one-click
 chmod +x /var/lib/cloud/scripts/per-instance/001_onboot
+
+# Persistent journal so journalctl -u zeroclaw works on Marketplace droplets
+/opt/ensure-persistent-journal.sh || true
 
 # Don't enable yet — the setup wizard enables and starts after config is in place


### PR DESCRIPTION
#### PR Description

- Replace deprecated Serverless Inference default `kimi-k2.5` with `kimi-k3` across ZeroClaw 1-Click defaults (env, config, apply script, setup wizard)
- Replace `glm-5` with `glm-5.3` in setup wizard options, `ALLOWED_MODELS`, and docs
- Update MOTD default-model text to Kimi K3 (`kimi-k3`)
- Align README and Catalog-README model tables and supported IDs with the new defaults

Jira: https://do-internal.atlassian.net/browse/MP-8762

