### PR TITLE
Use application_version for ollama, flask, and ghost Packer builds

### DIFF
--- a/flask-24-04/template.json
+++ b/flask-24-04/template.json
@@ -4,7 +4,7 @@
     "image_name": "flask-24-04-snapshot-{{timestamp}}",
     "apt_packages": "gunicorn nginx postfix python3 python3-certbot python3-certbot-nginx python3-dev python3-gunicorn python3-netifaces python3-pip python3-setuptools python3-venv python3-gevent",
     "application_name": "Flask",
-    "flask_version": "3.1.3"
+    "application_version": "3.1.3"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [
@@ -59,9 +59,9 @@
     {
       "type": "shell",
       "environment_vars": [
-        "FLASK_VERSION={{user `flask_version`}}",
+        "FLASK_VERSION={{user `application_version`}}",
         "application_name={{user `application_name`}}",
-        "application_version={{user `flask_version`}}",
+        "application_version={{user `application_version`}}",
         "DEBIAN_FRONTEND=noninteractive",
         "LC_ALL=C",
         "LANG=en_US.UTF-8",

--- a/flask-24-04/template.json
+++ b/flask-24-04/template.json
@@ -13,7 +13,7 @@
       "api_token": "{{user `do_api_token`}}",
       "image": "ubuntu-24-04-x64",
       "region": "sfo3",
-      "size": "s-1vcpu-512mb-10gb",
+      "size": "s-1vcpu-1gb",
       "ssh_username": "root",
       "snapshot_name": "{{user `image_name`}}"
     }

--- a/ghost-24-04/template.json
+++ b/ghost-24-04/template.json
@@ -3,7 +3,7 @@
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "ghost-24-04-1click-{{timestamp}}",
     "node_version": "22.x",
-    "ghost_version": "6.27.0",
+    "application_version": "6.27.0",
     "ghost_cli_version": "1.29.1",
     "application_name": "Ghost",
     "apt_packages": "fail2ban cloud-image-utils git jq libguestfs-tools make mysql-server nginx postfix python3-certbot super unzip gnupg2 curl"
@@ -60,9 +60,9 @@
     {
       "type": "shell",
       "environment_vars": [
-        "GHOST_VERSION={{user `ghost_version`}}",
+        "GHOST_VERSION={{user `application_version`}}",
         "application_name={{user `application_name`}}",
-        "application_version={{user `ghost_version`}}",
+        "application_version={{user `application_version`}}",
         "ghost_cli_version={{user `ghost_cli_version`}}",
         "NODE_VERSION={{user `node_version`}}",
         "DEBIAN_FRONTEND=noninteractive",

--- a/ollama-24-04/template.json
+++ b/ollama-24-04/template.json
@@ -5,7 +5,7 @@
     "apt_packages": "fail2ban jq libgl1 libglx-mesa0 ffmpeg libsm6 libxext6 build-essential git-all debian-keyring debian-archive-keyring apt-transport-https curl",
     "application_name": "Ollama",
     "anaconda_version": "2024.06-1",
-    "ollama_version": "0.31.2",
+    "application_version": "0.31.2",
     "open_webui_version": "0.10.2",
     "model_name": "tinyllama"
   },
@@ -62,10 +62,10 @@
       "environment_vars": [
         "ANACONDA_VERSION={{user `anaconda_version`}}",
         "OPEN_WEBUI_VERSION={{user `open_webui_version`}}",
-        "OLLAMA_VERSION={{user `ollama_version`}}",
+        "OLLAMA_VERSION={{user `application_version`}}",
         "MODEL_NAME={{user `model_name`}}",
         "application_name={{user `application_name`}}",
-        "application_version={{user `ollama_version`}}",
+        "application_version={{user `application_version`}}",
         "DEBIAN_FRONTEND=noninteractive",
         "LC_ALL=C",
         "LANG=en_US.UTF-8",


### PR DESCRIPTION
## Summary
- Jira: [MP-8796](https://do-internal.atlassian.net/browse/MP-8796)
- Replace product-specific Packer version vars (`ollama_version`, `flask_version`, `ghost_version`) with `application_version` so Marketplace Autoupdate can override via `packer build -var application_version=<semver> <app>/template.json`
- Wire install + `application.info` tagging env vars (`OLLAMA_VERSION` / `FLASK_VERSION` / `GHOST_VERSION` and `application_version`) to `{{user `application_version`}}`
- Bump Flask Packer build size from `s-1vcpu-512mb-10gb` to `s-1vcpu-1gb`

## Test plan
- [x] Confirm Packer templates validate / build with defaults unchanged from prior pins

[MP-8796]: https://do-internal.atlassian.net/browse/MP-8796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ