### PR TITLE
Fix OpenClaw update helper and bump image to v2026.9.3

### DIFF
--- a/openclaw-24-04/README.md
+++ b/openclaw-24-04/README.md
@@ -55,8 +55,8 @@ make build-openclaw-24-04
 
 ## What Gets Installed
 
-- **OpenClaw** (npm package version from `application_version` in `template.json`)
-- **Node.js 22** and **Docker** (sandbox image built at snapshot time and on first boot)
+- **OpenClaw** `v2026.9.3` (pinned via `application_version` in `template.json`)
+- **Node.js 24** and **Docker** (sandbox image built at snapshot time and on first boot)
 - **Caddy** – reverse proxy on ports 80/443 to `127.0.0.1:18789` with shortlived TLS by IP
 - **UFW** – SSH (rate-limited), HTTP, HTTPS
 - **fail2ban**
@@ -86,7 +86,15 @@ make build-openclaw-24-04
 
 ## Version Pinning
 
-Edit `application_version` in `template.json` (OpenClaw npm version, e.g. `v2026.8.1`), then rebuild.
+Edit `application_version` in `template.json` (OpenClaw npm version, e.g. `v2026.9.3`), then rebuild.
+
+## On-droplet updates (shown in MOTD)
+
+```bash
+sudo /opt/update-openclaw.sh              # latest from npm
+sudo /opt/update-openclaw.sh v2026.9.3    # specific version
+sudo /opt/update-openclaw.sh --rollback   # previous pin (OPENCLAW_VERSION_PREVIOUS)
+```
 
 ## License
 

--- a/openclaw-24-04/files/etc/config/anthropic.json
+++ b/openclaw-24-04/files/etc/config/anthropic.json
@@ -25,11 +25,6 @@
   "tools": {
     "deny": ["sessions_send"]
   },
-  "session": {
-    "agentToAgent": {
-      "maxPingPongTurns": 0
-    }
-  },
   "gateway": {
     "mode": "local",
     "bind": "loopback",

--- a/openclaw-24-04/files/etc/config/digitalocean-inference.json
+++ b/openclaw-24-04/files/etc/config/digitalocean-inference.json
@@ -37,11 +37,6 @@
   "tools": {
     "deny": ["sessions_send"]
   },
-  "session": {
-    "agentToAgent": {
-      "maxPingPongTurns": 0
-    }
-  },
   "gateway": {
     "mode": "local",
     "bind": "loopback",

--- a/openclaw-24-04/files/etc/config/openai.json
+++ b/openclaw-24-04/files/etc/config/openai.json
@@ -25,11 +25,6 @@
   "tools": {
     "deny": ["sessions_send"]
   },
-  "session": {
-    "agentToAgent": {
-      "maxPingPongTurns": 0
-    }
-  },
   "gateway": {
     "mode": "local",
     "bind": "loopback",

--- a/openclaw-24-04/files/etc/config/openclaw.json
+++ b/openclaw-24-04/files/etc/config/openclaw.json
@@ -18,11 +18,6 @@
   "tools": {
     "deny": ["sessions_send"]
   },
-  "session": {
-    "agentToAgent": {
-      "maxPingPongTurns": 0
-    }
-  },
   "gateway": {
     "mode": "local",
     "bind": "loopback",

--- a/openclaw-24-04/files/etc/config/openrouter.json
+++ b/openclaw-24-04/files/etc/config/openrouter.json
@@ -42,11 +42,6 @@
   "tools": {
     "deny": ["sessions_send"]
   },
-  "session": {
-    "agentToAgent": {
-      "maxPingPongTurns": 0
-    }
-  },
   "gateway": {
     "mode": "local",
     "bind": "loopback",

--- a/openclaw-24-04/files/etc/update-motd.d/99-one-click
+++ b/openclaw-24-04/files/etc/update-motd.d/99-one-click
@@ -46,7 +46,7 @@ on the channels you already use (WhatsApp, Telegram, Slack, Discord, and more).
 
 ⬆️ Update OpenClaw:
   Latest release:     sudo /opt/update-openclaw.sh
-  Specific version:   sudo /opt/update-openclaw.sh v2026.9.3
+  Specific version:   sudo /opt/update-openclaw.sh <latest version>   # e.g. 2026.9.3
   Rollback previous:  sudo /opt/update-openclaw.sh --rollback
   (Upgrades Node automatically if the release requires a newer runtime.
    Rollback restores the prior npm package only, not config migrations.)

--- a/openclaw-24-04/files/etc/update-motd.d/99-one-click
+++ b/openclaw-24-04/files/etc/update-motd.d/99-one-click
@@ -48,8 +48,19 @@ on the channels you already use (WhatsApp, Telegram, Slack, Discord, and more).
   Latest release:     sudo /opt/update-openclaw.sh
   Specific version:   sudo /opt/update-openclaw.sh <latest version>   # e.g. 2026.9.3
   Rollback previous:  sudo /opt/update-openclaw.sh --rollback
-  (Upgrades Node automatically if the release requires a newer runtime.
-   Rollback restores the prior npm package only, not config migrations.)
+  (Rollback reinstalls the version from before the last update
+   (OPENCLAW_VERSION_PREVIOUS). For any other pin, use the specific-version
+   command above. Upgrades Node automatically if needed. Rollback restores
+   the prior npm package only, not config migrations.)
+  If UI/CLI breaks after update or rollback, repair with doctor:
+    sudo -u openclaw openclaw doctor
+        # interactive checks; prompts YES/NO when fixes are needed
+    sudo -u openclaw openclaw doctor --fix
+        # apply recommended repairs (--repair is the same)
+    Optional flags (combine with --fix as needed):
+      --yes              accept defaults without prompting
+      --non-interactive  no prompts; safe migrations/repairs only
+    Then: sudo systemctl restart openclaw
 
 🔒 Custom domain (HTTPS):
   HTTPS is already enabled on this droplet IP (shortlived TLS via Caddy).

--- a/openclaw-24-04/files/etc/update-motd.d/99-one-click
+++ b/openclaw-24-04/files/etc/update-motd.d/99-one-click
@@ -40,10 +40,16 @@ on the channels you already use (WhatsApp, Telegram, Slack, Discord, and more).
   - /opt/stop-openclaw.sh      (stop gateway)
   - /opt/restart-openclaw.sh   (restart with status check)
   - /opt/status-openclaw.sh    (show status and token)
-  - /opt/update-openclaw.sh    (update to latest version)
   - /opt/openclaw-cli.sh       (run CLI commands)
   - /opt/openclaw-control-ui-pairing.sh    (full Control UI pairing walkthrough)
   - /opt/openclaw-approve-ui-pairing.sh    (approve pending pairing only)
+
+⬆️ Update OpenClaw:
+  Latest release:     sudo /opt/update-openclaw.sh
+  Specific version:   sudo /opt/update-openclaw.sh v2026.9.3
+  Rollback previous:  sudo /opt/update-openclaw.sh --rollback
+  (Upgrades Node automatically if the release requires a newer runtime.
+   Rollback restores the prior npm package only, not config migrations.)
 
 🔒 Custom domain (HTTPS):
   HTTPS is already enabled on this droplet IP (shortlived TLS via Caddy).

--- a/openclaw-24-04/files/opt/openclaw-tui.sh
+++ b/openclaw-24-04/files/opt/openclaw-tui.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-gateway_token=$(grep "^OPENCLAW_GATEWAY_TOKEN=" /opt/openclaw.env 2>/dev/null | cut -d'=' -f2)
+gateway_token=$(grep "^OPENCLAW_GATEWAY_TOKEN=" /opt/openclaw.env 2>/dev/null | cut -d'=' -f2-)
+gateway_token="${gateway_token#\"}"
+gateway_token="${gateway_token%\"}"
 
-/opt/openclaw-cli.sh tui --token=${gateway_token}
+exec /opt/openclaw-cli.sh tui --token="${gateway_token}"

--- a/openclaw-24-04/files/opt/status-openclaw.sh
+++ b/openclaw-24-04/files/opt/status-openclaw.sh
@@ -24,6 +24,17 @@ echo "=== Update OpenClaw ==="
 echo "  Latest:           sudo /opt/update-openclaw.sh"
 echo "  Specific version: sudo /opt/update-openclaw.sh <latest version>   # e.g. 2026.9.3"
 echo "  Rollback:         sudo /opt/update-openclaw.sh --rollback"
+echo "                    # reinstalls the version from before the last update;"
+echo "                    # for any other pin, use the specific-version command"
+echo "  If UI/CLI breaks after update or rollback, repair with doctor:"
+echo "    sudo -u openclaw openclaw doctor"
+echo "        # interactive checks; prompts YES/NO when fixes are needed"
+echo "    sudo -u openclaw openclaw doctor --fix"
+echo "        # apply recommended repairs (--repair is the same)"
+echo "    Optional flags (combine with --fix as needed):"
+echo "      --yes              accept defaults without prompting"
+echo "      --non-interactive  no prompts; safe migrations/repairs only"
+echo "    Then: sudo systemctl restart openclaw"
 if [ -f /opt/openclaw.env ]; then
     prev=$(grep -E '^OPENCLAW_VERSION_PREVIOUS=' /opt/openclaw.env 2>/dev/null | tail -n 1 | cut -d'=' -f2- || true)
     cur=$(grep -E '^OPENCLAW_VERSION=' /opt/openclaw.env 2>/dev/null | tail -n 1 | cut -d'=' -f2- || true)

--- a/openclaw-24-04/files/opt/status-openclaw.sh
+++ b/openclaw-24-04/files/opt/status-openclaw.sh
@@ -18,3 +18,15 @@ priv=$(hostname -I | awk '{print $1}')
 host="${pub:-$priv}"
 echo "  https://${host}/   (Caddy -> gateway on port 18789)"
 echo "  Direct loopback URL (SSH tunnel only): http://127.0.0.1:18789"
+
+echo ""
+echo "=== Update OpenClaw ==="
+echo "  Latest:           sudo /opt/update-openclaw.sh"
+echo "  Specific version: sudo /opt/update-openclaw.sh v2026.9.3"
+echo "  Rollback:         sudo /opt/update-openclaw.sh --rollback"
+if [ -f /opt/openclaw.env ]; then
+    prev=$(grep -E '^OPENCLAW_VERSION_PREVIOUS=' /opt/openclaw.env 2>/dev/null | tail -n 1 | cut -d'=' -f2- || true)
+    cur=$(grep -E '^OPENCLAW_VERSION=' /opt/openclaw.env 2>/dev/null | tail -n 1 | cut -d'=' -f2- || true)
+    [ -n "$cur" ] && echo "  Current pin:      ${cur}"
+    [ -n "$prev" ] && echo "  Previous pin:     ${prev}"
+fi

--- a/openclaw-24-04/files/opt/status-openclaw.sh
+++ b/openclaw-24-04/files/opt/status-openclaw.sh
@@ -22,7 +22,7 @@ echo "  Direct loopback URL (SSH tunnel only): http://127.0.0.1:18789"
 echo ""
 echo "=== Update OpenClaw ==="
 echo "  Latest:           sudo /opt/update-openclaw.sh"
-echo "  Specific version: sudo /opt/update-openclaw.sh v2026.9.3"
+echo "  Specific version: sudo /opt/update-openclaw.sh <latest version>   # e.g. 2026.9.3"
 echo "  Rollback:         sudo /opt/update-openclaw.sh --rollback"
 if [ -f /opt/openclaw.env ]; then
     prev=$(grep -E '^OPENCLAW_VERSION_PREVIOUS=' /opt/openclaw.env 2>/dev/null | tail -n 1 | cut -d'=' -f2- || true)

--- a/openclaw-24-04/files/opt/sync-openclaw-gateway.sh
+++ b/openclaw-24-04/files/opt/sync-openclaw-gateway.sh
@@ -49,9 +49,10 @@ jq --arg token "$GATEWAY_TOKEN" \
        )
      | .tools = (if (.tools | type) == "object" then .tools else {} end)
      | .tools.deny = (((.tools.deny // []) + ["sessions_send"]) | unique)
-     | .session = (if (.session | type) == "object" then .session else {} end)
-     | .session.agentToAgent = (if (.session.agentToAgent | type) == "object" then .session.agentToAgent else {} end)
-     | .session.agentToAgent.maxPingPongTurns = 0
+     # OpenClaw 2026.9.x removed session.agentToAgent (built-in defaults).
+     # Strip it so upgraded droplets keep a valid config for CLI pairing.
+     | del(.session.agentToAgent)
+     | if (.session | type) == "object" and (.session | length) == 0 then del(.session) else . end
      | .gateway.controlUi.allowedOrigins = (
          if ($pub != "" and $pub != $prv) then
            ["https://" + $pub, "http://" + $pub, "https://" + $prv, "http://" + $prv]

--- a/openclaw-24-04/files/opt/update-openclaw.sh
+++ b/openclaw-24-04/files/opt/update-openclaw.sh
@@ -105,9 +105,17 @@ ensure_node_for_openclaw() {
     local current
     current="$(node --version 2>/dev/null || echo 'missing')"
     echo "OpenClaw requires Node >=24.16.0 <25 or >=26.1.0 (found ${current})."
-    echo "Upgrading Node.js to 24.x..."
-    curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
-    apt-get install -y nodejs
+    echo "Upgrading Node.js to 24.x via NodeSource apt repository..."
+
+    # Configure the apt repo with a signed keyring (do not curl|bash remote setup scripts).
+    mkdir -p /etc/apt/keyrings
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+    chmod a+r /etc/apt/keyrings/nodesource.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list
+    apt-get update -y
+    DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
 
     if ! node_meets_openclaw_engines; then
         echo "❌ Error: Node still too old after upgrade ($(node --version 2>/dev/null || echo missing))" >&2

--- a/openclaw-24-04/files/opt/update-openclaw.sh
+++ b/openclaw-24-04/files/opt/update-openclaw.sh
@@ -1,55 +1,197 @@
 #!/bin/bash
+# Update OpenClaw from npm and restart the gateway service.
+#
+# Usage:
+#   /opt/update-openclaw.sh              # install latest from npm
+#   /opt/update-openclaw.sh v2026.9.3    # install a specific version
+#   /opt/update-openclaw.sh latest       # same as no args
+#   /opt/update-openclaw.sh --rollback   # reinstall previous version
+#
+# OPENCLAW_VERSION in /opt/openclaw.env is the installed pin (updated after
+# success). OPENCLAW_VERSION_PREVIOUS is saved before each successful change
+# so --rollback can restore it. Rollback reinstalls the prior npm package; it
+# does not undo OpenClaw config/state migrations.
 
-# OpenClaw Update Script
-# This script updates OpenClaw from npm and restarts the service
+set -euo pipefail
 
-APP_VERSION="Latest"
-if [ -f "/opt/openclaw.env" ]; then
-    APP_VERSION_VALUE=$(grep -E '^OPENCLAW_VERSION=' /opt/openclaw.env | tail -n 1 | cut -d'=' -f2-)
-    if [ -n "$APP_VERSION_VALUE" ]; then
-        APP_VERSION="$APP_VERSION_VALUE"
-    fi
-fi
-# If env file had unsubstituted template (e.g. OPENCLAW_VERSION=${APP_VERSION}), use Latest
-case "$APP_VERSION" in *'$'*) APP_VERSION="Latest";; esac
+ENV_FILE=/opt/openclaw.env
 
-echo "Updating OpenClaw (target version: ${APP_VERSION})..."
-
-# Stop the service
-echo "Stopping OpenClaw service..."
-systemctl stop openclaw
-
-echo "Updating OpenClaw from npm..."
-
-if [ "$APP_VERSION" = "Latest" ]; then
-    npm update -g openclaw
-else
-    npm install -g openclaw@${APP_VERSION}
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Run as root: sudo $0 ${*:-}" >&2
+    exit 1
 fi
 
-if [ $? -eq 0 ]; then
-    echo "OpenClaw updated successfully."
+usage() {
+    cat <<'EOF'
+Usage: /opt/update-openclaw.sh [version|--rollback]
 
-    # Update version in env file
-    INSTALLED_VERSION=$(npm list -g openclaw --depth=0 | grep openclaw@ | sed 's/.*openclaw@//' | sed 's/ .*//')
-    if [ -n "$INSTALLED_VERSION" ]; then
-        sed -i "s/^OPENCLAW_VERSION=.*/OPENCLAW_VERSION=v${INSTALLED_VERSION}/" /opt/openclaw.env
-    fi
+  (no args) / latest   Install the latest OpenClaw release from npm
+  v2026.9.3 / 2026.9.3 Install that exact version
+  --rollback           Reinstall OPENCLAW_VERSION_PREVIOUS from /opt/openclaw.env
 
-    # Restart OpenClaw
-    echo "Starting OpenClaw with updated version..."
-    systemctl start openclaw
+Before each successful version change, the current pin is saved as
+OPENCLAW_VERSION_PREVIOUS. Rollback restores that package only — it does not
+undo config or workspace migrations applied by a newer release.
+EOF
+}
 
-    if [ $? -eq 0 ]; then
-        echo "✅ OpenClaw updated and restarted successfully!"
-        echo "Version: ${INSTALLED_VERSION}"
+read_env_kv() {
+    local key="$1" line val
+    [ -f "$ENV_FILE" ] || return 1
+    line=$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -n 1) || return 1
+    val="${line#${key}=}"
+    val="${val#\"}"
+    val="${val%\"}"
+    val="${val#\'}"
+    val="${val%\'}"
+    case "$val" in
+        ''|*'${'*|PLACEHOLDER*) return 1 ;;
+    esac
+    printf '%s' "$val"
+}
+
+set_env_kv() {
+    local key="$1" value="$2"
+    touch "$ENV_FILE"
+    if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+        sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
     else
-        echo "❌ Error: Failed to restart OpenClaw"
+        echo "${key}=${value}" >>"$ENV_FILE"
+    fi
+}
+
+normalize_version() {
+    local v="${1#v}"
+    case "$v" in
+        ''|Latest|LATEST|latest) printf '%s' "latest" ;;
+        *) printf '%s' "$v" ;;
+    esac
+}
+
+current_installed_version() {
+    local from_env from_npm
+    from_env="$(read_env_kv OPENCLAW_VERSION || true)"
+    if [ -n "${from_env}" ]; then
+        normalize_version "$from_env"
+        return 0
+    fi
+    from_npm="$(npm list -g openclaw --depth=0 2>/dev/null | grep openclaw@ | sed 's/.*openclaw@//' | sed 's/ .*//' || true)"
+    if [ -n "${from_npm}" ]; then
+        printf '%s' "$from_npm"
+        return 0
+    fi
+    return 1
+}
+
+# Current OpenClaw engines: >=24.16.0 <25 || >=26.1.0
+node_meets_openclaw_engines() {
+    command -v node >/dev/null 2>&1 || return 1
+    node -e '
+      const [maj, min] = process.versions.node.split(".").map(Number);
+      const ok =
+        (maj === 24 && min >= 16) ||
+        (maj === 26 && min >= 1) ||
+        maj > 26;
+      process.exit(ok ? 0 : 1);
+    ' 2>/dev/null
+}
+
+ensure_node_for_openclaw() {
+    if node_meets_openclaw_engines; then
+        echo "Node $(node --version) meets OpenClaw requirements."
+        return 0
+    fi
+
+    local current
+    current="$(node --version 2>/dev/null || echo 'missing')"
+    echo "OpenClaw requires Node >=24.16.0 <25 or >=26.1.0 (found ${current})."
+    echo "Upgrading Node.js to 24.x..."
+    curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+    apt-get install -y nodejs
+
+    if ! node_meets_openclaw_engines; then
+        echo "❌ Error: Node still too old after upgrade ($(node --version 2>/dev/null || echo missing))" >&2
+        exit 1
+    fi
+    echo "Node upgraded to $(node --version)."
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --rollback|-r)
+        MODE="rollback"
+        PREV="$(read_env_kv OPENCLAW_VERSION_PREVIOUS || true)"
+        if [ -z "${PREV}" ]; then
+            echo "❌ Error: OPENCLAW_VERSION_PREVIOUS is not set in ${ENV_FILE}." >&2
+            echo "Cannot rollback. Install a specific version instead, e.g.:" >&2
+            echo "  sudo /opt/update-openclaw.sh v2026.9.3" >&2
+            exit 1
+        fi
+        TARGET="$(normalize_version "$PREV")"
+        ;;
+    *)
+        MODE="update"
+        TARGET="$(normalize_version "${1:-latest}")"
+        ;;
+esac
+
+if [ "$MODE" = "rollback" ]; then
+    echo "Rolling back OpenClaw to previous version: v${TARGET}..."
+else
+    echo "Updating OpenClaw (target version: ${TARGET})..."
+fi
+
+BEFORE_VERSION="$(current_installed_version || true)"
+if [ -n "${BEFORE_VERSION}" ] && [ "${BEFORE_VERSION}" != "latest" ]; then
+    echo "Currently installed: v${BEFORE_VERSION}"
+fi
+
+ensure_node_for_openclaw
+
+echo "Stopping OpenClaw service..."
+systemctl stop openclaw || true
+
+echo "Installing openclaw@${TARGET} from npm..."
+if npm install -g "openclaw@${TARGET}"; then
+    echo "OpenClaw package install succeeded."
+
+    INSTALLED_VERSION="$(npm list -g openclaw --depth=0 2>/dev/null | grep openclaw@ | sed 's/.*openclaw@//' | sed 's/ .*//' || true)"
+    if [ -z "${INSTALLED_VERSION}" ]; then
+        echo "❌ Error: openclaw installed but version could not be detected" >&2
+        systemctl start openclaw || true
+        exit 1
+    fi
+
+    # Save previous pin only when the installed version actually changes.
+    if [ -n "${BEFORE_VERSION}" ] && [ "${BEFORE_VERSION}" != "latest" ] \
+        && [ "${BEFORE_VERSION}" != "${INSTALLED_VERSION}" ]; then
+        set_env_kv OPENCLAW_VERSION_PREVIOUS "v${BEFORE_VERSION}"
+        echo "Saved previous version for rollback: v${BEFORE_VERSION}"
+    fi
+    set_env_kv OPENCLAW_VERSION "v${INSTALLED_VERSION}"
+
+    echo "Starting OpenClaw..."
+    if systemctl start openclaw; then
+        if [ "$MODE" = "rollback" ]; then
+            echo "✅ OpenClaw rolled back and restarted successfully!"
+        else
+            echo "✅ OpenClaw updated and restarted successfully!"
+        fi
+        echo "Version: ${INSTALLED_VERSION}"
+        if [ -n "${BEFORE_VERSION}" ] && [ "${BEFORE_VERSION}" != "${INSTALLED_VERSION}" ]; then
+            echo "Rollback (if needed): sudo /opt/update-openclaw.sh --rollback"
+        fi
+    else
+        echo "❌ Error: Failed to restart OpenClaw" >&2
+        echo "Check logs with: journalctl -u openclaw -xe" >&2
         exit 1
     fi
 else
-    echo "❌ Error: Failed to update OpenClaw"
-    systemctl start openclaw
+    echo "❌ Error: Failed to install openclaw@${TARGET}" >&2
+    systemctl start openclaw || true
     exit 1
 fi
 

--- a/openclaw-24-04/listing.md
+++ b/openclaw-24-04/listing.md
@@ -77,8 +77,8 @@ If Serverless Inference was not passed at create time, the first-login wizard ca
 | Restart | `/opt/restart-openclaw.sh` |
 | Status | `/opt/status-openclaw.sh` |
 | Update (latest) | `sudo /opt/update-openclaw.sh` |
-| Update (specific version) | `sudo /opt/update-openclaw.sh v2026.9.3` |
-| Rollback | `sudo /opt/update-openclaw.sh --rollback` |
+| Update (specific version) | `sudo /opt/update-openclaw.sh 2026.9.3` |
+| Rollback | `sudo /opt/update-openclaw.sh --rollback` (version before last update only) |
 | Domain TLS | `/opt/setup-openclaw-domain.sh` |
 | Re-run setup | `/etc/setup_wizard.sh` |
 | Control UI pairing | `/opt/openclaw-control-ui-pairing.sh` |
@@ -90,13 +90,29 @@ If Serverless Inference was not passed at create time, the first-login wizard ca
 sudo /opt/update-openclaw.sh
 
 # Install a specific version
-sudo /opt/update-openclaw.sh v2026.9.3
+sudo /opt/update-openclaw.sh 2026.9.3
 
-# Roll back to the previous package version (saved automatically on upgrade)
+# Roll back to the version from before the last update (OPENCLAW_VERSION_PREVIOUS)
 sudo /opt/update-openclaw.sh --rollback
 ```
 
-Before each successful version change, the script stores the prior pin as `OPENCLAW_VERSION_PREVIOUS` in `/opt/openclaw.env`. Rollback reinstalls that npm package and restarts the gateway; it does not undo config or workspace migrations. Prefer the SSH helper over the Control UI update button on this 1-Click image.
+Before each successful version change, the script stores the prior pin as `OPENCLAW_VERSION_PREVIOUS` in `/opt/openclaw.env`. `--rollback` reinstalls that package only — it is not a picker for arbitrary older releases. To install any other pin, use the specific-version command above. Rollback does not undo config or workspace migrations. Prefer the SSH helper over the Control UI update button on this 1-Click image.
+
+If the Control UI or CLI misbehaves after an update or rollback, run OpenClaw doctor and choose the posture you want:
+
+```bash
+# Interactive checks (prompts YES/NO when fixes are needed)
+sudo -u openclaw openclaw doctor
+
+# Apply recommended repairs (--repair is the same)
+sudo -u openclaw openclaw doctor --fix
+
+# Optional flags (combine with --fix as needed):
+#   --yes              accept defaults without prompting
+#   --non-interactive  no prompts; safe migrations/repairs only
+
+sudo systemctl restart openclaw
+```
 
 systemd: `systemctl {start|stop|restart|status} openclaw`  
 Logs: `journalctl -u openclaw -f`

--- a/openclaw-24-04/listing.md
+++ b/openclaw-24-04/listing.md
@@ -32,8 +32,8 @@ OpenClaw runs the gateway on the host and uses Docker for sandboxes. Prefer at l
 ## Included System Components
 
 - **Ubuntu 24.04 LTS**
-- **OpenClaw** (version pinned in the image build)
-- **Node.js 22** and **Docker**
+- **OpenClaw** `v2026.9.3` (version pinned in the image build)
+- **Node.js 24** and **Docker**
 - **Caddy** reverse proxy (ports 80/443 → gateway on localhost:18789)
 - **UFW** and **fail2ban**
 - Dedicated **`openclaw`** system user
@@ -76,10 +76,27 @@ If Serverless Inference was not passed at create time, the first-login wizard ca
 | Stop | `/opt/stop-openclaw.sh` |
 | Restart | `/opt/restart-openclaw.sh` |
 | Status | `/opt/status-openclaw.sh` |
-| Update | `/opt/update-openclaw.sh` |
+| Update (latest) | `sudo /opt/update-openclaw.sh` |
+| Update (specific version) | `sudo /opt/update-openclaw.sh v2026.9.3` |
+| Rollback | `sudo /opt/update-openclaw.sh --rollback` |
 | Domain TLS | `/opt/setup-openclaw-domain.sh` |
 | Re-run setup | `/etc/setup_wizard.sh` |
 | Control UI pairing | `/opt/openclaw-control-ui-pairing.sh` |
+
+### Updating OpenClaw
+
+```bash
+# Install the latest release from npm (default)
+sudo /opt/update-openclaw.sh
+
+# Install a specific version
+sudo /opt/update-openclaw.sh v2026.9.3
+
+# Roll back to the previous package version (saved automatically on upgrade)
+sudo /opt/update-openclaw.sh --rollback
+```
+
+Before each successful version change, the script stores the prior pin as `OPENCLAW_VERSION_PREVIOUS` in `/opt/openclaw.env`. Rollback reinstalls that npm package and restarts the gateway; it does not undo config or workspace migrations. Prefer the SSH helper over the Control UI update button on this 1-Click image.
 
 systemd: `systemctl {start|stop|restart|status} openclaw`  
 Logs: `journalctl -u openclaw -f`

--- a/openclaw-24-04/scripts/openclaw.sh
+++ b/openclaw-24-04/scripts/openclaw.sh
@@ -9,8 +9,15 @@ ufw limit ssh/tcp
 ufw --force enable
 
 # Install Node.js 24 (OpenClaw requires >=24.16.0 <25 || >=26.1.0)
-curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
-apt-get install -y nodejs
+# Use a signed apt keyring instead of curling a remote setup script into bash.
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+chmod a+r /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    > /etc/apt/sources.list.d/nodesource.list
+apt-get update -y
+DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
 
 # Install Caddy (reverse proxy with automatic TLS)
 curl -1sLf "https://dl.cloudsmith.io/public/caddy/stable/gpg.key" | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg

--- a/openclaw-24-04/scripts/openclaw.sh
+++ b/openclaw-24-04/scripts/openclaw.sh
@@ -8,8 +8,8 @@ ufw allow 443
 ufw limit ssh/tcp
 ufw --force enable
 
-# Install Node.js 22 (required for Openclaw)
-curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+# Install Node.js 24 (OpenClaw requires >=24.16.0 <25 || >=26.1.0)
+curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
 apt-get install -y nodejs
 
 # Install Caddy (reverse proxy with automatic TLS)

--- a/openclaw-24-04/template.json
+++ b/openclaw-24-04/template.json
@@ -4,7 +4,7 @@
     "image_name": "openclaw-snap-{{timestamp}}",
     "apt_packages": "procps file apt-transport-https ca-certificates curl software-properties-common git build-essential libsystemd-dev jq unzip docker.io gnupg fail2ban",
     "application_name": "OpenClaw",
-    "application_version": "v2026.8.2"
+    "application_version": "v2026.9.3"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [

--- a/openclaw-24-04/util/README.md
+++ b/openclaw-24-04/util/README.md
@@ -133,7 +133,7 @@ journalctl -u openclaw -n 100 --no-pager
 
 Common issues:
 - **Build failed:** Re-run the script; pnpm builds can fail due to transient issues
-- **Missing dependencies:** Ensure Node.js 22+ is installed
+- **Missing dependencies:** Ensure Node.js 24.16+ is installed
 - **Docker not running:** `systemctl start docker` (required for sandbox)
 - **Sandbox image missing** (`openclaw-sandbox:bookworm-slim`): image is built at snapshot time and on first boot. On a live droplet: `sudo /opt/build-openclaw-sandbox.sh`
 - **Gateway token missing** in logs: tokens live in `openclaw.json` (`gateway.auth.token` and `gateway.remote.token`), not only `/opt/openclaw.env`. Fix: `sudo /opt/ensure-openclaw-ready.sh`


### PR DESCRIPTION
## Summary
- Bump OpenClaw image pin from **v2026.8.2** to **v2026.9.3**.
- Fix `/opt/update-openclaw.sh`: default to **latest**, optional version pin, **`--rollback`**.
- Review OpenClaw helpers (`start`/`stop`/`restart`/`status`, CLI, TUI, pairing); 
- Align MOTD/status/listing/README with update + rollback usage.

## Test plan
- [x] Packer build `openclaw-24-04` succeeds; droplet reports OpenClaw `2026.9.3`
- [x] From a **2026.8.2** droplet, `sudo /opt/update-openclaw.sh` / pin to `2026.9.3` works
- [x] Check all helpers: start, stop, restart, status, CLI, TUI, pairing.
- [x] MOTD / `/opt/status-openclaw.sh` show update and rollback instructions

<img width="605" height="75" alt="image" src="https://github.com/user-attachments/assets/078af6a5-8611-446f-8c6c-7bc04f3c211f" />

<img width="432" height="825" alt="image" src="https://github.com/user-attachments/assets/b5cc5457-dbfb-46e7-a26a-f61992c7a36d" />
